### PR TITLE
spec: COGNITIVE-SUBSTRATE v1.1.0 — role as Identity binding (#52)

### DIFF
--- a/docs/alpha/COGNITIVE-SUBSTRATE.md
+++ b/docs/alpha/COGNITIVE-SUBSTRATE.md
@@ -226,7 +226,7 @@ Profiles and dependency manifests determine which packages are installed.
 Identity.role MUST NOT be treated as the sole package install authority.
 Role constrains applicability, weighting, and ordering inside the installed package set.
 
-If Identity.role implies role-bearing assets that are not present in `.cn/deps.lock.json`, the hub is misconfigured.
+If Identity.role implies role-bearing assets that are not present in the installed package set (`.cn/vendor/packages/`), or if `.cn/deps.json`, `.cn/deps.lock.json`, and `.cn/vendor/packages/` disagree, the hub is misconfigured.
 
 ---
 
@@ -245,7 +245,7 @@ Identity is represented across two hub-local files:
 - the agent's standing role
 - the agent's standing purpose, persona, or self-description
 
-Equivalent headings are valid, but role MUST be explicit rather than only inferable from prose.
+For machine-parseable validation, `spec/SOUL.md` MUST contain either YAML frontmatter with a `role:` field, or a literal `Role: <value>` line within the first 10 non-blank lines. Equivalent prose headings are valid for human readers, but the machine-readable anchor is the normative parse target for `cn setup` and `cn doctor`.
 
 `spec/USER.md` MUST make explicit near the top whatever standing user context is required at wake-up.
 


### PR DESCRIPTION
## Coherence Contract

**Gap:** Role determines skill loadout, RACI position, and conduct norms, but the cognitive substrate spec had no Identity contract and didn't name role as load-bearing.

**Mode:** MCI on the substrate spec, then tiny MCA in setup/doctor validation rules.

**Key design decision:** Role is an Identity binding, not a sixth authored class. Profiles remain install authority. Role governs applicability/weighting inside the installed package set.

## Changes (v1.0.0 → v1.1.0)

- §2.1: Identity includes standing role
- §5.8: Install manifests placed as config (not cognitive assets)
- §6: Role constrains applicability within installed set
- §7.1: **New Identity Contract** — SOUL.md MUST make role explicit
- §10.1: Identity validation checks (role absent, role/deps mismatch)
- §13: **New** cn setup/doctor role validation rules
- §11, §12: Updated builder guidance and migration

## Closes

Closes #52 at spec layer. Runtime MCA is ordinary cn setup/doctor validation.

## Review request

Score α (internal consistency), β (alignment with CAR/AGENT-RUNTIME), γ (evolution path) separately. Identify weakest axis, propose patches.