### PR TITLE
skills: eng learnings from N-pass bind loop review

### DIFF
--- a/src/agent/skills/eng/coding/SKILL.md
+++ b/src/agent/skills/eng/coding/SKILL.md
@@ -156,6 +156,25 @@ Constrain what external interactions can occur.
   - ✅ `to_string` guarantees single-line; `curl_quote` escapes `\` and `"`
   - Reference: `cn_json.ml` to_string, `cn_ffi.ml` Http.curl_quote
 
+### 5. Error Recovery
+
+5.1. **Make recovery a regular iteration, not a side-channel**
+  - ❌ Separate pre-loop correction path with its own budget, stop conditions, and receipt logic
+  - ✅ Correction runs as pass 0 inside the main loop, consuming normal budget, using the same stop conditions
+  - Rule: one set of stop conditions, one budget, one receipt trail. Side-channel recovery diverges silently.
+  - Reference: `cn_orchestrator.ml` misplaced ops correction (Issue #51)
+
+5.2. **Document intentionally non-obvious behavior inline**
+  - ❌ Code does something surprising; reviewer "fixes" it into the obvious-but-wrong behavior
+  - ✅ DESIGN NOTE in comment explains *why* the non-obvious choice is correct
+  - Rule: when behavior is intentional but looks like a bug, document the reasoning at the decision point, not in a separate doc
+  - Reference: `cn_orchestrator.ml` pass-0 effect-only termination note
+
+5.3. **Delete dead code; don't retain it "for testability"**
+  - ❌ `run_effect_pass` retained as "testable helper" but never called from production loop — tests prove nothing about runtime
+  - ✅ Test the actual code path. If the function isn't called, its tests are theater.
+  - Rule: if the main loop doesn't call it, delete it. Test coverage of dead code is false confidence.
+
 ## Reference
 
 Case study: `references/auto-update-case.md`

--- a/src/agent/skills/eng/ship/SKILL.md
+++ b/src/agent/skills/eng/ship/SKILL.md
@@ -117,6 +117,15 @@ git tag v2.5.0
 git push && git push --tags
 ```
 
+## Commit Discipline
+
+**Isolate renames from behavior changes.**
+
+- ❌ Rename `two_pass → n_pass` in the same commit that changes the loop logic
+- ✅ Dedicated rename commit (`c11478e`), then behavior change in a separate commit
+
+Why: renames touch many files but change no behavior. Mixed with logic changes, they're unauditable. Separate commits let reviewers verify "pure rename, no behavior change" in one pass, then review the real diff cleanly.
+
 ## Pre-Ship Checklist
 
 - [ ] Tests pass
@@ -124,6 +133,7 @@ git push && git push --tags
 - [ ] PR approved (if required)
 - [ ] No unresolved comments
 - [ ] **Features verified working** — don't assume, test it yourself
+- [ ] Renames isolated from behavior changes
 
 ## Deprecation Checklist
 

--- a/src/agent/skills/eng/testing/SKILL.md
+++ b/src/agent/skills/eng/testing/SKILL.md
@@ -113,10 +113,34 @@ For all valid input X:
   property(transform(X)) = true
 ```
 
-## 6. Anti-Patterns
+## 6. Mock Patterns
+
+### 6.1 Factory Mocks Over Shared Mocks
+
+```
+❌ let mock_llm_pass_2 _ = Ok "..."   (* shared across tests, couples them *)
+✅ let make_mock () =                  (* fresh state per test *)
+     let n = ref 0 in
+     fun _ -> incr n; match !n with
+       | 1 -> Ok "pass 2 output"
+       | _ -> Ok "terminal"
+```
+
+- Shared mocks couple tests to a specific call count and return sequence
+- Factory mocks create fresh state per test — each test owns its mock lifecycle
+- Reference: `cn_orchestrator_test.ml` `make_mock_effect_then_terminal`
+
+### 6.2 Dead Code Tests Are Theater
+
+- ❌ Testing a function "retained for testability" that production never calls
+- ✅ Test the actual production code path
+- If the function isn't in the call graph, its tests prove nothing about runtime behavior
+
+## 7. Anti-Patterns
 
 - ❌ Tests that test mocks, not implementation
 - ❌ Tests coupled to internal structure
 - ❌ Tests that pass when the feature is broken
 - ❌ Flaky tests left in suite (fix or delete)
 - ❌ "Test later" — test now or accept the risk explicitly
+- ❌ Shared stateful mocks across tests (couples test execution order)


### PR DESCRIPTION
Eng skill updates distilled from reviewing `claude/n-pass-bind-loop-VWKUT`.

**coding** — new §5 Error Recovery:
- Recovery as regular iteration (from #51 correction path design)
- Document non-obvious behavior inline (from pass-0 DESIGN NOTE)
- Delete dead code, don't retain for testability

**testing** — new §6 Mock Patterns:
- Factory mocks over shared mocks
- Dead code tests are theater

**ship** — Commit Discipline:
- Isolate renames from behavior changes
- Added to pre-ship checklist