### PR TITLE
fix: Runtime Contract authoritative over stale conversation history (closes #63)

### DIFF
--- a/docs/alpha/COGNITIVE-SUBSTRATE.md
+++ b/docs/alpha/COGNITIVE-SUBSTRATE.md
@@ -381,7 +381,7 @@ Split an artifact when:
 
 ## 9. Precedence
 
-Normative precedence is:
+Normative precedence for authored substrates is:
 
 Doctrine → Mindset → Skill → Reflection
 
@@ -390,6 +390,14 @@ It localizes the subject and user context to which doctrine, mindsets, and skill
 
 Capabilities describe affordance, not permission.
 Runtime policy and doctrine still govern which capabilities may be used.
+
+### 9.1 Runtime Contract Authority (normative)
+
+The Runtime Contract (§6.1) is authoritative over conversation history for all fields it declares: version, packages, overrides, workspace layout, and capabilities.
+
+Conversation history is a temporal record — it may contain probe results, version references, or workspace claims from prior sessions that are no longer true. When the Runtime Contract contradicts conversation history, the contract wins.
+
+Conversation entries SHOULD carry a `cn_version` stamp. Entries from a prior version are stale and MUST NOT be treated as current truth for any field the Runtime Contract covers.
 
 ---
 

--- a/docs/alpha/RUNTIME-CONTRACT-v3.10.0.md
+++ b/docs/alpha/RUNTIME-CONTRACT-v3.10.0.md
@@ -204,3 +204,5 @@ v3.10.0 replaces the overloaded capabilities block with a first-class Runtime Co
 - **capabilities** — observe/effect ABI, budgets, constraints
 
 The result: probing for self-knowledge becomes a contract bug, not normal behavior.
+
+The contract is authoritative over conversation history (COGNITIVE-SUBSTRATE §9.1). Stale conversation entries from prior versions MUST NOT override the current contract. Conversation entries carry a `cn_version` stamp; entries from a different version are annotated as stale at load time.

--- a/src/cmd/cn_context.ml
+++ b/src/cmd/cn_context.ml
@@ -120,7 +120,10 @@ let load_skills ~hub_path ~message ~(role : string option) ~n =
     |> List.map (fun (_, content, _, _) -> content)
 
 (** Load last N entries from state/conversation.json as message turns.
-    Returns structured turns for the messages array. *)
+    Returns structured turns for the messages array.
+    Entries from a different cn_version are prefixed with a staleness
+    notice so the agent knows they may contain outdated claims
+    (issue #63: stale history must not override Runtime Contract). *)
 let load_conversation_turns ~hub_path ~n : Cn_llm.message_turn list =
   let path = Cn_ffi.Path.join hub_path "state/conversation.json" in
   let raw = read_opt path in
@@ -133,10 +136,22 @@ let load_conversation_turns ~hub_path ~n : Cn_llm.message_turn list =
         let recent = if len <= n then items
           else List.filteri (fun i _ -> i >= len - n) items
         in
+        let current_version = Cn_lib.version in
         recent |> List.filter_map (fun entry ->
           match Cn_json.get_string "role" entry, Cn_json.get_string "content" entry with
           | Some role, Some content when content <> "" ->
-              Some { Cn_llm.role; content }
+              let entry_version = Cn_json.get_string "cn_version" entry in
+              let is_stale = match entry_version with
+                | Some v -> v <> current_version
+                | None -> true  (* pre-versioning entries are stale by definition *)
+              in
+              let content' = if is_stale then
+                Printf.sprintf "[stale: from cn %s — current runtime is %s. \
+Runtime Contract is authoritative for version, packages, workspace, capabilities.]\n%s"
+                  (Option.value ~default:"unknown" entry_version) current_version content
+              else content
+              in
+              Some { Cn_llm.role; content = content' }
           | _ -> None)
     | _ -> []
 

--- a/src/cmd/cn_runtime.ml
+++ b/src/cmd/cn_runtime.ml
@@ -148,10 +148,12 @@ let append_conversation hub_path ~trigger_id ~user_msg ~assistant_msg =
       Cn_json.Object [
         "role", Cn_json.String "user";
         "content", Cn_json.String user_msg;
-        "trigger_id", Cn_json.String trigger_id];
+        "trigger_id", Cn_json.String trigger_id;
+        "cn_version", Cn_json.String Cn_lib.version];
       Cn_json.Object [
         "role", Cn_json.String "assistant";
-        "content", Cn_json.String assistant_msg];
+        "content", Cn_json.String assistant_msg;
+        "cn_version", Cn_json.String Cn_lib.version];
     ] in
     (* Keep last 50 entries *)
     let len = List.length new_entries in

--- a/src/cmd/cn_runtime_contract.ml
+++ b/src/cmd/cn_runtime_contract.ml
@@ -161,6 +161,14 @@ let render_markdown (c : runtime_contract) =
   let buf = Buffer.create 2048 in
   Buffer.add_string buf "## Runtime Contract\n\n";
 
+  (* Authority declaration — issue #63: conversation history must not
+     override the current contract. This preamble is the agent-facing
+     instruction that closes the stale-history gap. *)
+  Buffer.add_string buf "**Authority:** This contract is the authoritative source for version, \
+packages, workspace layout, and capabilities. It is emitted fresh at every wake. \
+If conversation history contains contradictory claims (e.g. a directory that \
+was absent in a prior session), this contract supersedes them.\n\n";
+
   (* Self Model *)
   Buffer.add_string buf "### Self Model\n";
   Buffer.add_string buf (Printf.sprintf "cn_version: %s\n" c.cn_version);

--- a/test/cmd/cn_runtime_contract_test.ml
+++ b/test/cmd/cn_runtime_contract_test.ml
@@ -161,6 +161,21 @@ let%expect_test "render_markdown: no absolute paths" =
     Printf.printf "contains_absolute_path: %b\n" has_abs);
   [%expect {| contains_absolute_path: false |}]
 
+let%expect_test "render_markdown: contains authority preamble (issue #63)" =
+  with_test_hub (fun hub ->
+    let assets = Cn_assets.summarize ~hub_path:hub in
+    let c = Cn_runtime_contract.gather ~hub_path:hub
+              ~shell_config:default_shell_config ~assets ~peers:[] in
+    let md = Cn_runtime_contract.render_markdown c in
+    let has s = if Cn_orchestrator.contains_sub md s then "yes" else "no" in
+    Printf.printf "Authority: %s\n" (has "**Authority:**");
+    Printf.printf "authoritative: %s\n" (has "authoritative source");
+    Printf.printf "supersedes: %s\n" (has "this contract supersedes"));
+  [%expect {|
+    Authority: yes
+    authoritative: yes
+    supersedes: yes |}]
+
 let%expect_test "render_markdown: deterministic (two calls identical)" =
   with_test_hub (fun hub ->
     let assets = Cn_assets.summarize ~hub_path:hub in

--- a/test/cmd/cn_stale_history_test.ml
+++ b/test/cmd/cn_stale_history_test.ml
@@ -1,0 +1,144 @@
+(** cn_stale_history_test: ppx_expect tests for stale history handling (issue #63)
+
+    Tests:
+    - Conversation entries from current version load without annotation
+    - Conversation entries from prior version get staleness prefix
+    - Entries without cn_version (pre-versioning) are treated as stale
+    - Staleness prefix references the Runtime Contract as authoritative *)
+
+(* === Helpers === *)
+
+let mk_temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec attempt k =
+    if k = 0 then failwith "mk_temp_dir: exhausted attempts";
+    let dir =
+      Filename.concat base
+        (Printf.sprintf "%s-%d-%06d" prefix (Unix.getpid ()) (Random.int 1_000_000))
+    in
+    try Unix.mkdir dir 0o700; dir
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> attempt (k - 1)
+  in
+  Random.self_init ();
+  attempt 50
+
+let with_test_hub f =
+  let hub = mk_temp_dir "cn-stale-test" in
+  let dirs = ["state"; "spec"; ".cn";
+              ".cn/vendor/packages/cnos.core@1.0.0/doctrine";
+              ".cn/vendor/packages/cnos.core@1.0.0/mindsets"] in
+  List.iter (fun d ->
+    Cn_ffi.Fs.ensure_dir (Filename.concat hub d)
+  ) dirs;
+  let touch path content =
+    let full = Filename.concat hub path in
+    Cn_ffi.Fs.ensure_dir (Filename.dirname full);
+    let oc = open_out full in
+    output_string oc content;
+    close_out oc
+  in
+  (* Minimal doctrine so validate_packages passes *)
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/FOUNDATIONS.md" "# FOUNDATIONS";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/COHERENCE.md" "# COHERENCE";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/CAP.md" "# CAP";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/CA-CONDUCT.md" "# CA-CONDUCT";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/CBP.md" "# CBP";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/doctrine/AGENT-OPS.md" "# AGENT-OPS";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/mindsets/ENGINEERING.md" "# ENGINEERING";
+  touch ".cn/vendor/packages/cnos.core@1.0.0/mindsets/WRITING.md" "# WRITING";
+  touch "spec/SOUL.md" "# Identity";
+  touch "spec/USER.md" "# User";
+  Fun.protect ~finally:(fun () ->
+    let rec rm path =
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry ->
+          rm (Filename.concat path entry)
+        );
+        Unix.rmdir path
+      end else
+        Sys.remove path
+    in
+    (try rm hub with _ -> ())
+  ) (fun () -> f hub)
+
+let write_conversation hub entries =
+  let path = Filename.concat hub "state/conversation.json" in
+  let json = Cn_json.Array entries in
+  Cn_ffi.Fs.write path (Cn_json.to_string json ^ "\n")
+
+(* === Tests === *)
+
+let%expect_test "current version entries load without annotation" =
+  with_test_hub (fun hub ->
+    let current = Cn_lib.version in
+    write_conversation hub [
+      Cn_json.Object [
+        "role", Cn_json.String "user";
+        "content", Cn_json.String "hello";
+        "cn_version", Cn_json.String current];
+      Cn_json.Object [
+        "role", Cn_json.String "assistant";
+        "content", Cn_json.String "hi there";
+        "cn_version", Cn_json.String current];
+    ];
+    let turns = Cn_context.load_conversation_turns ~hub_path:hub ~n:10 in
+    List.iter (fun (t : Cn_llm.message_turn) ->
+      let has_stale = Cn_orchestrator.contains_sub t.content "[stale:" in
+      Printf.printf "%s: stale=%b\n" t.role has_stale
+    ) turns);
+  [%expect {|
+    user: stale=false
+    assistant: stale=false |}]
+
+let%expect_test "prior version entries get staleness prefix" =
+  with_test_hub (fun hub ->
+    write_conversation hub [
+      Cn_json.Object [
+        "role", Cn_json.String "user";
+        "content", Cn_json.String "where is agent/?";
+        "cn_version", Cn_json.String "0.0.1"];
+      Cn_json.Object [
+        "role", Cn_json.String "assistant";
+        "content", Cn_json.String "agent/ was not found";
+        "cn_version", Cn_json.String "0.0.1"];
+    ];
+    let turns = Cn_context.load_conversation_turns ~hub_path:hub ~n:10 in
+    List.iter (fun (t : Cn_llm.message_turn) ->
+      let has_stale = Cn_orchestrator.contains_sub t.content "[stale:" in
+      let has_authority = Cn_orchestrator.contains_sub t.content "Runtime Contract is authoritative" in
+      Printf.printf "%s: stale=%b authority_ref=%b\n" t.role has_stale has_authority
+    ) turns);
+  [%expect {|
+    user: stale=true authority_ref=true
+    assistant: stale=true authority_ref=true |}]
+
+let%expect_test "entries without cn_version are stale" =
+  with_test_hub (fun hub ->
+    write_conversation hub [
+      Cn_json.Object [
+        "role", Cn_json.String "user";
+        "content", Cn_json.String "old message"];
+    ];
+    let turns = Cn_context.load_conversation_turns ~hub_path:hub ~n:10 in
+    List.iter (fun (t : Cn_llm.message_turn) ->
+      let has_stale = Cn_orchestrator.contains_sub t.content "[stale:" in
+      let has_unknown = Cn_orchestrator.contains_sub t.content "unknown" in
+      Printf.printf "%s: stale=%b unknown_version=%b\n" t.role has_stale has_unknown
+    ) turns);
+  [%expect {| user: stale=true unknown_version=true |}]
+
+let%expect_test "staleness prefix preserves original content" =
+  with_test_hub (fun hub ->
+    write_conversation hub [
+      Cn_json.Object [
+        "role", Cn_json.String "assistant";
+        "content", Cn_json.String "agent/ directory does not exist";
+        "cn_version", Cn_json.String "3.11.0"];
+    ];
+    let turns = Cn_context.load_conversation_turns ~hub_path:hub ~n:10 in
+    List.iter (fun (t : Cn_llm.message_turn) ->
+      let has_original = Cn_orchestrator.contains_sub t.content
+        "agent/ directory does not exist" in
+      Printf.printf "original_preserved: %b\n" has_original
+    ) turns);
+  [%expect {| original_preserved: true |}]

--- a/test/cmd/dune
+++ b/test/cmd/dune
@@ -135,3 +135,11 @@
  (libraries cn_cmd cn_ffi cn_lib unix)
  (inline_tests)
  (preprocess (pps ppx_expect)))
+
+; cn_stale_history tests (ppx_expect) — stale conversation history (Issue #63)
+(library
+ (name cn_stale_history_test)
+ (modules cn_stale_history_test)
+ (libraries cn_cmd cn_ffi cn_lib unix)
+ (inline_tests)
+ (preprocess (pps ppx_expect)))


### PR DESCRIPTION
P0 fix. Three-layer approach: authority preamble in contract, cn_version stamp on conversation entries, staleness annotation at load time. 5 new tests.