### PR TITLE
fix: CDD §11 + post-release skill — tighten MCI capture, concrete commitments, freeze semantics

### DIFF
--- a/docs/beta/guides/TROUBLESHOOTING.md
+++ b/docs/beta/guides/TROUBLESHOOTING.md
@@ -1,0 +1,209 @@
+# Troubleshooting Guide
+
+How to diagnose issues with a CN agent deployment.
+
+## Quick Checks
+
+### Is the daemon running?
+
+```bash
+systemctl status cn-pi          # or whatever your service name is
+journalctl -u cn-pi --since "1 hour ago" --no-pager
+```
+
+### What version is running?
+
+```bash
+cd /path/to/hub
+./bin/cn --version
+```
+
+### Is the agent processing messages?
+
+Check the daemon log for recent activity:
+
+```bash
+tail -50 /path/to/hub/logs/daemon.log
+```
+
+Look for `Processed: tg-<id> (N ops)` lines. If you see them, the daemon is receiving and processing Telegram messages.
+
+## Log Locations
+
+| Log | Path | Contains |
+|-----|------|----------|
+| Daemon log | `logs/daemon.log` | Service lifecycle, inbox/outbox sync, message processing summaries |
+| CN structured log | `logs/cn.log` | JSON-structured ops: inbox materialize, outbox send, auto-save, queue |
+| Event logs | `logs/events/YYYYMMDD.jsonl` | Daily event journals |
+| Input logs | `logs/input/tg-<id>.md` | Full prompt sent to LLM (includes user message at the end) |
+| Output logs | `logs/output/tg-<id>.md` | Agent's response for that message |
+| Rotated CN logs | `logs/cn-YYYYMMDD.log` | Older CN structured logs |
+
+## Reading Conversation History
+
+CN persists every Telegram exchange:
+
+```bash
+# See recent messages processed
+ls -lt logs/input/ | head -10
+
+# Read what the user sent (user message is at the bottom of the file)
+tail -5 logs/input/tg-194570546.md
+
+# Read the agent's response
+cat logs/output/tg-194570546.md
+```
+
+**Note:** Input files are large (60-70KB) because they contain the full prompt context. The user's actual message is in the last few lines.
+
+## Common Issues
+
+### Agent responds but does nothing (0 ops)
+
+The daemon log shows `Processed: tg-<id> (0 ops)`. This means the agent responded conversationally without invoking any CN Shell operations. This is normal for simple questions.
+
+### "Unknown peer" errors
+
+```
+✗ Unknown peer: pi
+```
+
+The agent is trying to send to itself or to a peer not listed in `state/peers.md`. Check:
+
+```bash
+cat state/peers.md
+```
+
+Verify the peer name matches and the repo URL is correct.
+
+### Inbox rejection (orphan)
+
+```
+⚠ inbox.reject branch:pi/sigma-topic peer:sigma author:unknown reason:orphan
+```
+
+Stale inbound branches that no longer have a matching thread. These are harmless but noisy. They'll keep appearing every sync cycle until the branches are cleaned up:
+
+```bash
+# List orphan branches
+git branch -a | grep "pi/"
+
+# Clean up (careful — verify these are truly orphaned)
+git branch -d pi/old-branch-name
+```
+
+### Outbox stuck (no recipient)
+
+```
+outbox.skip thread:some-thread.md reason:no recipient
+```
+
+A thread in `threads/mail/outbox/` has no valid `to:` field, or the `to:` peer doesn't exist in `state/peers.md`.
+
+### Agent can't find files it should see
+
+Check the Runtime Contract for `readable_paths` and `writable_paths`. The agent can only access paths explicitly listed. Logs, for example, are typically not in the agent's readable paths.
+
+### Daemon keeps restarting
+
+```bash
+journalctl -u cn-pi --since "1 hour ago" | grep -E "Started|Stopped|Stopping"
+```
+
+If you see rapid start/stop cycles, check for:
+- Missing secrets (`cat .cn/secrets.env` — needs ANTHROPIC_KEY and TELEGRAM_TOKEN)
+- Binary not found or wrong permissions
+- Hub directory issues
+
+### Telegram messages not arriving
+
+1. Verify the bot token: `cat .cn/secrets.env | grep TELEGRAM`
+2. Check if the daemon is polling: look for `Processed: tg-` entries in daemon.log
+3. Verify there's no other process consuming the same bot token (Telegram only allows one poller per token)
+
+## Checking Git-Based Comms
+
+### Inbox
+
+```bash
+ls threads/mail/inbox/         # Materialized inbound threads
+```
+
+### Outbox (pending)
+
+```bash
+ls threads/mail/outbox/        # Threads waiting to be flushed
+```
+
+### Sent
+
+```bash
+ls threads/mail/sent/          # Successfully delivered threads
+```
+
+### Sync status
+
+The daemon log shows sync activity:
+
+```
+From https://github.com/user/cn-peer
+   abc1234..def5678  main -> origin/main
+⚠ From sigma: 1 inbound
+  ← pi/thread-name
+```
+
+## Checking Agent State
+
+### Runtime Contract
+
+The agent's self-model is loaded at wake time from `agent/wake/`. Check what it sees:
+
+```bash
+cat agent/wake/RUNTIME-CONTRACT.md 2>/dev/null
+```
+
+### Doctor
+
+If the agent has the doctor skill, it runs self-diagnostics. Check recent system threads:
+
+```bash
+ls -lt threads/system/ | head -5
+cat threads/system/mca-review-*.md | tail -20
+```
+
+### Thread state
+
+```bash
+# Recent daily reflections
+ls threads/daily/
+
+# Active adhoc threads
+ls threads/adhoc/
+```
+
+## Deployment Issues
+
+### After upgrading CN version
+
+1. Stop the daemon: `systemctl stop cn-pi`
+2. Replace the binary: `cp cn-new bin/cn && chmod +x bin/cn`
+3. Verify: `./bin/cn --version`
+4. Start: `systemctl start cn-pi`
+5. Check: `tail -20 logs/daemon.log`
+
+### After updating packages (cnos.core, cnos.eng)
+
+Packages are vendored in `.cn/vendor/`. After updating:
+
+```bash
+# Check what's installed
+cat .cn/deps.json
+ls .cn/vendor/
+```
+
+The agent loads packages at wake time. Restart the daemon to pick up changes.
+
+## Getting Help
+
+- File issues: https://github.com/usurobor/cnos/issues
+- Check existing issues: #68 (self-diagnostics), #59 (deep doctor)

--- a/docs/gamma/CDD.md
+++ b/docs/gamma/CDD.md
@@ -1,8 +1,8 @@
 # Coherence-Driven Development (CDD)
 
-**Version:** 1.2.0
+**Version:** 1.3.0
 **Status:** Draft
-**Date:** 2026-03-11
+**Date:** 2026-03-23
 **Placement:** γ document (`docs/gamma/`)
 **Audience:** Contributors, reviewers, maintainers, release operators
 **Scope:** Defines the development method used to evolve cnos coherently
@@ -409,20 +409,40 @@ The system works one way, but teaches another.
 
 ---
 
-## 11. The Place of Human Judgment
+## 11. Post-Release Assessment
 
-CDD is rigorous, but not mechanical.
+CDD does not end at merge. Every release triggers a post-release assessment.
 
-It requires judgment:
+The assessment has four mandatory parts:
+
+1. **Coherence measurement** — score α/β/γ, compare to baseline, update CHANGELOG TSC table
+2. **Encoding lag report** — all converged-but-unimplemented design commitments in a lag table (none/low/growing/stale)
+3. **Process learning** — what went wrong, what went right, skill patches executed immediately
+4. **Next move commitment** — concrete next MCA (issue, owner, branch, first AC, freeze state)
+
+### Rules
+
+- After every release, all outstanding MCI must be captured in the Encoding Lag table.
+- The MCI/MCA balance decision is mandatory (balanced / freeze MCI / resume MCI).
+- The next MCA must be named concretely: issue number, owner, first AC, freeze/resume state.
+- Small process/skill corrections discovered in the assessment should be executed immediately.
+- Larger MCA becomes the next delivery cycle's work.
+- "Freeze MCI" means operationally: no new substantial design docs or plans until the committed MCA backlog is reduced below threshold.
+
+### Delegation
+
+The full procedure is defined in `ops/post-release/SKILL.md`. CDD §11 defines the requirement; the skill defines the execution.
+
+### Human judgment
+
+CDD is rigorous, but not mechanical. It requires judgment:
 
 - when to stop iterating
 - what counts as the real gap
 - whether a contradiction is superficial or structural
 - whether a release is coherent enough
 
-CLP exists because coherence cannot always be inferred from checklists alone. But checklists still matter.
-
-This also means CDD must not become a gate that blocks shipping. CA-CONDUCT says: "Done beats perfect. Bias for action." CDD's role is to ensure that action is coherent, not to replace action with ceremony.
+CLP exists because coherence cannot always be inferred from checklists alone. But checklists still matter. CDD must not become a gate that blocks shipping. CA-CONDUCT says: "Done beats perfect. Bias for action." CDD's role is to ensure that action is coherent, not to replace action with ceremony.
 
 ---
 
@@ -441,6 +461,7 @@ This also means CDD must not become a gate that blocks shipping. CA-CONDUCT says
 9. Update docs
 10. Release with notes
 11. Observe the running system
+12. Post-release assessment (measurement, lag, learning, next move)
 
 For a small change, the coherence contract can be a single sentence in the commit message or PR description. The method scales down.
 

--- a/packages/cnos.core/skills/ops/cdd/SKILL.md
+++ b/packages/cnos.core/skills/ops/cdd/SKILL.md
@@ -25,9 +25,9 @@ CDD owns the full arc from branch to observation:
 6. **Gate** — verify the release checklist (§9)
 7. **Release** — version, tag, CI, merge, announce (§10)
 8. **Observe** — confirm runtime matches design (§10.7)
-9. **Measure** — score the coherence delta, update CHANGELOG TSC table (§11)
+9. **Assess** — post-release assessment: measure, encoding lag, process learning, next move commitment (§11)
 
-Start at step 1. The process is complete when the coherence delta is recorded.
+Start at step 1. The process is complete when the post-release assessment is recorded and the next MCA is committed.
 
 ---
 

--- a/packages/cnos.core/skills/ops/post-release/SKILL.md
+++ b/packages/cnos.core/skills/ops/post-release/SKILL.md
@@ -32,8 +32,15 @@ The assessment produces one artifact with four sections:
 **Skill patches:** (committed Y/N, link if Y)
 
 ### 4. Next Move
-**Priority:** ...
+**Next MCA:** #NN — title
+**Owner:** ...
+**Branch:** ...
+**First AC:** ...
+**MCI frozen until shipped?** yes / no
 **Rationale:** ...
+
+**Immediate fixes** (executed in this session):
+- ...
 ```
 
 ## Procedure
@@ -59,6 +66,8 @@ The coherence note describes which incoherence was reduced, not what feature was
 
 ### Step 3: Encoding lag table
 
+All converged-but-unimplemented design commitments MUST appear in the lag table. This is not optional and has no wiggle room — if a design is converged and not shipped, it appears here.
+
 For every open design issue (issues with design docs, architecture docs, or converged plans that are not yet fully implemented):
 
 | Issue | Title | Design | Impl | Lag |
@@ -79,6 +88,8 @@ Based on the lag table:
 
 This decision is **mandatory**. Every release states the balance.
 
+**What "freeze MCI" means operationally:** No new substantial design docs, plans, or architecture proposals until the committed MCA backlog is reduced below the freeze threshold. Small clarifications to existing designs are allowed; new design commitments are not.
+
 ### Step 5: Process learning
 
 Answer three questions:
@@ -88,10 +99,20 @@ Answer three questions:
 
 ### Step 6: Decide next move
 
-Based on measurement + lag + learning, state what happens next:
-- Which issue to implement
-- Whether to freeze or resume MCI
-- Any skill/process patches to ship first
+Based on measurement + lag + learning, state what happens next as a **concrete commitment**:
+
+- **Next MCA issue:** the specific issue number to implement next
+- **Owner:** who is responsible for the next MCA
+- **Branch:** name of branch (or "pending branch creation")
+- **First AC to close:** which acceptance criterion ships first
+- **MCI frozen?** Whether MCI is frozen until this MCA ships
+
+This turns the assessment into an executable handoff, not just reflection.
+
+**Execution rule:**
+- Small process/skill fixes discovered in the assessment → execute immediately (same session)
+- Everything larger → becomes the next cycle's work via the commitment above
+- Do not attempt to execute a large MCA inside the post-release assessment itself
 
 ## Anti-patterns
 
@@ -119,7 +140,7 @@ Based on measurement + lag + learning, state what happens next:
 | #67 | Network | subsumed by #73 | not started | growing |
 
 MCI/MCA balance: **Freeze MCI** — 3 issues at growing lag.
-Next sessions are pure MCA until #62 and #73 Phase 1 ship.
+No new design docs until backlog reduced below threshold.
 
 ### Process Learning
 Wrong: Review missed CAA.md (§2.0 gate not followed). Fixed with structural table format.
@@ -127,5 +148,14 @@ Right: Three-agent review loop caught complementary gaps.
 Skill patches: review §2.0 gate (committed), CDD §7.6 output format (committed).
 
 ### Next Move
-#62 (land branch with doc fixes) → #73 Phase 1 (open op registry).
+Next MCA: #62 — Runtime Contract v2
+Owner: sigma
+Branch: claude/runtime-contract-v2-VWKUT
+First AC: CAA.md updated with wake-time architecture
+MCI frozen until shipped? Yes
+Rationale: Vertical self-model is foundation for #73, #65, #59.
+
+Immediate fixes (executed this session):
+- review §2.0 structural gate (eeca922)
+- CDD §7.6 output format (64634fb)
 ```

--- a/src/agent/skills/ops/cdd/SKILL.md
+++ b/src/agent/skills/ops/cdd/SKILL.md
@@ -25,9 +25,9 @@ CDD owns the full arc from branch to observation:
 6. **Gate** — verify the release checklist (§9)
 7. **Release** — version, tag, CI, merge, announce (§10)
 8. **Observe** — confirm runtime matches design (§10.7)
-9. **Measure** — score the coherence delta, update CHANGELOG TSC table (§11)
+9. **Assess** — post-release assessment: measure, encoding lag, process learning, next move commitment (§11)
 
-Start at step 1. The process is complete when the coherence delta is recorded.
+Start at step 1. The process is complete when the post-release assessment is recorded and the next MCA is committed.
 
 ---
 

--- a/src/agent/skills/ops/post-release/SKILL.md
+++ b/src/agent/skills/ops/post-release/SKILL.md
@@ -32,8 +32,15 @@ The assessment produces one artifact with four sections:
 **Skill patches:** (committed Y/N, link if Y)
 
 ### 4. Next Move
-**Priority:** ...
+**Next MCA:** #NN — title
+**Owner:** ...
+**Branch:** ...
+**First AC:** ...
+**MCI frozen until shipped?** yes / no
 **Rationale:** ...
+
+**Immediate fixes** (executed in this session):
+- ...
 ```
 
 ## Procedure
@@ -59,6 +66,8 @@ The coherence note describes which incoherence was reduced, not what feature was
 
 ### Step 3: Encoding lag table
 
+All converged-but-unimplemented design commitments MUST appear in the lag table. This is not optional and has no wiggle room — if a design is converged and not shipped, it appears here.
+
 For every open design issue (issues with design docs, architecture docs, or converged plans that are not yet fully implemented):
 
 | Issue | Title | Design | Impl | Lag |
@@ -79,6 +88,8 @@ Based on the lag table:
 
 This decision is **mandatory**. Every release states the balance.
 
+**What "freeze MCI" means operationally:** No new substantial design docs, plans, or architecture proposals until the committed MCA backlog is reduced below the freeze threshold. Small clarifications to existing designs are allowed; new design commitments are not.
+
 ### Step 5: Process learning
 
 Answer three questions:
@@ -88,10 +99,20 @@ Answer three questions:
 
 ### Step 6: Decide next move
 
-Based on measurement + lag + learning, state what happens next:
-- Which issue to implement
-- Whether to freeze or resume MCI
-- Any skill/process patches to ship first
+Based on measurement + lag + learning, state what happens next as a **concrete commitment**:
+
+- **Next MCA issue:** the specific issue number to implement next
+- **Owner:** who is responsible for the next MCA
+- **Branch:** name of branch (or "pending branch creation")
+- **First AC to close:** which acceptance criterion ships first
+- **MCI frozen?** Whether MCI is frozen until this MCA ships
+
+This turns the assessment into an executable handoff, not just reflection.
+
+**Execution rule:**
+- Small process/skill fixes discovered in the assessment → execute immediately (same session)
+- Everything larger → becomes the next cycle's work via the commitment above
+- Do not attempt to execute a large MCA inside the post-release assessment itself
 
 ## Anti-patterns
 
@@ -119,7 +140,7 @@ Based on measurement + lag + learning, state what happens next:
 | #67 | Network | subsumed by #73 | not started | growing |
 
 MCI/MCA balance: **Freeze MCI** — 3 issues at growing lag.
-Next sessions are pure MCA until #62 and #73 Phase 1 ship.
+No new design docs until backlog reduced below threshold.
 
 ### Process Learning
 Wrong: Review missed CAA.md (§2.0 gate not followed). Fixed with structural table format.
@@ -127,5 +148,14 @@ Right: Three-agent review loop caught complementary gaps.
 Skill patches: review §2.0 gate (committed), CDD §7.6 output format (committed).
 
 ### Next Move
-#62 (land branch with doc fixes) → #73 Phase 1 (open op registry).
+Next MCA: #62 — Runtime Contract v2
+Owner: sigma
+Branch: claude/runtime-contract-v2-VWKUT
+First AC: CAA.md updated with wake-time architecture
+MCI frozen until shipped? Yes
+Rationale: Vertical self-model is foundation for #73, #65, #59.
+
+Immediate fixes (executed this session):
+- review §2.0 structural gate (eeca922)
+- CDD §7.6 output format (64634fb)
 ```


### PR DESCRIPTION
## Coherence Contract

**Gap:** Post-release skill was close but had four looseness areas identified by axiom. CDD.md §11 was still 'The Place of Human Judgment' — the skill referenced a section that didn't exist.

**Mode:** MCA — tighten existing artifacts, fix section reference.

## Changes

### Post-release skill (4 tightenings)

1. **All MCI must be captured** — 'All converged-but-unimplemented design commitments MUST appear in the lag table.' No wiggle room.

2. **Next MCA is a concrete commitment** — issue number, owner, branch, first AC, freeze state. Turns assessment into executable handoff, not reflection.

3. **Freeze MCI defined operationally** — 'No new substantial design docs or plans until the committed MCA backlog is reduced below threshold.'

4. **Decide vs execute distinguished** — Small process/skill fixes: execute immediately. Larger MCA: next cycle's work via the commitment above.

### CDD.md v1.2.0 → v1.3.0

- §11 renamed from 'The Place of Human Judgment' to 'Post-Release Assessment'
- §11 describes four mandatory parts + rules (was: philosophical paragraph)
- Human judgment preserved within §11 (not lost, relocated)
- §12 workflow: step 12 added (post-release assessment)
- Post-release skill §11 reference now points to a real section

### CDD skill

- Lifecycle step 9: 'Measure' → 'Assess' (matches expanded §11 scope)

### Bonus

- `docs/beta/guides/TROUBLESHOOTING.md` — first operator troubleshooting guide (discovered during Pi log investigation)

## AC coverage

This is a process fix from axiom feedback, no originating issue. All four feedback items addressed.