### PR TITLE
docs: retroactive epoch assessments v3.12–v3.14 + release gate (#85)

### DIFF
--- a/docs/gamma/cdd/POST-RELEASE-EPOCH-v3.12.md
+++ b/docs/gamma/cdd/POST-RELEASE-EPOCH-v3.12.md
@@ -1,0 +1,92 @@
+# Post-Release Epoch Assessment — v3.12.0–v3.12.2
+
+Epoch: **Runtime Contract v1 + Authority Hardening**
+Releases covered: v3.12.0 (#56, #57), v3.12.1 (#61), v3.12.2 (#63)
+Date range: 2026-03-23
+
+This is a retroactive epoch assessment per CDD §11, created under issue #85.
+Individual per-release assessments were not performed at release time.
+Option B (epoch grouping) was chosen per the #85 recommendation.
+
+---
+
+## 1. Coherence Measurement
+
+### Baseline
+
+v3.11.0 — α A+, β A+, γ A
+
+Coherence note: N-pass merge + misplaced ops correction (#51). Structured output reverted (needs rework). γ at A (not A+) due to the revert — evolution stability took a minor hit.
+
+### This epoch
+
+| Version | C_Σ | α | β | γ | What shipped |
+|---------|-----|---|---|---|---|
+| v3.12.0 | A+ | A+ | A+ | A+ | Wake-up self-model contract (#56). CDD/review skill hardening (#57). |
+| v3.12.1 | A+ | A+ | A+ | A+ | Daemon boot log declares config sources (#61). |
+| v3.12.2 | A+ | A+ | A+ | A+ | Runtime Contract authoritative over stale history (#63). |
+
+### Delta
+
+- **α (PATTERN):** Held at A+. Runtime Contract introduced a new structural primitive (self_model / workspace / capabilities) that is internally consistent and type-safe.
+- **β (RELATION):** Held at A+. All three releases tightened the relationship between agent context and runtime truth — the contract now replaces guesswork with declared state.
+- **γ (EXIT/PROCESS):** Improved from A to A+. The v3.11.0 revert instability was absorbed. Three releases shipped in one day with consistent process. CDD/review skill hardening (#57) made the release process more explicit.
+
+### Coherence contract closed?
+
+The arc across this epoch had a single coherent thesis: **the agent should know itself through a declared contract, not through probing**. v3.12.0 introduced the contract, v3.12.1 extended it to operator-visible boot diagnostics, v3.12.2 established contract authority over stale conversation history.
+
+Contract closed: **yes**. The Runtime Contract v1 exists, renders at wake, and is authoritative.
+
+Residual gap: the contract is v1 (flat structure). The vertical self-model (#62) was already designed but not yet shipped — this became epoch 2's primary MCA.
+
+---
+
+## 2. Encoding Lag (as of v3.12.2)
+
+| Issue | Title | Design | Impl | Lag |
+|-------|-------|--------|------|-----|
+| #62 | Runtime Contract v2 — vertical self-model | converged (PLAN-runtime-contract-v2.md) | not started | growing |
+| #65 | Communication as first-class runtime contract | converged (issue spec) | not started | growing |
+| #73 | Runtime Extensions — capability providers | converged (issue spec) | not started | growing |
+| #67 | Network access as CN Shell capability | converged (issue spec, subsumed by #73) | not started | growing |
+| #59 | cn doctor — deep self-model validation | partial design | partial impl (basic doctor exists) | low |
+| #64 | P0: agent probes filesystem despite RC | bug report | not started | growing |
+
+**MCI/MCA balance: Freeze MCI**
+
+**Rationale:** 5 issues at growing lag, including a P0 bug (#64) that directly contradicts the epoch's thesis (agent should use contract, not probe). Designs are outpacing implementation. The system has a clear Runtime Contract v1 but multiple converged designs waiting for runtime enforcement.
+
+---
+
+## 3. Process Learning
+
+### What went wrong
+
+1. **No post-release assessment existed.** The post-release skill was not yet created during this epoch. Three releases shipped in rapid succession without any structured reflection. This is the exact failure mode CDD §11 was designed to prevent.
+2. **v3.12.2 has no CHANGELOG entry.** The tag exists (`v3.12.2`) but no detailed release notes were written in CHANGELOG.md — only a TSC row (which is also missing). The release is discoverable only through `git log`.
+3. **Velocity over assessment.** Three releases in one day. Each built coherently on the last, but no pause to assess encoding lag meant the growing design backlog was invisible.
+
+### What went right
+
+1. **Tight thematic coherence.** All three releases advanced a single thesis (Runtime Contract). No scope drift.
+2. **CDD/review skill hardening (#57)** shipped alongside the primary feature (#56), strengthening the process that governs future releases.
+3. **Type-safe design.** `secret_source` in v3.12.1 made secret leakage structurally impossible — pattern-level safety, not just policy.
+
+### Skill patches
+
+- Post-release skill created later in #78 (v3.14.1) — partially addresses the gap
+- This epoch assessment (#85) adds the remaining process gate (AC 6)
+
+---
+
+## 4. Next Move (as decided at epoch boundary)
+
+**Next MCA:** #62 — Runtime Contract v2 (vertical self-model)
+**Owner:** sigma
+**First AC:** CAA.md updated with wake-time architecture
+**MCI frozen until shipped?** Yes — 5 issues at growing lag, P0 open
+**Rationale:** #62 is the foundation for #73 (extensions), #65 (communication), and #59 (doctor). Shipping v2 unblocks the entire design backlog. #64 (filesystem probe P0) is a direct consequence of v1's limitations.
+
+**Immediate fixes** (executed retroactively via #85):
+- Process gate added to CDD §9: assessment required before next release tag

--- a/docs/gamma/cdd/POST-RELEASE-EPOCH-v3.14.md
+++ b/docs/gamma/cdd/POST-RELEASE-EPOCH-v3.14.md
@@ -1,0 +1,113 @@
+# Post-Release Epoch Assessment — v3.14.0–v3.14.2
+
+Epoch: **RT v2 + CDD Governance + Bundle Migration**
+Releases covered: v3.13.0 (#75, untagged), v3.14.0 (#62), v3.14.1 (#78), v3.14.2 (#81)
+Date range: 2026-03-24
+
+This is a retroactive epoch assessment per CDD §11, created under issue #85.
+v3.13.0 is included because it shipped between the two epochs and was never assessed.
+Option B (epoch grouping) was chosen per the #85 recommendation.
+
+---
+
+## 1. Coherence Measurement
+
+### Baseline
+
+v3.12.2 (end of epoch 1) — α A+, β A+, γ A+
+
+Encoding lag was at MCI-freeze levels (5 growing). The epoch 1 assessment committed to shipping #62 as the next MCA with MCI frozen.
+
+### This epoch
+
+| Version | C_Σ | α | β | γ | What shipped |
+|---------|-----|---|---|---|---|
+| v3.13.0 | A- | A- | A- | A- | Docs governance (#75): CDD pipeline, self-coherence format, feature bundles, frozen snapshots. |
+| v3.14.0 | A | A | A- | A | Runtime Contract v2 (#62): vertical self-model, zone classification, doctor validation. |
+| v3.14.1 | A | A | A | A | CDD post-release tightening (#78): encoding lag table mandatory, concrete next-MCA, MCI freeze triggers. |
+| v3.14.2 | A | A | A | A | Alpha bundle migration (#81): legacy design docs into CDD bundle structure. |
+
+### Delta
+
+- **α (PATTERN):** Regressed from A+ to A. The v3.13.0 docs governance rewrite introduced new structural concepts (feature bundles, frozen snapshots, bootstrap-first rule) that temporarily increased surface area before settling. By v3.14.2 the pattern stabilized at A — coherent but broader.
+- **β (RELATION):** Regressed from A+ to A. v3.14.0 scored A- on β because the zone classification touched all architecture docs — many relations were in flux during the transition. v3.14.1 restored β to A by codifying the relationships in the post-release skill.
+- **γ (EXIT/PROCESS):** Held at A (relative to epoch 1 end). v3.13.0 dipped to A- as the new CDD pipeline was being established, but v3.14.0 onward restored A. The process is more explicit now but the score reflects that the new process has not yet been stress-tested through many cycles.
+
+### Coherence contract closed?
+
+This epoch had two interlocking theses:
+1. **Ship the vertical self-model (#62)** — the MCA committed in epoch 1's assessment.
+2. **Make the development method self-enforcing** — CDD pipeline, post-release skill, feature bundles.
+
+Thesis 1: **closed.** Runtime Contract v2 shipped in v3.14.0. The agent now receives a vertical self-model (identity → cognition → body → medium) at every wake. Zone classification covers all paths.
+
+Thesis 2: **partially closed.** CDD pipeline exists, post-release skill exists, but the skill was never executed for any release in this epoch (the very gap #85 addresses). The method is documented but not yet proven through practice.
+
+Residual gap: post-release assessments never ran. This epoch assessment closes that gap retroactively.
+
+---
+
+## 2. Encoding Lag (as of v3.14.2)
+
+| Issue | Title | Design | Impl | Lag |
+|-------|-------|--------|------|-----|
+| #62 | Runtime Contract v2 | converged | **shipped (v3.14.0)** | none |
+| #73 | Runtime Extensions — capability providers | converged (issue spec) | not started | **stale** |
+| #65 | Communication — surfaces, transport | converged (issue spec) | not started | **stale** |
+| #67 | Network access as CN Shell capability | converged (subsumed by #73) | not started | **stale** |
+| #68 | Agent self-diagnostics | converged (issue spec) | not started | growing |
+| #59 | cn doctor — deep validation | partial design | partial impl | low |
+| #64 | P0: agent probes filesystem despite RC | bug report | not started | growing |
+| #84 | CA mindset reflection requirements | design (issue spec) | not started | growing |
+| #79 | Projection surfaces | design (issue spec) | not started | growing |
+
+**MCI/MCA balance: Freeze MCI**
+
+**Rationale:** 3 issues at stale lag (#73, #65, #67 — all carried over from epoch 1 with no progress). 4 issues at growing. The epoch shipped its committed MCA (#62) but did not reduce the broader design backlog. The stale issues are the most concerning — these designs have been waiting across two full epochs.
+
+Positive signal: #62 moving from growing to shipped proves the system can close design lag when focused. The problem is breadth, not capability.
+
+---
+
+## 3. Process Learning
+
+### What went wrong
+
+1. **Post-release skill created but never used.** The skill shipped in v3.14.1 (#78) — literally a release about making post-release assessment mandatory — but was not applied to v3.14.1 itself or any subsequent release. Ironic and structurally predictable: the skill had no enforcement gate.
+2. **v3.13.0 never tagged.** CHANGELOG has the entry, code changes merged, but no `git tag` exists. This means `v3.13.0` is a ghost release — documented but not referenceable by tooling.
+3. **TSC scores dropped from A+ to A without alarm.** The regression from A+ (epoch 1) to A (epoch 2) happened gradually across four releases. No single release triggered concern because each was individually coherent. The epoch view reveals the trend: broadening scope (governance, bundles, snapshots) diluted per-axis depth.
+4. **MCI freeze was not honored.** Epoch 1's assessment (retroactively) called for MCI freeze, but v3.13.0 (#75) was pure MCI — a governance design with no runtime implementation. This is exactly what "freeze MCI" prohibits.
+
+### What went right
+
+1. **#62 shipped.** The committed MCA from epoch 1 was delivered. Runtime Contract v2 is the most significant structural change in the v3.x series — vertical self-model, zone classification, full architecture alignment.
+2. **CDD pipeline became explicit.** v3.13.0 defined the 9-step pipeline with per-step artifacts. v3.14.1 added the post-release skill with concrete templates. The method now exists as executable procedure, not just doctrine.
+3. **Bundle migration pattern.** v3.14.2 proved that doc reorganization can follow a repeatable pattern (move → bundle README → frozen snapshot → cross-ref update). This pattern was reused in v3.14.3, v3.14.4, v3.14.5.
+4. **Feature bundles + frozen snapshots.** The version-directory pattern with manifests provides structural traceability that didn't exist before.
+
+### Skill patches
+
+- Post-release skill created in v3.14.1 (#78) — addresses the assessment gap
+- This epoch assessment (#85) adds the enforcement gate (CDD §9.11) — the skill now cannot be skipped
+- v3.12.2 CHANGELOG entry gap noted — future releases must have full CHANGELOG entries (already enforced by CDD §11.3)
+
+---
+
+## 4. Next Move (as decided at epoch boundary)
+
+**Next MCA:** #85 — Post-release assessments + process gate
+**Owner:** sigma
+**Branch:** claude/review-agent-runtime-docs-LyUlu
+**First AC:** Epoch assessments written, encoding lag table current, process gate committed
+**MCI frozen until shipped?** Yes — 3 stale issues, 4 growing. No new designs until stale backlog is addressed.
+
+**Rationale:** Before tackling any stale design issue (#73, #65, #67), the process itself must be trustworthy. #85 closes the meta-gap: the system that measures encoding lag must itself be enforced. After #85, the next MCA should target a stale issue — likely #73 (Runtime Extensions) since #65 and #67 depend on it.
+
+**Stale issue triage (recommended priority):**
+1. #73 Runtime Extensions — foundation for #65 and #67
+2. #65 Communication — depends on #73 transport model
+3. #67 Network — subsumed by #73, may close automatically
+
+**Immediate fixes** (executed in this session via #85):
+- Process gate added to CDD §9: assessment required before next release tag
+- Both epoch assessments committed as CDD §11 artifacts

--- a/docs/gamma/cdd/README.md
+++ b/docs/gamma/cdd/README.md
@@ -16,6 +16,8 @@ Coherence-Driven Development: the method used to evolve cnos coherently.
 |----------|-------|-------------|
 | [CDD.md](./CDD.md) | Canonical spec | Full CDD method: gap → mode → artifacts → review → gate → release → assess |
 | [AGILE-PROCESS.md](./AGILE-PROCESS.md) | Reference | Lightweight agile process for async agent collaboration |
+| [POST-RELEASE-EPOCH-v3.12.md](./POST-RELEASE-EPOCH-v3.12.md) | Assessment | Epoch assessment: v3.12.0–v3.12.2 (Runtime Contract v1 + authority hardening) |
+| [POST-RELEASE-EPOCH-v3.14.md](./POST-RELEASE-EPOCH-v3.14.md) | Assessment | Epoch assessment: v3.14.0–v3.14.2 (RT v2 + CDD governance + bundle migration) |
 
 ---
 

--- a/packages/cnos.core/skills/ops/cdd/SKILL.md
+++ b/packages/cnos.core/skills/ops/cdd/SKILL.md
@@ -443,6 +443,13 @@ Before merge or release, verify each item. A missing item is a known coherence d
   - ❌ Ship v3.6.0 with β = B+ when v3.5.1 was β = A+, no explanation
   - ✅ "β dropped from A+ to A because traceability docs lag — tracked, will fix in v3.6.1"
 
+9.11. **Previous release post-release assessment exists**
+  - Before tagging a new release, verify that the previous release has a completed post-release assessment (§11)
+  - The assessment may be individual or part of an epoch assessment covering the previous release
+  - This gate prevents the accumulation of unassessed releases — the failure mode described in #85
+  - ❌ Tag v3.15.0 when v3.14.5 has no post-release assessment
+  - ✅ "v3.14.5 assessment exists (POST-RELEASE-EPOCH-v3.14.md covers v3.14.0–v3.14.2; individual assessments exist for v3.14.3+)"
+
 ---
 
 ## 10. Release and Close

--- a/src/agent/skills/ops/cdd/SKILL.md
+++ b/src/agent/skills/ops/cdd/SKILL.md
@@ -443,6 +443,13 @@ Before merge or release, verify each item. A missing item is a known coherence d
   - ❌ Ship v3.6.0 with β = B+ when v3.5.1 was β = A+, no explanation
   - ✅ "β dropped from A+ to A because traceability docs lag — tracked, will fix in v3.6.1"
 
+9.11. **Previous release post-release assessment exists**
+  - Before tagging a new release, verify that the previous release has a completed post-release assessment (§11)
+  - The assessment may be individual or part of an epoch assessment covering the previous release
+  - This gate prevents the accumulation of unassessed releases — the failure mode described in #85
+  - ❌ Tag v3.15.0 when v3.14.5 has no post-release assessment
+  - ✅ "v3.14.5 assessment exists (POST-RELEASE-EPOCH-v3.14.md covers v3.14.0–v3.14.2; individual assessments exist for v3.14.3+)"
+
 ---
 
 ## 10. Release and Close


### PR DESCRIPTION
## Summary

- **Two epoch assessments** (CDD §11) covering 6 unassessed releases (v3.12.0–v3.14.2), using Option B from #85
  - Epoch 1 (v3.12.0–v3.12.2): Runtime Contract v1 + authority hardening — MCI freeze triggered (5 growing)
  - Epoch 2 (v3.14.0–v3.14.2): RT v2 + CDD governance + bundle migration — MCI freeze continues (3 stale, 4 growing)
- **Process gate §9.11** added to CDD skill (both copies): previous release must have a post-release assessment before tagging a new release
- Bundle README updated with assessment document map entries

## Acceptance Criteria (from #85)

1. ✅ Post-release assessment exists for every release from v3.12.0 onward (via epoch grouping)
2. ✅ Each assessment includes all four §11 sections: measurement, encoding lag, process learning, next-move
3. ✅ Encoding lag table reflects current state of all open design issues
4. ✅ MCI/MCA balance decision stated and committed (freeze MCI in both epochs)
5. ✅ Assessment artifacts committed to `docs/gamma/cdd/`
6. ✅ Process gate §9.11 prevents tagging without prior assessment

## Test plan

- [ ] Verify epoch 1 assessment covers v3.12.0, v3.12.1, v3.12.2
- [ ] Verify epoch 2 assessment covers v3.13.0 (untagged), v3.14.0, v3.14.1, v3.14.2
- [ ] Verify encoding lag tables list all open design issues with correct lag levels
- [ ] Verify §9.11 gate exists in both `packages/cnos.core/skills/ops/cdd/SKILL.md` and `src/agent/skills/ops/cdd/SKILL.md`
- [ ] Verify bundle README references both assessment files

Closes #85

https://claude.ai/code/session_015b5Qz8rA5q5yryapBBJoDm