### PR TITLE
fix: two-membrane projection integrity (#106)

### DIFF
--- a/docs/gamma/cdd/3.16.2/README.md
+++ b/docs/gamma/cdd/3.16.2/README.md
@@ -1,13 +1,61 @@
-# v3.16.2 — Strip tool_calls markup from human surfaces
+# v3.16.2 — Two-membrane projection integrity
 
-**Issue:** #106
+**Issue:** #106 — Two-membrane fix: presentation leak + self-knowledge probe
 **Branch:** `claude/review-agent-runtime-docs-LyUlu`
-**Mode:** MCA (bugfix — internal markup leaks to human surface)
-**Scope:** Add plural XML tag variants to blocklist, add anti-probe instruction to runtime contract, tests
+**Mode:** MCA (bugfix — P0, internal markup on human surface)
+**Prior version:** v3.16.1
+
+---
+
+## §0 Observation Inputs
+
+### CHANGELOG TSC (v3.16.1 baseline)
+α A / β A / γ A — Daemon retry limit + dead-letter (#28). All axes healthy.
+
+### Encoding Lag
+- 16 open issues, 3 stale (#73, #65, #67), 13 growing
+- #106 added as **new P0** in v3.16.1 assessment
+- MCI freeze active
+
+### Doctor / Status
+Not available (cn doctor #59 — partial impl, low lag).
+
+### Last Assessment (v3.16.1)
+- **Next MCA committed:** #106 (P0 override, §3.1)
+- **First AC:** `<tool_calls>` markup stripped before human surface
+- **MCI frozen:** yes
+
+## §1 Selection
+
+**Selected gap:** #106 — internal markup (`<tool_calls>`, `<cn:ops>`) leaks to human-facing Telegram surface; agent reads `.cn/cn.json` for version instead of using runtime identity.
+
+**Selection rule:** §3.1 P0 override. User-facing coherence failure.
+
+## §4 Gap
+
+Two boundary violations with a shared root cause:
+
+1. **Presentation membrane:** `is_control_plane_like` prefix blocklist had `<tool_call>` (singular) which does not match `<tool_calls>` (plural) — position 10 is `s` vs `>`. Mid-body XML blocks bypass the start-of-string check entirely.
+2. **Self-knowledge membrane:** No explicit anti-probe instruction in Runtime Contract preamble. Sandbox denylist already blocks `.cn/` reads, but the agent could hallucinate the attempt.
+
+## §5 Mode
+
+**MCA** — code must change. The blocklist is wrong, the mid-body stripping is missing, and the anti-probe instruction is absent.
+
+---
 
 ## Frozen Artifacts
 
 | Artifact | File | Status |
 |----------|------|--------|
 | Snapshot manifest | `README.md` (this file) | complete |
-| Self-coherence report | `SELF-COHERENCE.md` | stub |
+| Self-coherence report | `SELF-COHERENCE.md` | complete |
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `src/cmd/cn_output.ml` | `xml_prefixes` lifted to module level, 8 new variants, `strip_xml_pseudo_tools`, sanitize all candidates |
+| `src/cmd/cn_runtime_contract.ml` | Anti-probe instruction in authority preamble |
+| `test/cmd/cn_output_test.ml` | I4 expanded (22→), 9 new #106 tests |
+| `docs/gamma/rules/INVARIANTS.md` | I5: Two-Membrane Projection Integrity |

--- a/docs/gamma/cdd/3.16.2/SELF-COHERENCE.md
+++ b/docs/gamma/cdd/3.16.2/SELF-COHERENCE.md
@@ -9,17 +9,15 @@
 
 | Step | Status | Evidence |
 |------|--------|----------|
-| 0. Observe | done | v3.16.1 assessment committed #106 as next MCA (§3.1 P0 override) |
-| 1. Select | done | §3.1 P0: user-visible coherence failure |
-| 2. Branch | done | `claude/review-agent-runtime-docs-LyUlu`, pre-flight passed |
-| 3. Bootstrap | done | `docs/gamma/cdd/3.16.2/README.md` created as first diff |
-| 4. Gap | done | Root cause identified; two-membrane design from senior eng review |
-| 5. Mode | done | MCA — code must change |
-| 6. Design | done | Two-membrane architecture per issue spec |
-| 7. Tests | done | I4 expanded (7 variants), 6 new #106 tests, membrane integration tests |
-| 8. Code | done | `cn_output.ml`, `cn_runtime_contract.ml`, `INVARIANTS.md` |
-| 9. Pre-flight | this step |
-| 10. Self-coherence | this file |
+| 0. Observe | done | Read CHANGELOG TSC (v3.16.1: A/A/A/A), encoding lag (16 issues, #106 new P0), doctor (n/a — #59 partial), last assessment (v3.16.1: committed #106 as next MCA via §3.1 P0 override) |
+| 1. Select | done | §3.1 P0: user-visible coherence failure. v3.16.1 assessment committed #106. MCI freeze holds. |
+| 2. Branch | done | `claude/review-agent-runtime-docs-LyUlu`. Pre-flight: v3.16.2 > v3.16.1 ✓, no duplicate branch ✓, no duplicate PR ✓, scope declared ✓ |
+| 3. Bootstrap | done | `docs/gamma/cdd/3.16.2/README.md` with observation inputs, gap, mode, scope, frozen artifact table |
+| 4. Gap | done | Root cause: prefix match bug + mid-body bypass + missing anti-probe. Two-membrane design from senior eng review. |
+| 5. Mode | done | MCA — blocklist is wrong, mid-body stripping missing, anti-probe absent |
+| 6. Artifacts | done | Design (issue #106 spec) → tests (I4 expanded + 9 new) → code (cn_output.ml, cn_runtime_contract.ml) → docs (I5 in INVARIANTS.md) |
+| 7. Self-coherence | this file |
+| 8. Review | in progress | Round 1: 7 findings (5D, 2C), all addressed. Awaiting round 2. |
 
 ## §4 Root Cause Analysis
 
@@ -87,7 +85,7 @@ All 7/7 ACs accounted for. Pre-flight passed.
 
 ### A. Harden Cn_output
 - [x] Add stripping/blocking for `<tool_calls>` and equivalent wrappers
-- [x] Apply to every candidate source (body via `strip_xml_pseudo_tools`, reply via `is_control_plane_like`)
+- [x] Apply to every candidate source (body + reply via shared `sanitize` helper: `strip_embedded_frontmatter` + `strip_xml_pseudo_tools` + `is_control_plane_like`)
 - [x] One module owns invariant (Cn_output — no per-sink sanitizers)
 
 ### B. Invariant tests


### PR DESCRIPTION
## Summary

Fixes #106 — two boundary violations with a shared root cause: the boundary between control plane and presentation plane was not enforced as a complete invariant.

### Membrane 1: Presentation (Cn_output)

- **Root cause:** `xml_prefixes` blocklist had `<tool_call>` (singular, 11 chars ending `>`) which does NOT prefix-match `<tool_calls>` (12 chars, position 10 is `s` vs `>`). Additionally, `is_control_plane_like` only checks the *start* of the candidate string — mid-body XML pseudo-tool blocks in otherwise-valid prose passed through undetected.
- **Fix:** Lift `xml_prefixes` to module level. Add 7 missing variants: `<tool_calls>`, `<function_calls>`, `<tool_result>`, `<tool_results>`, `<invoke>`, `<invoke>`, `<thinking>`. Add `strip_xml_pseudo_tools()` state machine (mirrors `strip_embedded_frontmatter` for `---` blocks). Apply both strippers in `render_human_facing` before candidate check.

### Membrane 2: Self-knowledge (Runtime Contract)

- Anti-probe instruction added to authority preamble: "Do not read cn.json or any manifest file to determine your own version — use the cn_version field below."
- Sandbox denylist already blocks `.cn/` reads — no code change needed.

### Invariant documentation

- I5 added to `INVARIANTS.md` defining both membranes as enforced invariants.

## AC coverage

| AC | Status | Evidence |
|----|--------|----------|
| `<tool_calls>` never rendered on human surface | Met | `xml_prefixes` + `strip_xml_pseudo_tools` |
| All human projection through `Cn_output.render_for_sink` | Met (pre-existing) | Line 251: same function for Telegram + ConversationStore |
| Fallback + trace on no safe payload | Met (pre-existing) | `try_candidates` + `resolve_render` |
| Runtime context has correct version | Met (pre-existing) | Runtime Contract v2 |
| Agent doesn't fs_read cn.json for version | Met | Anti-probe instruction + sandbox denylist |
| `.cn/` reads rejected | Met (pre-existing) | `cn_sandbox.ml` denylist |
| Invariant documented | Met | I5 in INVARIANTS.md |

## Test plan

- [x] I4 expect test expanded with 7 new XML variants (22 total)
- [x] `#106: Telegram and ConversationStore block <tool_calls> identically` — integration test proving single membrane
- [x] `#106: mixed prose + <tool_calls> mid-body stripped` — mid-body XML removal
- [x] `#106: reply payload containing <tool_calls> falls back` — reply candidate with XML
- [x] `strip_xml_pseudo_tools` unit tests: single-line, multi-line, body-is-entirely-XML
- [ ] CI build verification

https://claude.ai/code/session_015b5Qz8rA5q5yryapBBJoDm