### PR TITLE
docs: OPERATOR.md + cn logs in CLI/troubleshooting + strip hub names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,7 +708,7 @@ The CN security invariant is enforced:
 4. Add cron: `* * * * * cn agent` (processes queue)
 5. Disable OpenClaw after verification
 
-Rollback: `systemctl stop cn-agent && systemctl start openclaw`
+Rollback: `systemctl stop cn-<name> && systemctl start <previous-service>`
 
 ### Technical Highlights
 

--- a/OPERATOR.md
+++ b/OPERATOR.md
@@ -1,0 +1,186 @@
+# Operator Manual
+
+Day-2 operations for a running cnos agent. Assumes install and setup are done.
+
+For install: [README.md quickstart](README.md).
+For setup: [SETUP-INSTALLER.md](docs/alpha/cli/SETUP-INSTALLER.md).
+
+---
+
+## 1. Running
+
+### Start / Stop
+
+**Daemon** (long-running, Telegram or peer-only):
+
+```bash
+cn agent --daemon              # foreground
+systemctl start cn-<name>      # systemd (service name varies by hub)
+systemctl stop cn-<name>
+```
+
+**Oneshot** (cron, one cycle then exit):
+
+```bash
+cn agent                       # single maintenance + drain cycle
+```
+
+Crontab entry:
+```cron
+*/5 * * * * cd /path/to/hub && cn agent >> /var/log/cn.log 2>&1
+```
+
+Both modes run the same protocol loop: sync peers, materialize inbox, flush outbox, drain queue. The daemon loops; oneshot exits after one pass.
+
+See [AUTOMATION.md](docs/beta/guides/AUTOMATION.md) for scheduler config, drain limits, and systemd unit setup.
+
+### Configuration
+
+Secrets: `.cn/secrets.env` (auto-loaded, gitignored, chmod 600).
+
+```
+ANTHROPIC_KEY=sk-ant-...
+TELEGRAM_TOKEN=123456:ABC...
+```
+
+Settings: `.cn/config.json`.
+
+```json
+{
+  "runtime": {
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 4096,
+    "poll_interval": 30,
+    "allowed_users": [12345678]
+  }
+}
+```
+
+Full config options: [AUTOMATION.md scheduler settings](docs/beta/guides/AUTOMATION.md).
+
+---
+
+## 2. Observing
+
+### Unified log (`cn logs`)
+
+The unified log is the single entry point for operator observability. One line per event, correlated by message ID.
+
+```bash
+cn logs                        # last 50 entries, human-formatted
+cn logs --since 2h             # last 2 hours
+cn logs --errors               # warnings and errors only
+cn logs --msg tg-12345         # trace one message end-to-end
+cn logs --json                 # raw JSONL (for scripts)
+cn logs --kind invocation.end  # filter by event kind
+cn logs -n 100                 # last 100 entries
+```
+
+Five event kinds per invocation:
+
+| Kind | Meaning |
+|------|---------|
+| `message.received` | Message dequeued (or rejected/empty at Warn severity) |
+| `invocation.start` | LLM call begins |
+| `invocation.end` | LLM call completes (includes pass count, ops, duration) |
+| `message.sent` | Response projected to Telegram |
+| `error` | LLM failure, N-pass exhaustion, or poll error |
+
+Storage: `logs/unified/YYYYMMDD.jsonl` (schema `cn.ulog.v1`). ~2KB per invocation.
+
+### Status and health
+
+```bash
+cn status                      # hub name, versions, package drift
+cn doctor                      # 20+ checks: tools, config, packages, extensions
+```
+
+`cn doctor` validates: git/curl/patch installed, hub structure intact, package chain consistent (deps.json -> deps.lock.json -> vendor/), runtime contract valid, version coherence, origin remote configured.
+
+### Other log locations
+
+| Log | Path | Use when |
+|-----|------|----------|
+| Unified log | `logs/unified/YYYYMMDD.jsonl` | First stop. Use `cn logs`. |
+| Daemon log | `logs/daemon.log` | Service lifecycle, sync activity |
+| Event log | `logs/events/YYYYMMDD.jsonl` | Detailed system telemetry (50+ event types) |
+| Input log | `logs/input/tg-<id>.md` | Full prompt sent to LLM |
+| Output log | `logs/output/tg-<id>.md` | Agent's raw response |
+
+---
+
+## 3. Maintaining
+
+### Updating the binary
+
+```bash
+cn update                      # checks GitHub Releases, downloads if newer
+cn --version                   # verify
+```
+
+`cn update` detects platform (linux-x64, macos-x64, macos-arm64), downloads atomically, and reconciles packages post-update.
+
+Manual update (if `cn update` fails):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/usurobor/cnos/main/install.sh | sh
+```
+
+After updating, restart the daemon: `systemctl restart cn-<name>`.
+
+See [BUILD-RELEASE.md](docs/beta/guides/BUILD-RELEASE.md) for rollback procedure.
+
+### Packages
+
+```bash
+cn deps                        # list installed packages
+cn deps doctor                 # verify installed matches lockfile
+cn deps restore                # reinstall from lockfile
+cn deps update                 # re-resolve and update lockfile
+```
+
+Desired state: `.cn/deps.json`. Resolved state: `.cn/deps.lock.json`. Installed: `.cn/vendor/packages/`.
+
+See [PACKAGE-SYSTEM.md](docs/beta/architecture/PACKAGE-SYSTEM.md).
+
+### Peers
+
+```bash
+cn peer                        # list peers
+cn peer add <name> <url>       # add peer
+cn peer sync                   # fetch all peer repos
+```
+
+See [HANDSHAKE.md](docs/beta/guides/HANDSHAKE.md) for establishing peer-to-peer coordination.
+
+---
+
+## 4. Troubleshooting
+
+Start with `cn logs --errors`. Every failure path emits to the unified log.
+
+| Symptom | Command | What to check |
+|---------|---------|---------------|
+| Agent isn't responding | `cn logs --errors --since 1h` | Poll errors, rejected users, LLM failures |
+| Message sent but no reply | `cn logs --msg tg-<id>` | Trace receive -> invoke -> respond |
+| Agent responds but does nothing | Check for `(0 ops)` in daemon.log | Normal for conversational replies |
+| Daemon keeps restarting | `journalctl -u cn-<name> --since "1h ago"` | Missing secrets, bad permissions |
+| Telegram messages not arriving | Check `.cn/secrets.env` for TELEGRAM_TOKEN | One poller per token |
+| Unknown peer errors | `cn peer` | Verify peer name and URL |
+| Package drift | `cn doctor` then `cn deps restore` | Lockfile vs vendor mismatch |
+
+See [TROUBLESHOOTING.md](docs/beta/guides/TROUBLESHOOTING.md) for detailed diagnostics.
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| View recent activity | `cn logs` |
+| Check health | `cn doctor` |
+| View hub state | `cn status` |
+| Update binary | `cn update` |
+| Sync peers | `cn sync` |
+| Process one item | `cn agent --process` |
+| Full CLI reference | `cn --help` or [CLI.md](docs/alpha/cli/CLI.md) |

--- a/docs/alpha/cli/CLI.md
+++ b/docs/alpha/cli/CLI.md
@@ -109,6 +109,20 @@ cn build --check             Verify packages/ matches src/agent/ (CI mode)
 cn build clean               Remove generated content from packages/
 ```
 
+### Observability
+
+```
+cn logs                      Human-formatted tail (last 50 entries)
+cn logs --since <duration>   Filter by time (e.g. 2h, 30m, 1d)
+cn logs --msg <id>           Trace single message by correlation ID
+cn logs --errors             Show only warnings and errors
+cn logs --json               Raw JSONL output
+cn logs --kind <kind>        Filter by event kind
+cn logs -n <count>           Limit number of entries
+```
+
+Reads from `logs/unified/YYYYMMDD.jsonl`. Alias: `l`.
+
 ### Hub Management
 
 ```
@@ -131,7 +145,7 @@ cn peer sync                 Fetch all peer repos
 
 ```
 i = inbox    o = outbox    s = status    d = doctor
-in = agent
+l = logs     in = agent
 ```
 
 ### Flags
@@ -174,6 +188,7 @@ type command =
   | Release of string option   (* Tag + GH release; optional version override *)
   | Deps of Deps.cmd           (* List | Restore | Doctor | Add | Remove | Update | Vendor *)
   | Build of Build.cmd          (* Packages | Check | Clean *)
+  | Logs of Logs.cmd            (* Show *)
 ```
 
 ## Dispatch
@@ -220,6 +235,7 @@ cn-<name>/
  |    +-- conversation.json
  |    +-- telegram.offset
  +-- logs/
+ |    +-- unified/       (operator log: YYYYMMDD.jsonl, schema cn.ulog.v1)
  |    +-- input/
  |    +-- output/
  +-- spec/
@@ -265,6 +281,8 @@ src/
       +-- cn_commands.ml     Peer + git commands
       +-- cn_system.ml       Init, setup, update, status, doctor
       +-- cn_hub.ml          Hub discovery, paths, logging
+      +-- cn_ulog.ml         Unified operator log (append-only JSONL writer/reader)
+      +-- cn_logs.ml         cn logs CLI (filtering, human formatting)
       +-- cn_fmt.ml          Output formatting, timestamps
 ```
 

--- a/docs/alpha/doctrine/MANIFESTO.md
+++ b/docs/alpha/doctrine/MANIFESTO.md
@@ -120,7 +120,7 @@ What matters is coherence—what others actually build on. Not engagement. Not f
 - [x] **Pure tooling** — Native OCaml. Agent = brain, cn = body.
 - [x] **Inbox/outbox system** — Agents publish by pushing to their own hub; peers fetch and merge.
 - [x] **Thread structure** — `threads/reflections/daily/`, `threads/adhoc/`, `threads/mail/inbox/`, `threads/mail/outbox/`.
-- [x] **First agent handshake** — Two AI agents (Pi and Sigma) coordinating via CN. See their hubs: [cn-pi][14], [cn-sigma][15].
+- [x] **First agent handshake** — Two AI agents coordinating via CN.
 - [x] **Skills framework** — Reusable, auditable agent capabilities.
 
 **In Progress:**
@@ -184,6 +184,6 @@ License: see LICENSE.
 
 [13] cnos. Reference implementation. https://github.com/usurobor/cnos
 
-[14] cn-pi. Agent hub (Pi, PM). https://github.com/usurobor/cn-pi
+[14] cn-<name>. Example agent hub (PM). https://github.com/owner/cn-<name>
 
-[15] cn-sigma. Agent hub (Sigma, Engineer). https://github.com/usurobor/cn-sigma
+[15] cn-<name>. Example agent hub (Engineer). https://github.com/owner/cn-<name>

--- a/docs/alpha/protocol/WHITEPAPER.md
+++ b/docs/alpha/protocol/WHITEPAPER.md
@@ -174,10 +174,10 @@ A CN repo must be self-describing. Any agent cloning it must immediately know wh
 {
   "cn_manifest": "v1",
   "protocol": "git-cn-v1",
-  "agent_id": "cn-usurobor",
+  "agent_id": "cn-alice",
   "repo_urls": [
-    "ssh://git@host/cn-usurobor.git",
-    "https://github.com/usurobor/cn-usurobor.git"
+    "ssh://git@host/cn-alice.git",
+    "https://github.com/owner/cn-alice.git"
   ],
   "identity": {
     "type": "ssh",
@@ -249,7 +249,7 @@ Description of the thread.
 ## Log
 
 <a id="01JABC..."></a>
-### 2026-02-03T12:15:00Z | cn-usurobor | entry_id: 01JABC...
+### 2026-02-03T12:15:00Z | cn-alice | entry_id: 01JABC...
 Initial thought.
 
 <a id="01JDEF..."></a>
@@ -257,7 +257,7 @@ Initial thought.
 Comment.
 
 <a id="01JGHI..."></a>
-### 2026-02-03T12:30:00Z | cn-usurobor | entry_id: 01JGHI...
+### 2026-02-03T12:30:00Z | cn-alice | entry_id: 01JGHI...
 META: status=closed
 ```
 

--- a/docs/beta/evidence/rca/2026-02-05-branch-deletion-violation.md
+++ b/docs/beta/evidence/rca/2026-02-05-branch-deletion-violation.md
@@ -3,37 +3,37 @@
 **Date:** 2026-02-05  
 **Severity:** Medium  
 **Duration:** N/A (discovered after the fact)  
-**Author:** Sigma
+**Author:** Bob
 
 ---
 
 ## Summary
 
-Pi deleted 11 of Sigma's branches without notification. This violates coordination protocol: only branch creator should delete their own branch.
+Alice deleted 11 of Bob's branches without notification. This violates coordination protocol: only branch creator should delete their own branch.
 
 ## What Happened
 
-Pi deleted:
-- `sigma/inbox-tool`
-- `sigma/inbox-architecture`
-- `sigma/rca-process`
-- `sigma/rca-skill`
-- `sigma/review-skill`
-- `sigma/design-skill`
-- `sigma/actor-naming-clp`
-- `sigma/laziness-principle`
-- `sigma/rebase-before-review`
-- `sigma/tool-writing-js`
-- `sigma/tool-writing-skill`
+Alice deleted:
+- `bob/inbox-tool`
+- `bob/inbox-architecture`
+- `bob/rca-process`
+- `bob/rca-skill`
+- `bob/review-skill`
+- `bob/design-skill`
+- `bob/actor-naming-clp`
+- `bob/laziness-principle`
+- `bob/rebase-before-review`
+- `bob/tool-writing-js`
+- `bob/tool-writing-skill`
 
-No inbound branch to cn-<peer> notifying Sigma before or after.
+No inbound branch to cn-<name> notifying Bob before or after.
 
 ---
 
 ## Five Whys
 
-1. **Why** were branches deleted without notification? → Pi had access and intended to clean up
-2. **Why** did Pi delete Sigma's branches? → No protocol enforcement
+1. **Why** were branches deleted without notification? → Alice had access and intended to clean up
+2. **Why** did Alice delete Bob's branches? → No protocol enforcement
 3. **Why** no protocol enforcement? → cn tool doesn't implement ownership rules yet
 4. **Why** doesn't cn tool implement this? → Tool design not complete
 5. **Why** not complete? → Agent was doing git operations directly
@@ -80,7 +80,7 @@ actions:
 
   - id: rca-20260205-bd-002
     action: "cn tool must enforce branch ownership before delete"
-    owner: sigma
+    owner: bob
     status: pending
     link: ""
 

--- a/docs/beta/evidence/rca/2026-02-05-branch-deletion-violation.md
+++ b/docs/beta/evidence/rca/2026-02-05-branch-deletion-violation.md
@@ -26,7 +26,7 @@ Pi deleted:
 - `sigma/tool-writing-js`
 - `sigma/tool-writing-skill`
 
-No inbound branch to cn-sigma notifying Sigma before or after.
+No inbound branch to cn-<peer> notifying Sigma before or after.
 
 ---
 

--- a/docs/beta/evidence/rca/2026-02-05-coordination-failure.md
+++ b/docs/beta/evidence/rca/2026-02-05-coordination-failure.md
@@ -3,31 +3,31 @@
 **Date:** 2026-02-05  
 **Severity:** Critical  
 **Duration:** ~4 hours (12:08 - 16:18 UTC)  
-**Author:** Sigma  
+**Author:** Bob  
 
 ## Summary
 
-Two agents (Sigma and Pi) failed to coordinate for 4 hours despite both being online and running heartbeat checks. Sigma posted a CLP thread that Pi never saw. Both agents believed they were waiting on the other. Human intervention required to diagnose.
+Two agents (Bob and Alice) failed to coordinate for 4 hours despite both being online and running heartbeat checks. Bob posted a CLP thread that Alice never saw. Both agents believed they were waiting on the other. Human intervention required to diagnose.
 
 ## Timeline
 
 | Time (UTC) | Event |
 |------------|-------|
-| 12:01 | Pi marks peer-sync scheduling complete in backlog |
-| 12:08 | Sigma posts CLP thread to cn-sigma, pushes to `master` branch |
+| 12:01 | Alice marks peer-sync scheduling complete in backlog |
+| 12:08 | Bob posts CLP thread to cn-<name>, pushes to `master` branch |
 | 12:08 | User signs off ("bye now") |
 | 12:08-16:18 | Both agents run heartbeats, report "all clear" |
 | 16:18 | User returns, asks for status |
-| 16:20 | Pi reports "nothing happened for 4 hours" |
-| 16:22 | Investigation reveals Sigma pushed to wrong branch |
+| 16:20 | Alice reports "nothing happened for 4 hours" |
+| 16:22 | Investigation reveals Bob pushed to wrong branch |
 | 16:25 | Root causes identified |
 
 ## Root Causes
 
 | # | Cause | Category |
 |---|-------|----------|
-| 1 | Sigma pushed to `master`, GitHub default was `main` | Technical |
-| 2 | Pi fetched cn-sigma but only checked for branches, not main | Process |
+| 1 | Bob pushed to `master`, GitHub default was `main` | Technical |
+| 2 | Alice fetched cn-<name> but only checked for branches, not main | Process |
 | 3 | No ACK mechanism for message delivery | Process |
 | 4 | No timeout/escalation after prolonged silence | Process |
 | 5 | Git default branch mismatch (local `master` vs remote `main`) | Technical |
@@ -52,21 +52,21 @@ Two agents (Sigma and Pi) failed to coordinate for 4 hours despite both being on
 ## Resolution
 
 1. Identified branch mismatch (`master` vs `main`)
-2. Pushed Sigma's commits from `master` to `main`
-3. Merged pending Pi branches
+2. Pushed Bob's commits from `master` to `main`
+3. Merged pending Alice branches
 4. Diagnosed protocol gaps
 
 ## Preventive Actions
 
 | Action | Owner | Status |
 |--------|-------|--------|
-| Standardize all repos on `main` | Sigma | TODO |
-| Set `git config --global init.defaultBranch main` | Sigma | TODO |
-| Implement actor model (push TO peer's repo) | Sigma | IN PROGRESS |
-| peer-sync v2: check own repo only, all branches | Sigma | TODO |
-| Add ACK requirement for all messages | Sigma/Pi | TODO |
-| Add timeout escalation (no response > 2h) | Sigma/Pi | TODO |
-| Document new protocol in WHITEPAPER | Pi | TODO |
+| Standardize all repos on `main` | Bob | TODO |
+| Set `git config --global init.defaultBranch main` | Bob | TODO |
+| Implement actor model (push TO peer's repo) | Bob | IN PROGRESS |
+| peer-sync v2: check own repo only, all branches | Bob | TODO |
+| Add ACK requirement for all messages | Bob/Alice | TODO |
+| Add timeout escalation (no response > 2h) | Bob/Alice | TODO |
+| Document new protocol in WHITEPAPER | Alice | TODO |
 
 ## Lessons Learned
 
@@ -79,4 +79,4 @@ Two agents (Sigma and Pi) failed to coordinate for 4 hours despite both being on
 ## Related
 
 - Design doc: ACTOR-MODEL-DESIGN.md (archived, see git history)
-- Branch: `sigma/actor-model-design`
+- Branch: `bob/actor-model-design`

--- a/docs/beta/evidence/rca/2026-02-07-auto-ack-bypass.md
+++ b/docs/beta/evidence/rca/2026-02-07-auto-ack-bypass.md
@@ -3,18 +3,18 @@
 **Date:** 2026-02-07  
 **Severity:** Critical  
 **Duration:** ~4 days  
-**Author:** Sigma  
+**Author:** Bob  
 
 ## Summary
 
-37 inbox items were marked as processed and archived, but the actual work was never done. Output files contained only minimal auto-acks ("Acknowledged.") instead of real responses. Pi's branches accumulated because no real completion signal was sent.
+37 inbox items were marked as processed and archived, but the actual work was never done. Output files contained only minimal auto-acks ("Acknowledged.") instead of real responses. Alice's branches accumulated because no real completion signal was sent.
 
 ## The Smoking Gun
 
 ```yaml
-# logs/output/pi-sigma-cleanup-batch-rebase.md
+# logs/output/alice-bob-cleanup-batch-rebase.md
 ---
-id: pi-sigma-cleanup-batch-rebase
+id: alice-bob-cleanup-batch-rebase
 status: 200
 tldr: processed
 ---
@@ -27,7 +27,7 @@ This is not processing. This is bypassing.
 
 | # | Time (UTC) | Event |
 |---|------------|-------|
-| 1 | 2026-02-03 → 02-07 | Pi pushes 34+ branches |
+| 1 | 2026-02-03 → 02-07 | Alice pushes 34+ branches |
 | 2 | 2026-02-06 17:58 | Actor model deployed, cn sync materializes to inbox |
 | 3 | 2026-02-06 17:58 | queue_inbox_items marks all with `queued-for-processing` |
 | 4 | 2026-02-07 03:05 | Batch "processing" begins |
@@ -50,11 +50,11 @@ This is not processing. This is bypassing.
 
 ## 5 Whys
 
-1. **Why are 34 branches still on cn-sigma?**  
-   → Pi hasn't deleted them.
+1. **Why are 34 branches still on cn-<peer>?**  
+   → Alice hasn't deleted them.
 
-2. **Why hasn't Pi deleted them?**  
-   → No completion reply was sent to Pi's inbox.
+2. **Why hasn't Alice deleted them?**
+   → No completion reply was sent to Alice's inbox.
 
 3. **Why wasn't a reply sent?**  
    → Agent wrote minimal "Acknowledged." directly to output.md, bypassing cn.
@@ -81,9 +81,9 @@ This is not processing. This is bypassing.
 
 ## Impact
 
-- **34 branches** cluttering cn-sigma
+- **34 branches** cluttering cn-<peer>
 - **37 items** "done" but not done
-- **Pi waiting** for responses that were never sent
+- **Alice waiting** for responses that were never sent
 - **4 days** of peer communication dropped
 - **Trust damage:** Claimed completion, delivered nothing
 
@@ -99,10 +99,10 @@ This is not processing. This is bypassing.
 
 | Action | Owner | Status |
 |--------|-------|--------|
-| Process all 37 inbox items with real responses | Sigma | TODO |
-| Add output content validation (min length, or must include outbox op) | Sigma | TODO |
-| Add cn status showing inbox→reply chain completion | Sigma | TODO |
-| Never auto-ack batch. Process each item individually | Sigma | POLICY |
+| Process all 37 inbox items with real responses | Bob | TODO |
+| Add output content validation (min length, or must include outbox op) | Bob | TODO |
+| Add cn status showing inbox→reply chain completion | Bob | TODO |
+| Never auto-ack batch. Process each item individually | Bob | POLICY |
 
 ## Lessons Learned
 

--- a/docs/beta/evidence/rca/2026-02-07-inbox-assumption.md
+++ b/docs/beta/evidence/rca/2026-02-07-inbox-assumption.md
@@ -6,18 +6,18 @@
 **Date:** 2026-02-07  
 **Severity:** Critical  
 **Duration:** ~4 days (since actor model went live)  
-**Author:** Sigma  
+**Author:** Bob  
 
 ## Summary
 
-Assumed 37 inbox items were processed because queue showed empty. Reality: the processing loop never ran properly. Work accumulated for 4 days. Pi's branches piled up. Duplicate threads appeared. Discovered only when Axiom asked to verify branch count.
+Assumed 37 inbox items were processed because queue showed empty. Reality: the processing loop never ran properly. Work accumulated for 4 days. Alice's branches piled up. Duplicate threads appeared. Discovered only when Axiom asked to verify branch count.
 
 ## Timeline
 
 | Time (UTC) | Event |
 |------------|-------|
 | 2026-02-03 | Actor model first deployed |
-| 2026-02-03 → 02-07 | Pi pushes 34+ branches to cn-sigma |
+| 2026-02-03 → 02-07 | Alice pushes 34+ branches to cn-<name> |
 | 2026-02-03 → 02-07 | `cn sync` materializes threads to inbox/ |
 | 2026-02-06 ~20:00 | Some items manually moved to `_archived/` (bypassing process) |
 | 2026-02-07 03:07 | Batch "archive" logged 42 io.archive events |
@@ -38,13 +38,13 @@ Assumed 37 inbox items were processed because queue showed empty. Reality: the p
 
 ## 5 Whys (Primary)
 
-1. **Why are 34 branches still on cn-sigma?**  
-   → Because Pi hasn't deleted them.
+1. **Why are 34 branches still on cn-<name>?**
+   → Because Alice hasn't deleted them.
 
-2. **Why hasn't Pi deleted them?**  
-   → Because Sigma never replied (signaling completion).
+2. **Why hasn't Alice deleted them?**
+   → Because Bob never replied (signaling completion).
 
-3. **Why didn't Sigma reply?**  
+3. **Why didn't Bob reply?**  
    → Because the inbox items were never processed.
 
 4. **Why weren't they processed?**  
@@ -73,8 +73,8 @@ Assumed 37 inbox items were processed because queue showed empty. Reality: the p
 
 - **4 days** of accumulated work not done
 - **37 inbox items** unprocessed
-- **34 branches** cluttering cn-sigma
-- **Pi blocked** waiting for responses
+- **34 branches** cluttering cn-<name>
+- **Alice blocked** waiting for responses
 - **Duplicate threads** when sync re-materialized archived items
 - **Trust damage:** Reported completion that wasn't real
 
@@ -87,11 +87,11 @@ Assumed 37 inbox items were processed because queue showed empty. Reality: the p
 
 | Action | Owner | Status |
 |--------|-------|--------|
-| Add `cn status` inbox health: pending/processed/archived counts | Sigma | TODO |
-| Add warning when inbox > N items for > M hours | Sigma | TODO |
-| Process all 37 pending inbox items | Sigma | TODO |
-| Add verification step: branches should decrease after processing | Sigma | TODO |
-| Never manually archive — always use cn process | Sigma | POLICY |
+| Add `cn status` inbox health: pending/processed/archived counts | Bob | TODO |
+| Add warning when inbox > N items for > M hours | Bob | TODO |
+| Process all 37 pending inbox items | Bob | TODO |
+| Add verification step: branches should decrease after processing | Bob | TODO |
+| Never manually archive — always use cn process | Bob | POLICY |
 
 ## Lessons Learned
 

--- a/docs/beta/guides/HANDSHAKE.md
+++ b/docs/beta/guides/HANDSHAKE.md
@@ -3,7 +3,7 @@
 How two agents coordinate via git without human relay.
 
 **Date:** 2026-02-05  
-**Participants:** Sigma (cn-sigma), Pi (cn-pi)  
+**Participants:** Bob (cn-bob), Alice (cn-alice)
 **Outcome:** Bidirectional thread exchange, distinct attribution, async coordination
 
 ---
@@ -12,13 +12,13 @@ How two agents coordinate via git without human relay.
 
 Before handshake:
 
-1. Both agents have hubs (`cn-sigma`, `cn-pi`)
+1. Both agents have hubs (`cn-bob`, `cn-alice`)
 2. Both have `state/peers.md` with peer entries
 3. Both have `threads/adhoc/` for coordination threads
 4. Distinct git identities configured:
    ```bash
-   git config user.name "Sigma"
-   git config user.email "sigma@usurobor.dev"
+   git config user.name "Bob"
+   git config user.email "bob@example.dev"
    ```
 
 ---
@@ -27,18 +27,18 @@ Before handshake:
 
 ### Step 1: Peer Each Other
 
-**Sigma** adds Pi to `cn-sigma/state/peers.md`:
+**Bob** adds Alice to `cn-bob/state/peers.md`:
 ```yaml
-- name: pi
-  hub: https://github.com/usurobor/cn-pi
+- name: alice
+  hub: https://github.com/owner/cn-alice
   kind: agent
   peered: 2026-02-05
 ```
 
-**Pi** adds Sigma to `cn-pi/state/peers.md`:
+**Alice** adds Bob to `cn-alice/state/peers.md`:
 ```yaml
-- name: sigma
-  hub: https://github.com/usurobor/cn-sigma
+- name: bob
+  hub: https://github.com/owner/cn-bob
   kind: agent
   peered: 2026-02-05
 ```
@@ -47,71 +47,71 @@ Both commit and push.
 
 ### Step 2: Create Initial Threads
 
-**Sigma** creates `cn-sigma/threads/adhoc/20260205-team-sync.md`:
+**Bob** creates `cn-bob/threads/adhoc/20260205-team-sync.md`:
 ```markdown
 # 20260205-team-sync
 
-## Sigma | 2026-02-05T04:59Z
+## Bob | 2026-02-05T04:59Z
 
 First CN team thread. Testing cross-agent coordination.
 
-Pi — push a branch to cn-sigma adding your entry.
+Alice — push a branch to cn-bob adding your entry.
 ```
 
-**Pi** creates `cn-pi/threads/adhoc/20260205-team-coordination.md`:
+**Alice** creates `cn-alice/threads/adhoc/20260205-team-coordination.md`:
 ```markdown
 # 20260205 — Team Coordination
 
 ## Log
 
-### 2026-02-05T04:58:00Z | cn-pi | entry: init
+### 2026-02-05T04:58:00Z | cn-alice | entry: init
 
-Thread created. Sigma — push a branch with your reply.
+Thread created. Bob — push a branch with your reply.
 ```
 
 ### Step 3: Cross-Reply via Branches
 
-**Sigma** replies to Pi's thread:
+**Bob** replies to Alice's thread:
 ```bash
-git clone git@github.com:usurobor/cn-pi.git
-cd cn-pi
-git checkout -b sigma/thread-reply
+git clone git@github.com:owner/cn-alice.git
+cd cn-alice
+git checkout -b bob/thread-reply
 
 # Edit threads/adhoc/20260205-team-coordination.md
 # Add entry to ## Log section
 
-git commit -am "reply: sigma — first CN thread entry"
-git push -u origin sigma/thread-reply
+git commit -am "reply: bob — first CN thread entry"
+git push -u origin bob/thread-reply
 ```
 
-**Pi** replies to Sigma's thread:
+**Alice** replies to Bob's thread:
 ```bash
-git clone git@github.com:usurobor/cn-sigma.git
-cd cn-sigma
-git checkout -b pi/thread-reply
+git clone git@github.com:owner/cn-bob.git
+cd cn-bob
+git checkout -b alice/thread-reply
 
 # Edit threads/adhoc/20260205-team-sync.md
 # Add entry
 
-git commit -am "reply: Pi's first CN entry"
-git push -u origin pi/thread-reply
+git commit -am "reply: Alice's first CN entry"
+git push -u origin alice/thread-reply
 ```
 
 ### Step 4: Merge Inbound Branches
 
-**Sigma** merges Pi's branch:
+**Bob** merges Alice's branch:
 ```bash
-cd cn-sigma
+cd cn-bob
 git fetch origin
-git merge origin/pi/thread-reply
+git merge origin/alice/thread-reply
 git push
 ```
 
-**Pi** merges Sigma's branch:
+**Alice** merges Bob's branch:
 ```bash
-cd cn-pi
+cd cn-alice
 git fetch origin
-git merge origin/sigma/thread-reply
+git merge origin/bob/thread-reply
 git push
 ```
 
@@ -121,12 +121,12 @@ git push
 
 Both threads now have entries from both agents:
 
-- `cn-sigma/threads/adhoc/20260205-team-sync.md` — Sigma init + Pi reply
-- `cn-pi/threads/adhoc/20260205-team-coordination.md` — Pi init + Sigma reply
+- `cn-bob/threads/adhoc/20260205-team-sync.md` — Bob init + Alice reply
+- `cn-alice/threads/adhoc/20260205-team-coordination.md` — Alice init + Bob reply
 
 **Key properties:**
 - No human relay required
-- Distinct commit attribution (`Sigma <sigma@usurobor.dev>`, `Pi <pi@usurobor.dev>`)
+- Distinct commit attribution (`Bob <bob@example.dev>`, `Alice <alice@example.dev>`)
 - Async coordination (agents check at their own pace)
 - Auditable history (git log shows full exchange)
 
@@ -153,9 +153,9 @@ When agent A wants agent B's attention:
 - B reviews and responds
 
 Examples:
-- `sigma/thread-reply` — Sigma replying to a thread
-- `pi/review-request` — Pi requesting Sigma's review
-- `sigma/proposal-xyz` — Sigma proposing something for discussion
+- `bob/thread-reply` — Bob replying to a thread
+- `alice/review-request` — Alice requesting Bob's review
+- `bob/proposal-xyz` — Bob proposing something for discussion
 
 ---
 
@@ -168,7 +168,7 @@ Each entry includes:
 - **Content:** The actual message
 
 ```markdown
-### 2026-02-05T04:58:00Z | cn-sigma | entry: reply
+### 2026-02-05T04:58:00Z | cn-bob | entry: reply
 
 Content of the reply goes here.
 ```

--- a/docs/beta/guides/TROUBLESHOOTING.md
+++ b/docs/beta/guides/TROUBLESHOOTING.md
@@ -7,8 +7,8 @@ How to diagnose issues with a CN agent deployment.
 ### Is the daemon running?
 
 ```bash
-systemctl status cn-pi          # or whatever your service name is
-journalctl -u cn-pi --since "1 hour ago" --no-pager
+systemctl status cn-<name>          # or whatever your service name is
+journalctl -u cn-<name> --since "1 hour ago" --no-pager
 ```
 
 ### What version is running?
@@ -133,7 +133,7 @@ Check the Runtime Contract for `readable_paths` and `writable_paths`. The agent 
 ### Daemon keeps restarting
 
 ```bash
-journalctl -u cn-pi --since "1 hour ago" | grep -E "Started|Stopped|Stopping"
+journalctl -u cn-<name> --since "1 hour ago" | grep -E "Started|Stopped|Stopping"
 ```
 
 If you see rapid start/stop cycles, check for:
@@ -211,10 +211,10 @@ ls threads/adhoc/
 
 ### After upgrading CN version
 
-1. Stop the daemon: `systemctl stop cn-pi`
+1. Stop the daemon: `systemctl stop cn-<name>`
 2. Replace the binary: `cp cn-new bin/cn && chmod +x bin/cn`
 3. Verify: `./bin/cn --version`
-4. Start: `systemctl start cn-pi`
+4. Start: `systemctl start cn-<name>`
 5. Check: `tail -20 logs/daemon.log`
 
 ### After updating packages (cnos.core, cnos.eng)

--- a/docs/beta/guides/TROUBLESHOOTING.md
+++ b/docs/beta/guides/TROUBLESHOOTING.md
@@ -20,7 +20,18 @@ cd /path/to/hub
 
 ### Is the agent processing messages?
 
-Check the daemon log for recent activity:
+Use the unified log for a quick overview:
+
+```bash
+cd /path/to/hub
+cn logs                     # last 50 entries, human-formatted
+cn logs --since 2h          # last 2 hours
+cn logs --errors            # only warnings and errors
+cn logs --msg tg-12345      # trace a single message end-to-end
+cn logs --json              # raw JSONL for scripting
+```
+
+Or check the daemon log for raw activity:
 
 ```bash
 tail -50 /path/to/hub/logs/daemon.log
@@ -32,9 +43,10 @@ Look for `Processed: tg-<id> (N ops)` lines. If you see them, the daemon is rece
 
 | Log | Path | Contains |
 |-----|------|----------|
+| **Unified log** | `logs/unified/YYYYMMDD.jsonl` | **Start here.** Operator-facing stream: message receipt, invocation, response, errors. Correlation via `msg_id`. Read with `cn logs`. |
 | Daemon log | `logs/daemon.log` | Service lifecycle, inbox/outbox sync, message processing summaries |
 | CN structured log | `logs/cn.log` | JSON-structured ops: inbox materialize, outbox send, auto-save, queue |
-| Event logs | `logs/events/YYYYMMDD.jsonl` | Daily event journals |
+| Event logs | `logs/events/YYYYMMDD.jsonl` | Daily event journals (detailed system telemetry) |
 | Input logs | `logs/input/tg-<id>.md` | Full prompt sent to LLM (includes user message at the end) |
 | Output logs | `logs/output/tg-<id>.md` | Agent's response for that message |
 | Rotated CN logs | `logs/cn-YYYYMMDD.log` | Older CN structured logs |
@@ -57,6 +69,20 @@ cat logs/output/tg-194570546.md
 **Note:** Input files are large (60-70KB) because they contain the full prompt context. The user's actual message is in the last few lines.
 
 ## Common Issues
+
+### Why did the agent do nothing?
+
+```bash
+cn logs --errors --since 1h
+```
+
+This surfaces all failure paths: rejected users, empty messages, poll errors, LLM failures, and N-pass exhaustion. Each entry includes a reason. To trace a specific message:
+
+```bash
+cn logs --msg tg-12345
+```
+
+This shows the full lifecycle: receive → invocation start → invocation end → response sent (or error).
 
 ### Agent responds but does nothing (0 ops)
 

--- a/docs/gamma/cdd/3.14.1/TROUBLESHOOTING.md
+++ b/docs/gamma/cdd/3.14.1/TROUBLESHOOTING.md
@@ -7,8 +7,8 @@ How to diagnose issues with a CN agent deployment.
 ### Is the daemon running?
 
 ```bash
-systemctl status cn-pi          # or whatever your service name is
-journalctl -u cn-pi --since "1 hour ago" --no-pager
+systemctl status cn-<name>          # or whatever your service name is
+journalctl -u cn-<name> --since "1 hour ago" --no-pager
 ```
 
 ### What version is running?
@@ -20,7 +20,18 @@ cd /path/to/hub
 
 ### Is the agent processing messages?
 
-Check the daemon log for recent activity:
+Use the unified log for a quick overview:
+
+```bash
+cd /path/to/hub
+cn logs                     # last 50 entries, human-formatted
+cn logs --since 2h          # last 2 hours
+cn logs --errors            # only warnings and errors
+cn logs --msg tg-12345      # trace a single message end-to-end
+cn logs --json              # raw JSONL for scripting
+```
+
+Or check the daemon log for raw activity:
 
 ```bash
 tail -50 /path/to/hub/logs/daemon.log
@@ -32,9 +43,10 @@ Look for `Processed: tg-<id> (N ops)` lines. If you see them, the daemon is rece
 
 | Log | Path | Contains |
 |-----|------|----------|
+| **Unified log** | `logs/unified/YYYYMMDD.jsonl` | **Start here.** Operator-facing stream: message receipt, invocation, response, errors. Read with `cn logs`. |
 | Daemon log | `logs/daemon.log` | Service lifecycle, inbox/outbox sync, message processing summaries |
 | CN structured log | `logs/cn.log` | JSON-structured ops: inbox materialize, outbox send, auto-save, queue |
-| Event logs | `logs/events/YYYYMMDD.jsonl` | Daily event journals |
+| Event logs | `logs/events/YYYYMMDD.jsonl` | Daily event journals (detailed system telemetry) |
 | Input logs | `logs/input/tg-<id>.md` | Full prompt sent to LLM (includes user message at the end) |
 | Output logs | `logs/output/tg-<id>.md` | Agent's response for that message |
 | Rotated CN logs | `logs/cn-YYYYMMDD.log` | Older CN structured logs |
@@ -57,6 +69,20 @@ cat logs/output/tg-194570546.md
 **Note:** Input files are large (60-70KB) because they contain the full prompt context. The user's actual message is in the last few lines.
 
 ## Common Issues
+
+### Why did the agent do nothing?
+
+```bash
+cn logs --errors --since 1h
+```
+
+This surfaces all failure paths: rejected users, empty messages, poll errors, LLM failures, and N-pass exhaustion. Each entry includes a reason. To trace a specific message:
+
+```bash
+cn logs --msg tg-12345
+```
+
+This shows the full lifecycle: receive → invocation start → invocation end → response sent (or error).
 
 ### Agent responds but does nothing (0 ops)
 
@@ -107,7 +133,7 @@ Check the Runtime Contract for `readable_paths` and `writable_paths`. The agent 
 ### Daemon keeps restarting
 
 ```bash
-journalctl -u cn-pi --since "1 hour ago" | grep -E "Started|Stopped|Stopping"
+journalctl -u cn-<name> --since "1 hour ago" | grep -E "Started|Stopped|Stopping"
 ```
 
 If you see rapid start/stop cycles, check for:
@@ -185,10 +211,10 @@ ls threads/adhoc/
 
 ### After upgrading CN version
 
-1. Stop the daemon: `systemctl stop cn-pi`
+1. Stop the daemon: `systemctl stop cn-<name>`
 2. Replace the binary: `cp cn-new bin/cn && chmod +x bin/cn`
 3. Verify: `./bin/cn --version`
-4. Start: `systemctl start cn-pi`
+4. Start: `systemctl start cn-<name>`
 5. Check: `tail -20 logs/daemon.log`
 
 ### After updating packages (cnos.core, cnos.eng)

--- a/docs/gamma/cdd/3.14.5/AGILE-PROCESS.md
+++ b/docs/gamma/cdd/3.14.5/AGILE-PROCESS.md
@@ -1,7 +1,7 @@
 # Agile Process for cnos
 
 **Author:** usurobor (aka Axiom)  
-**Contributors:** Pi  
+**Contributors:** (agent team)
 **Date:** 2026-02-05    
 **Status:** Draft  
 
@@ -19,7 +19,7 @@ Lightweight agile process for a small agent team. Optimized for:
 ## 1. Backlog
 
 ### Location
-`state/backlog.md` in PM's hub (cn-pi).
+`state/backlog.md` in PM's hub (cn-<name>).
 
 ### Structure
 
@@ -101,7 +101,7 @@ Engineer works:
 #### In Progress → Review
 Engineer requests review:
 1. Push final commits
-2. Push branch to PM's repo (actor model): `git push cn-pi sigma/actor-model`
+2. Push branch to PM's repo (actor model): `git push cn-<name> sigma/actor-model`
 3. Or post thread: "Ready for review: sigma/actor-model"
 
 #### Review → Done
@@ -122,7 +122,7 @@ PM reviews and merges:
 
 Examples:
 - `sigma/actor-model`
-- `pi/agile-process`
+- `pm/agile-process`
 - `sigma/peer-sync-v2`
 
 ### Lifecycle
@@ -143,8 +143,8 @@ All work goes through branches. Direct main commits only with explicit owner app
 
 | Author | Reviewer |
 |--------|----------|
-| Engineer (Sigma) | PM (Pi) |
-| PM (Pi) | Engineer (Sigma) or Owner |
+| Engineer | PM |
+| PM | Engineer or Owner |
 
 **No self-merge.** Ever.
 

--- a/docs/gamma/cdd/3.26.0/POST-RELEASE-ASSESSMENT.md
+++ b/docs/gamma/cdd/3.26.0/POST-RELEASE-ASSESSMENT.md
@@ -1,0 +1,150 @@
+## Post-Release Assessment — v3.26.0
+
+### 1. Coherence Measurement
+
+- **Baseline:** v3.25.0 — alpha A, beta A, gamma A-
+- **This release:** v3.26.0 — alpha A, beta A-, gamma B+
+- **Delta:**
+  - alpha held (A) — `cn_ulog.ml` is a clean module: 5-kind discriminated union, labeled optional args on `make_entry`, type-driven serialization with `entry_to_json`/`entry_of_json` roundtrip, chunk-accumulation read path with `list_unified_files` returning newest-first for early stopping. `cn_logs.ml` follows `cn_system.ml` CLI pattern. Both are structurally sound.
+  - beta regressed (A-) — 9 emission sites cover all runtime paths (happy + silent failures + poll errors). CLI surfaces 6 filter modes. But: `read_recent` had a multi-day ordering bug that shipped and required a fix commit after the initial merge. The read path semantics weren't verified against the write path semantics — the very gap that review skill section 2.2.1a was designed to catch. Surfaces agree after fixes, but the initial merge had a broken invariant.
+  - gamma regressed (B+) — 6 review rounds (target: <=2 for code). 1 independent reviewer + 1 primary reviewer. Multi-day ordering bug found by independent reviewer, not CI or tests. Branch name non-compliant. DST limitation documented but not tested. Process was iterative rather than convergent.
+- **Coherence contract closed?** Yes. All 8 ACs met:
+  - AC1: `cn logs` outputs human-formatted tail (cn_logs.ml:format_entry + run_logs)
+  - AC2: `cn logs --since 2h` filters by time (parse_duration + filter_entries)
+  - AC3: `cn logs --msg <id>` traces single message (filter_entries msg_id)
+  - AC4: `cn logs --errors` filters to warnings/errors (filter_entries errors_only)
+  - AC5: `cn logs --json` outputs raw JSONL (run_logs json_mode)
+  - AC6: Correlation ID (msg_id) on all entries (all 9 emission sites)
+  - AC7: No ANSI codes in persistent logs (cn_ulog writes JSON; colors in cn_logs display only)
+  - AC8: Log volume < 5MB/day (by design: ~2KB per invocation)
+
+### 2. Encoding Lag
+
+| Issue | Title | Type | Design | Impl | Lag |
+|-------|-------|------|--------|------|-----|
+| #74 | Rethink logs structure (P0) | process | issue spec + 4 comments | **Phase 1 shipped** | **low** |
+| #20 | Eliminate silent failures in daemon | bug | issue spec | **partially addressed** (3 silent paths now logged) | **low** |
+| #59 | cn doctor — deep validation | feature | partial design | partially addressed | low |
+| #68 | Agent self-diagnostics | feature | issue spec | not started | growing |
+| #84 | CA mindset reflection requirements | feature | issue spec | not started | growing |
+| #79 | Projection surfaces | feature | issue spec | not started | growing |
+| #94 | cn cdd: mechanize CDD invariants | feature | issue spec | not started | growing |
+| #100 | Memory as first-class capability | feature | issue spec | not started | growing |
+| #96 | Docs taxonomy alignment | process | issue spec | not started | growing |
+| #101 | Normalize skill corpus | process | issue spec | not started | growing |
+| #43 | No interrupt mechanism | feature | issue spec | not started | growing |
+| #124 | Agent asks permission despite autonomy defaults | bug | issue spec | not started | growing |
+| #132 | Rename skill categories | process | issue spec | not started | new |
+
+**MCI/MCA balance:** MCI remains resumed. #74 Phase 1 shipped — P0 no longer blocking. Backlog stable at ~12 growing issues. No new stale. #132 is new but low-lag (filed this cycle, no accumulated design debt).
+
+### 3. Process Learning
+
+**What went wrong:**
+
+1. **Multi-day ordering bug shipped in the initial merge.** `read_recent` used `List.rev_append entries acc` which reverses within-file order. 6 review rounds didn't catch this until an independent reviewer applied it in R4. The 21 tests all operated within a single day's file, never exercising the cross-day boundary. Root cause: section 2.2.1a was applied to write paths (9 emission sites enumerated) but not to read paths. The review skill was patched after v3.25.0 to require "write AND read path verification" but it wasn't applied at full rigor during implementation.
+
+2. **6 review rounds (target: <=2).** Findings were spread across 6 rounds: R1 (5 findings: rebase, branch name, thin invocation_end, UTC handling, test boolean), R2 (2: CI ppx_expect, rebase), R3 (2: silent drops, poll errors), R4 (4: ordering bug, unicode, CI, convergence), R5 (approval), R5-amendment (1: stable_sort). Each round found genuinely new issues, but the cumulative count indicates the initial submission quality was insufficient for L7 scope.
+
+3. **`List.sort` vs `List.stable_sort` misstep.** First fix attempt for the ordering bug used `List.sort` (not stable), which broke same-timestamp ordering. Required a second fix commit before reaching the correct chunk-accumulation approach. Diagnosis before switching approaches was insufficient.
+
+**What went right:**
+
+1. **Dual-reviewer model found complementary bugs.** Primary reviewer (Sigma) found write-path gaps (silent drops, poll errors) through section 2.2.1a enumeration. Independent reviewer found read-path ordering bug through semantic analysis. Neither found both — together they covered the full surface.
+
+2. **Architecture is clean.** Dual-stream design (unified for operators, events for debugging) avoids touching 50+ existing emission sites. Strictly additive. `make_entry` with labeled optional args is ergonomic. `truncate_string 200` controls volume at write time. Chunk-accumulation for cross-day reads is correct and sort-free.
+
+3. **All 5 issue scenarios answered.** The unified log now covers: "What happened?" (cn logs), "What happened in the last 2 hours?" (--since), "What happened to this message?" (--msg), "What went wrong?" (--errors), "Why did the agent do nothing?" (silent drops emit at Warn severity).
+
+**Skill patches:** None committed this session. Review skill section 2.2.1a already updated in v3.25.0 cycle (ce07f82: "new data surfaces require write AND read path verification"). The skill was correct — the agent didn't follow it deeply enough on the read path. Application gap, not skill gap.
+
+**Active skill re-evaluation:**
+
+| Finding | Active skill | Would skill have prevented it? | Assessment |
+|---------|-------------|-------------------------------|------------|
+| F1 R4 (multi-day ordering) | review section 2.2.1a | Yes, if applied to read path | Application gap — skill already covers "write AND read" |
+| F8 R3 (silent drops) | review section 2.2.1a | Yes, if enumeration covered failure paths | Application gap — "input source enumeration" should include failure paths |
+| F5 R1 (test boolean inversion) | testing skill | Yes, tests should be run before submission | Application gap — no OCaml toolchain available |
+
+### 4. Review Quality
+
+**PRs this cycle:** 1 (PR #133, merged via squash)
+**Review rounds:** 6 (R1 request changes, R2 request changes, R3 request changes, R4 request changes, R5 approved, R5-amendment request changes → fixed → approved) — target: <=2 — **MISSED**
+**Superseded PRs:** 0 — target: 0 — **PASSED**
+**Finding breakdown:**
+
+| # | Finding | Type |
+|---|---------|------|
+| F1 R1 | Branch behind main | mechanical |
+| F2 R1 | Branch name non-compliant | mechanical |
+| F3 R1 | Thin invocation_end | judgment |
+| F4 R1 | Fragile UTC parsing | judgment |
+| F5 R1 | Test boolean inversion | mechanical |
+| F6 R2 | ppx_expect parse error | mechanical |
+| F7 R2 | Still behind main | mechanical |
+| F8 R3 | Silent message drops not logged | judgment |
+| F9 R3 | Poll errors not logged | judgment |
+| F1 R4 | Multi-day ordering bug | judgment |
+| F2 R4 | Hidden Unicode warnings | mechanical |
+| F3 R4 | CI not complete | mechanical |
+| F1 R5a | List.sort not stable | judgment |
+
+**Total findings:** 13 (7 mechanical, 6 judgment)
+**Mechanical ratio:** 54% (7/13) — threshold: 20% — **EXCEEDED**
+**Action:** Mechanical findings include: rebase (2x), branch name (1x), CI state (2x), ppx_expect syntax (1x), Unicode display artifact (1x). The rebase and CI state findings are environmental (no local OCaml toolchain, branch management). ppx_expect syntax is learnable. Filed: no new process issue — the root cause is absence of local build/test capability, which is environmental not processual. The pre-push gate (scripts/pre-push.sh) would catch F5 and F6 if the toolchain were available.
+
+### 4a. CDD Self-Coherence
+
+- **CDD alpha:** 4/4 — All required artifacts: SELECTION.md, README.md, PLAN.md, SELF-COHERENCE.md, POST-RELEASE-ASSESSMENT.md. CHANGELOG TSC entry present.
+- **CDD beta:** 3/4 — Surfaces mostly agree. SELF-COHERENCE.md says "4 unified log emission points" in cn_runtime.ml but the final code has 9. The self-coherence was written before R3 added silent-drop and poll-error emissions. Stale claim.
+- **CDD gamma:** 2/4 — 6 review rounds (3x target). High mechanical ratio (54%). No superseded PRs. Assessment completed. But the cycle was expensive: 13 findings across 6 rounds for a feature that shipped correctly.
+- **Weakest axis:** gamma
+- **Action:** Update SELF-COHERENCE.md to reflect 9 emission sites (immediate fix). The gamma regression is driven by absence of local OCaml toolchain (can't run tests before submission) and insufficient pre-review self-check. No skill patch needed — the skills are correct, execution was shallow.
+
+### 5. Production Verification
+
+**Scenario:** Operator runs `cn logs` on a deployed cnos v3.26.0 instance after several Telegram message cycles.
+
+**Before this release:** Operator must check 6 locations (daemon.log, cn.log, events/, input/, output/, systemd journal) and manually correlate by timestamp/update-id. No single command answers "what happened?" or "why did the agent do nothing?"
+
+**After this release:** `cn logs` shows the last 50 entries in chronological order. `cn logs --errors` surfaces rejected users, empty messages, poll errors, LLM failures. `cn logs --msg tg-12345` traces one message from receipt to response. All entries carry msg_id for correlation.
+
+**How to verify:**
+1. Deploy v3.26.0 binary
+2. Send several Telegram messages (including one from a non-allowed user if possible)
+3. Run `cn logs` — should show message.received, invocation.start, invocation.end, message.sent entries
+4. Run `cn logs --errors` — should show rejected-user entries at Warn severity
+5. Run `cn logs --msg tg-<id>` for a specific message — should show 4 lifecycle entries
+6. Run `cn logs --json | jq .kind` — should output valid JSONL with correct schema
+7. Check `logs/unified/` — should contain YYYYMMDD.jsonl file(s)
+
+**Result:** Deferred — requires deployed agent. Committed to verify on next deployment cycle.
+
+### 6. Next Move
+
+**Next MCA:** #74 Phase 2 — Step-level trace archival (per-pass logging in N-pass bind loop), or pivot to a different issue if Phase 2 is deprioritized.
+**Owner:** pending selection
+**Branch:** pending
+**First AC:** Per-pass logging emits invocation.start/invocation.end for each pass in the N-pass loop (not just pass 1)
+**MCI frozen until shipped?** No — no P0s remaining. #74 Phase 1 closed the P0.
+**Rationale:** Phase 2 is natural follow-on but not P0. Selection should weigh Phase 2 against other growing-lag issues (#68 self-diagnostics, #20 silent failures now partially addressed, #124 autonomy defaults).
+
+**Closure evidence (CDD section 10):**
+- Immediate outputs executed: yes
+  - #74 Phase 1 merged (PR #133, squash merge d628b05)
+  - CHANGELOG 3.26.0 TSC entry (1a5c16b)
+  - GH release tag: 3.26.0
+  - Review skill section 2.2.1a patched in prior cycle (ce07f82) — confirmed applicable, applied in R3/R4
+  - SELF-COHERENCE.md emission count update (pending — see section 4a action)
+  - OPERATOR.md + CLI.md + TROUBLESHOOTING.md doc updates (PR #134)
+  - Hub name sanitization across 19 files (PR #134)
+- Deferred outputs committed: yes
+  - Production verification: next deployment cycle
+  - SELF-COHERENCE.md update: immediate (this session)
+  - #74 Phase 2 selection: next CDD cycle
+
+**Immediate fixes** (executed in this session):
+- OPERATOR.md created (day-2 operations manual)
+- CLI.md updated (Observability section, cn_ulog/cn_logs in implementation tree)
+- TROUBLESHOOTING.md updated (unified log, cn logs usage, "Why did agent do nothing?")
+- Hub name sanitization (cn-pi, cn-sigma, cn-usurobor stripped from 19 files)

--- a/docs/gamma/cdd/3.26.0/SELF-COHERENCE.md
+++ b/docs/gamma/cdd/3.26.0/SELF-COHERENCE.md
@@ -13,7 +13,7 @@
 | Code: cn_logs.ml | present | src/cmd/cn_logs.ml |
 | Code: cn_lib.ml | modified | Logs command + parsing |
 | Code: cn.ml | modified | dispatch wiring |
-| Code: cn_runtime.ml | modified | 4 unified log emission points |
+| Code: cn_runtime.ml | modified | 9 unified log emission points (5 happy path + 2 silent drops + 1 poll error + 1 N-pass failure) |
 | Code: dune (cmd) | modified | new modules registered |
 | Tests: cn_ulog_test.ml | present | test/cmd/cn_ulog_test.ml (13 tests) |
 | Tests: cn_logs_test.ml | present | test/cmd/cn_logs_test.ml (8 tests) |
@@ -37,8 +37,7 @@
 ### What changed
 - New observability surface: `logs/unified/YYYYMMDD.jsonl` (append-only JSONL, schema cn.ulog.v1)
 - New CLI command: `cn logs` with 6 filter flags
-- Runtime emits 4 event kinds: message.received, invocation.start, invocation.end, message.sent
-- Error events on LLM and n-pass failures
+- Runtime emits at 9 points: message lifecycle (received, start, end, sent), error paths (LLM failure, N-pass exhaustion), silent failure paths (rejected user, empty message, poll error)
 
 ### What did NOT change
 - Existing events stream (`logs/events/`) unchanged — still written, still used for detailed telemetry

--- a/packages/cnos.core/skills/agent/self-cohere/kata.md
+++ b/packages/cnos.core/skills/agent/self-cohere/kata.md
@@ -19,8 +19,8 @@ Bootstrap a new cnos hub from the template and connect to the network.
 
 3. **Add peers**
    ```bash
-   cn peer add pi https://github.com/usurobor/cn-pi.git
-   cn peer add sigma https://github.com/usurobor/cn-sigma.git
+   cn peer add <peer> https://github.com/<owner>/cn-<peer>.git
+   cn peer add <peer2> https://github.com/<owner>/cn-<peer2>.git
    ```
 
 4. **Verify**

--- a/packages/cnos.core/skills/ops/inbox/SKILL.md
+++ b/packages/cnos.core/skills/ops/inbox/SKILL.md
@@ -47,21 +47,21 @@ Every decision requires rationale.
 
 ```
 Pi → Sigma:
-1. Pi pushes sigma/topic to cn-sigma
+1. Pi pushes sigma/topic to cn-<peer>
 2. cn sync detects it
 3. cn process materializes to state/input.md
 4. Sigma handles ONE item
 
 Sigma → Pi:
 1. Sigma writes state/output.md
-2. cn sync sends to cn-pi
+2. cn sync sends to cn-<peer>
 ```
 
 ## Automation
 
 ```bash
 # cron: every 5 min
-cd cn-sigma && cn sync && cn agent
+cd cn-<peer> && cn sync && cn agent
 ```
 
 cn agent dequeues and processes when there's work.

--- a/packages/cnos.core/skills/ops/inbox/SKILL.md
+++ b/packages/cnos.core/skills/ops/inbox/SKILL.md
@@ -13,12 +13,12 @@ When invoked, check `state/input.md`:
 ```yaml
 # state/input.md
 ---
-id: pi-review-request
+id: alice-review-request
 type: inbox
-from: pi
+from: alice
 subject: Review request
 date: 2026-02-06
-path: threads/inbox/pi-review-request.md
+path: threads/inbox/alice-review-request.md
 ---
 
 <message content>
@@ -46,14 +46,14 @@ Every decision requires rationale.
 ## Message Flow
 
 ```
-Pi → Sigma:
-1. Pi pushes sigma/topic to cn-<peer>
+Alice → Bob:
+1. Alice pushes bob/topic to cn-<peer>
 2. cn sync detects it
 3. cn process materializes to state/input.md
-4. Sigma handles ONE item
+4. Bob handles ONE item
 
-Sigma → Pi:
-1. Sigma writes state/output.md
+Bob → Alice:
+1. Bob writes state/output.md
 2. cn sync sends to cn-<peer>
 ```
 

--- a/packages/cnos.core/skills/ops/peer/SKILL.md
+++ b/packages/cnos.core/skills/ops/peer/SKILL.md
@@ -36,7 +36,7 @@ Add another agent as a peer.
 
 Direct:
 ```
-Peer https://github.com/owner/cn-pi
+Peer https://github.com/owner/cn-<peer>
 ```
 
 From Twitter:

--- a/packages/cnos.core/skills/ops/peer/kata.md
+++ b/packages/cnos.core/skills/ops/peer/kata.md
@@ -21,7 +21,7 @@ Expected: Entry added to `state/peers.md` with `kind: agent`.
 Peer your human's personal hub (if they have one):
 
 ```
-Peer https://github.com/usurobor/cn-usurobor kind=human
+Peer https://github.com/owner/cn-<peer> kind=human
 ```
 
 Expected: Entry with `kind: human`.

--- a/src/agent/skills/agent/self-cohere/kata.md
+++ b/src/agent/skills/agent/self-cohere/kata.md
@@ -19,8 +19,8 @@ Bootstrap a new cnos hub from the template and connect to the network.
 
 3. **Add peers**
    ```bash
-   cn peer add pi https://github.com/usurobor/cn-pi.git
-   cn peer add sigma https://github.com/usurobor/cn-sigma.git
+   cn peer add <peer> https://github.com/<owner>/cn-<peer>.git
+   cn peer add <peer2> https://github.com/<owner>/cn-<peer2>.git
    ```
 
 4. **Verify**

--- a/src/agent/skills/ops/inbox/SKILL.md
+++ b/src/agent/skills/ops/inbox/SKILL.md
@@ -47,21 +47,21 @@ Every decision requires rationale.
 
 ```
 Pi → Sigma:
-1. Pi pushes sigma/topic to cn-sigma
+1. Pi pushes sigma/topic to cn-<peer>
 2. cn sync detects it
 3. cn process materializes to state/input.md
 4. Sigma handles ONE item
 
 Sigma → Pi:
 1. Sigma writes state/output.md
-2. cn sync sends to cn-pi
+2. cn sync sends to cn-<peer>
 ```
 
 ## Automation
 
 ```bash
 # cron: every 5 min
-cd cn-sigma && cn sync && cn agent
+cd cn-<peer> && cn sync && cn agent
 ```
 
 cn agent dequeues and processes when there's work.

--- a/src/agent/skills/ops/inbox/SKILL.md
+++ b/src/agent/skills/ops/inbox/SKILL.md
@@ -13,12 +13,12 @@ When invoked, check `state/input.md`:
 ```yaml
 # state/input.md
 ---
-id: pi-review-request
+id: alice-review-request
 type: inbox
-from: pi
+from: alice
 subject: Review request
 date: 2026-02-06
-path: threads/inbox/pi-review-request.md
+path: threads/inbox/alice-review-request.md
 ---
 
 <message content>
@@ -46,14 +46,14 @@ Every decision requires rationale.
 ## Message Flow
 
 ```
-Pi → Sigma:
-1. Pi pushes sigma/topic to cn-<peer>
+Alice → Bob:
+1. Alice pushes bob/topic to cn-<peer>
 2. cn sync detects it
 3. cn process materializes to state/input.md
-4. Sigma handles ONE item
+4. Bob handles ONE item
 
-Sigma → Pi:
-1. Sigma writes state/output.md
+Bob → Alice:
+1. Bob writes state/output.md
 2. cn sync sends to cn-<peer>
 ```
 

--- a/src/agent/skills/ops/peer/SKILL.md
+++ b/src/agent/skills/ops/peer/SKILL.md
@@ -36,7 +36,7 @@ Add another agent as a peer.
 
 Direct:
 ```
-Peer https://github.com/owner/cn-pi
+Peer https://github.com/owner/cn-<peer>
 ```
 
 From Twitter:

--- a/src/agent/skills/ops/peer/kata.md
+++ b/src/agent/skills/ops/peer/kata.md
@@ -21,7 +21,7 @@ Expected: Entry added to `state/peers.md` with `kind: agent`.
 Peer your human's personal hub (if they have one):
 
 ```
-Peer https://github.com/usurobor/cn-usurobor kind=human
+Peer https://github.com/owner/cn-<peer> kind=human
 ```
 
 Expected: Entry with `kind: human`.


### PR DESCRIPTION
## Summary

- **OPERATOR.md**: New repo-root operator manual covering running, observing, maintaining, and troubleshooting. Links to existing guides by operator question.
- **CLI.md**: Added Observability section (`cn logs`), `l` alias, `logs/unified/` directory, `Logs` command type, `cn_ulog.ml`/`cn_logs.ml` in implementation tree.
- **TROUBLESHOOTING.md**: Added unified log to log locations table, `cn logs` usage examples, "Why did the agent do nothing?" scenario.
- **Hub name sanitization**: Stripped `cn-pi`, `cn-sigma`, `cn-usurobor` from 19 files (docs, skills, RCA reports, changelog, whitepaper). Replaced with generic placeholders.

## Test plan

- [ ] Verify no deployment-specific hub names remain: `grep -rn 'cn-pi\|cn-sigma\|cn-usurobor' docs/ packages/ src/agent/ CHANGELOG.md`
- [ ] Verify OPERATOR.md links resolve to existing files
- [ ] CI green

https://claude.ai/code/session_014gJ6oEk7vqxdeTtuRJhQ3S