### PR TITLE
cdd: artifact manifest + execution trace + closeout

### DIFF
--- a/docs/gamma/cdd/CDD.md
+++ b/docs/gamma/cdd/CDD.md
@@ -298,7 +298,64 @@ The canonical artifact order is:
 12. assess
 13. close
 
-### 5.3 Supporting rules
+### 5.3 Artifact manifest
+
+CDD is artifact-driven. For substantial changes, each lifecycle step must leave one inspectable evidence surface.
+
+| Step | Name | Required evidence | Owner |
+|------|------|-------------------|-------|
+| 0 | Observe | CDD Trace row recording inputs read and selected signal | primary branch artifact |
+| 1 | Select | CDD Trace row naming selected gap | primary branch artifact |
+| 2 | Branch | valid branch name | branch + CDD Trace row |
+| 3 | Bootstrap | version directory + manifest README + declared stubs | branch diff |
+| 4 | Gap | named incoherence / coherence contract | primary branch artifact |
+| 5 | Mode | mode + active skills (+ bundle/level if used) | primary branch artifact |
+| 6a | Design | design artifact or explicit "not required" note by change class | primary branch artifact |
+| 6b | Plan | plan artifact when cycle-sized, otherwise explicit "not required" note | primary branch artifact or linked plan |
+| 6c | Tests | test files or explicit reason no tests apply | diff / primary branch artifact |
+| 6d | Code | implementation diff or explicit "docs/process only" note | diff / primary branch artifact |
+| 6e | Docs | changed canonical docs / specs / READMEs as required | diff |
+| 7 | Self-coherence | SELF-COHERENCE.md | version directory |
+| 8 | Review | review artifact / PR review / review comment link | review surface |
+| 9 | Gate | gate result / release-readiness evidence | release surface or review surface |
+| 10 | Release | CHANGELOG row, tag, release note / release artifact | release surface |
+| 11 | Observe | post-release observation result | post-release assessment |
+| 12 | Assess | POST-RELEASE-ASSESSMENT.md | version directory |
+| 13 | Close | immediate outputs executed + deferred outputs committed | post-release assessment |
+
+Rules:
+- "Not required" is valid only when stated explicitly.
+- An omitted step with no explicit note is incomplete, not implicit.
+- Small-change mode may collapse steps 4–7 into commit/PR-body evidence, but the same distinctions still apply.
+
+### 5.4 CDD Trace
+
+Every substantial cycle must carry a lightweight execution trace. For steps 0–10, the trace lives in the primary branch artifact. For steps 11–13, closure lives in the post-release assessment.
+
+The primary branch artifact is the artifact that owns the named incoherence, mode, active skills, and acceptance criteria. In most cycles this is the design artifact. For governance/process work it may be the governing doc being changed. For smaller substantial changes it may be the PR body when no separate design doc is required.
+
+Required format:
+
+```markdown
+## CDD Trace
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|--------------|----------|
+| §2.0 | — | — | Observation inputs read; selected signal |
+| §2.1 | — | — | Selected gap |
+| §2.4 | primary artifact | skill1, skill2 | Work shape, level (if used), mode, active skills |
+| §2.5 | design / plan / tests / docs | — | Artifact progress or explicit "not required" |
+| §2.6 | review surface | review (+ others if loaded) | CLP review result |
+| §2.8 | release surface | release, writing (if used) | Tag / changelog / release decision |
+```
+
+Rules:
+- One row per completed lifecycle step.
+- "Skills loaded" is required when skills shaped generation or lifecycle execution.
+- If a lifecycle skill is used later (review, release, writing, post-release), record it when it becomes active.
+- Missing rows mean the step is not yet evidenced.
+- Contradictory rows are findings.
+
+### 5.5 Supporting rules
 
 - one source of truth per fact
 - derive, do not duplicate
@@ -308,7 +365,7 @@ The canonical artifact order is:
 - enumerate affected files before implementation begins
 - every AC must map to evidence before review
 
-### 5.4 Frozen snapshot rule
+### 5.6 Frozen snapshot rule
 
 After release, version directories are frozen by repository policy. Only path-reference repairs are allowed after freeze:
 

--- a/packages/cnos.core/skills/cdd/design/SKILL.md
+++ b/packages/cnos.core/skills/cdd/design/SKILL.md
@@ -302,11 +302,28 @@ List every file that needs to change, grouped by action.
 
 ## Known Debt
 [What remains after this change]
+
+## CDD Trace
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|--------------|----------|
+| §2.0 | — | — | [observation inputs and selected signal] |
+| §2.1 | — | — | [selected gap] |
+| §2.4 | this artifact | [active skills] | [work shape, level if used, mode] |
+| §2.5 | [artifact name] | — | [design/plan/tests/docs progress] |
 ```
 
 ---
 
-### 3.2. Pre-Submission Checklist
+### 3.2. Keep the CDD Trace in the primary branch artifact
+
+If this design artifact is the primary branch artifact for a substantial cycle, it must carry the CDD Trace.
+
+- ❌ Mode and active skills stated, but no trace of when or why they were chosen
+- ✅ The design artifact records observation, selected gap, mode, active skills, and artifact progress
+
+If another artifact is the primary branch artifact, point to it explicitly.
+
+### 3.3. Pre-Submission Checklist
 
 Before requesting review:
 
@@ -331,3 +348,4 @@ Before requesting review:
 - [ ] Known debt acknowledged
 - [ ] Artifact boundaries respected: gap lives here, order lives in plan, summary lives in issue
 - [ ] Companion artifacts linked (issue, plan, prior art)
+- [ ] CDD Trace present and filled through the current lifecycle step (if substantial)

--- a/packages/cnos.core/skills/cdd/post-release/SKILL.md
+++ b/packages/cnos.core/skills/cdd/post-release/SKILL.md
@@ -55,7 +55,15 @@ The assessment produces one artifact with five sections:
 **How to verify:** [concrete steps]
 **Result:** [pass / fail / deferred]
 
-### 6. Next Move
+### 6. CDD Closeout
+
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|--------------|----------|
+| §2.9 | observation surface | post-release | runtime/design alignment result |
+| §2.10 | POST-RELEASE-ASSESSMENT.md | post-release | assessment completed |
+| §2.11 | immediate fixes / next MCA issue | post-release (+ others if used) | cycle closed / deferred outputs committed |
+
+### 7. Next Move
 **Next MCA:** #NN — title
 **Owner:** ...
 **Branch:** ...
@@ -223,8 +231,9 @@ Before committing the assessment, verify mechanically:
 - [ ] §4 mechanical ratio: if >20%, a process issue is **filed and referenced** (not just noted)
 - [ ] §4a CDD self-coherence: α/β/γ scored, weakest axis named, action stated (or "none" if all ≥3)
 - [ ] §5.7 has production verification scenario (or explicit deferral with commitment)
-- [ ] §5 has all 6 fields: Next MCA, Owner, Branch, **First AC**, MCI frozen?, Rationale
-- [ ] §5 Closure evidence: immediate outputs listed with links, deferred outputs with issue/owner
+- [ ] §6 CDD Closeout trace present with rows for observe/assess/close steps
+- [ ] §7 has all 6 fields: Next MCA, Owner, Branch, **First AC**, MCI frozen?, Rationale
+- [ ] §7 Closure evidence: immediate outputs listed with links, deferred outputs with issue/owner
 - [ ] CHANGELOG TSC row added or updated to match assessment scores
 
 This gate is mechanical. Two agents checking the same template must find the same missing fields.

--- a/packages/cnos.core/skills/cdd/release/SKILL.md
+++ b/packages/cnos.core/skills/cdd/release/SKILL.md
@@ -67,6 +67,7 @@ Failure mode: version drift — tag says X, binary says Y, agent reports Z. Or: 
   - ❌ Ledger row without engineering level (Level column is required)
   - ✅ Each commit's impact named, linked to issues
   - ✅ Honest TSC grades — not everything is A+
+  - If release notes or CHANGELOG wording are being authored, load the writing skill and record it in the CDD Trace.
 
 2.5. **Tag and push**
   - **Tag naming convention:** use bare version numbers without `v` prefix: `3.15.1`, not `v3.15.1`. This matches VERSION file content, branch naming (`claude/3.15.0-22-...`), and snapshot directory names (`docs/gamma/cdd/3.15.0/`). Consistency across all version surfaces.
@@ -97,6 +98,13 @@ Failure mode: version drift — tag says X, binary says Y, agent reports Z. Or: 
   - Check telemetry for errors on first cycle
   - ❌ "It deployed" (no functional validation)
   - ✅ Trace telemetry, confirm receipts/artifacts exist, agent responds correctly
+
+2.9. **CDD Trace update**
+  - Update the primary branch artifact's CDD Trace with the release row:
+    - artifact: tag / CHANGELOG / release artifact
+    - skills loaded: release, plus writing if used
+    - decision: released version X.Y.Z
+  - If the branch has no primary branch artifact, the PR body must carry the trace instead.
 
 ## 3. Rules
 

--- a/packages/cnos.core/skills/cdd/review/SKILL.md
+++ b/packages/cnos.core/skills/cdd/review/SKILL.md
@@ -119,6 +119,15 @@ Review fails via **surface reading** — checking only what changed, missing wha
   - ❌ "Active skills: ocaml" but code has `List.hd` and bare `with _ ->` (OCaml skill §3.1 violations)
   - ✅ "Active skills: ocaml, performance-reliability — implementation consistent with both"
 
+2.0.8. **CDD execution trace (CDD §5.4)**
+  - For substantial changes, verify that the primary branch artifact contains a CDD Trace.
+  - Check that rows exist for all completed steps through the current review point.
+  - Check that step §2.4 records: mode, active skills, work shape, and level if level shorthand is used.
+  - Check that any lifecycle skill already used (review, writing, release) is recorded when relevant.
+  - Missing or contradictory rows are findings.
+  - ❌ "Design exists" but no visible trace of selection, mode, or loaded skills
+  - ✅ "Trace rows cover observe, select, mode, and current artifacts; decisions align with the diff"
+
 ---
 
 ### 2.1. Diff — what changed

--- a/src/agent/skills/cdd/design/SKILL.md
+++ b/src/agent/skills/cdd/design/SKILL.md
@@ -302,11 +302,28 @@ List every file that needs to change, grouped by action.
 
 ## Known Debt
 [What remains after this change]
+
+## CDD Trace
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|--------------|----------|
+| §2.0 | — | — | [observation inputs and selected signal] |
+| §2.1 | — | — | [selected gap] |
+| §2.4 | this artifact | [active skills] | [work shape, level if used, mode] |
+| §2.5 | [artifact name] | — | [design/plan/tests/docs progress] |
 ```
 
 ---
 
-### 3.2. Pre-Submission Checklist
+### 3.2. Keep the CDD Trace in the primary branch artifact
+
+If this design artifact is the primary branch artifact for a substantial cycle, it must carry the CDD Trace.
+
+- ❌ Mode and active skills stated, but no trace of when or why they were chosen
+- ✅ The design artifact records observation, selected gap, mode, active skills, and artifact progress
+
+If another artifact is the primary branch artifact, point to it explicitly.
+
+### 3.3. Pre-Submission Checklist
 
 Before requesting review:
 
@@ -331,3 +348,4 @@ Before requesting review:
 - [ ] Known debt acknowledged
 - [ ] Artifact boundaries respected: gap lives here, order lives in plan, summary lives in issue
 - [ ] Companion artifacts linked (issue, plan, prior art)
+- [ ] CDD Trace present and filled through the current lifecycle step (if substantial)

--- a/src/agent/skills/cdd/post-release/SKILL.md
+++ b/src/agent/skills/cdd/post-release/SKILL.md
@@ -55,7 +55,15 @@ The assessment produces one artifact with five sections:
 **How to verify:** [concrete steps]
 **Result:** [pass / fail / deferred]
 
-### 6. Next Move
+### 6. CDD Closeout
+
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|--------------|----------|
+| §2.9 | observation surface | post-release | runtime/design alignment result |
+| §2.10 | POST-RELEASE-ASSESSMENT.md | post-release | assessment completed |
+| §2.11 | immediate fixes / next MCA issue | post-release (+ others if used) | cycle closed / deferred outputs committed |
+
+### 7. Next Move
 **Next MCA:** #NN — title
 **Owner:** ...
 **Branch:** ...
@@ -223,8 +231,9 @@ Before committing the assessment, verify mechanically:
 - [ ] §4 mechanical ratio: if >20%, a process issue is **filed and referenced** (not just noted)
 - [ ] §4a CDD self-coherence: α/β/γ scored, weakest axis named, action stated (or "none" if all ≥3)
 - [ ] §5.7 has production verification scenario (or explicit deferral with commitment)
-- [ ] §5 has all 6 fields: Next MCA, Owner, Branch, **First AC**, MCI frozen?, Rationale
-- [ ] §5 Closure evidence: immediate outputs listed with links, deferred outputs with issue/owner
+- [ ] §6 CDD Closeout trace present with rows for observe/assess/close steps
+- [ ] §7 has all 6 fields: Next MCA, Owner, Branch, **First AC**, MCI frozen?, Rationale
+- [ ] §7 Closure evidence: immediate outputs listed with links, deferred outputs with issue/owner
 - [ ] CHANGELOG TSC row added or updated to match assessment scores
 
 This gate is mechanical. Two agents checking the same template must find the same missing fields.

--- a/src/agent/skills/cdd/release/SKILL.md
+++ b/src/agent/skills/cdd/release/SKILL.md
@@ -67,6 +67,7 @@ Failure mode: version drift — tag says X, binary says Y, agent reports Z. Or: 
   - ❌ Ledger row without engineering level (Level column is required)
   - ✅ Each commit's impact named, linked to issues
   - ✅ Honest TSC grades — not everything is A+
+  - If release notes or CHANGELOG wording are being authored, load the writing skill and record it in the CDD Trace.
 
 2.5. **Tag and push**
   - **Tag naming convention:** use bare version numbers without `v` prefix: `3.15.1`, not `v3.15.1`. This matches VERSION file content, branch naming (`claude/3.15.0-22-...`), and snapshot directory names (`docs/gamma/cdd/3.15.0/`). Consistency across all version surfaces.
@@ -97,6 +98,13 @@ Failure mode: version drift — tag says X, binary says Y, agent reports Z. Or: 
   - Check telemetry for errors on first cycle
   - ❌ "It deployed" (no functional validation)
   - ✅ Trace telemetry, confirm receipts/artifacts exist, agent responds correctly
+
+2.9. **CDD Trace update**
+  - Update the primary branch artifact's CDD Trace with the release row:
+    - artifact: tag / CHANGELOG / release artifact
+    - skills loaded: release, plus writing if used
+    - decision: released version X.Y.Z
+  - If the branch has no primary branch artifact, the PR body must carry the trace instead.
 
 ## 3. Rules
 

--- a/src/agent/skills/cdd/review/SKILL.md
+++ b/src/agent/skills/cdd/review/SKILL.md
@@ -119,6 +119,15 @@ Review fails via **surface reading** — checking only what changed, missing wha
   - ❌ "Active skills: ocaml" but code has `List.hd` and bare `with _ ->` (OCaml skill §3.1 violations)
   - ✅ "Active skills: ocaml, performance-reliability — implementation consistent with both"
 
+2.0.8. **CDD execution trace (CDD §5.4)**
+  - For substantial changes, verify that the primary branch artifact contains a CDD Trace.
+  - Check that rows exist for all completed steps through the current review point.
+  - Check that step §2.4 records: mode, active skills, work shape, and level if level shorthand is used.
+  - Check that any lifecycle skill already used (review, writing, release) is recorded when relevant.
+  - Missing or contradictory rows are findings.
+  - ❌ "Design exists" but no visible trace of selection, mode, or loaded skills
+  - ✅ "Trace rows cover observe, select, mode, and current artifacts; decisions align with the diff"
+
 ---
 
 ### 2.1. Diff — what changed


### PR DESCRIPTION
## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|--------------|----------|
| §2.0 | — | cdd | Traceability gap identified during #138 cron removal — skills not traced, steps not evidenced |
| §2.4 | this PR | writing, process-economics | Docs/process L6, MCA. Dominant risk: over-heavy process that won't be used |
| §2.5 | 5 patch targets | writing, process-economics | All patches to existing surfaces, no new standalone artifacts |
| §2.6 | PR #this | — | Pending review |

## Gap (§2.3)

**What:** CDD §5.2 names the ordered artifact flow but does not bind step names to concrete evidence surfaces. No artifact manifest. No execution trace. No way to audit which skills were loaded or which steps were completed.

**Why it matters:** This session demonstrated the failure mode — active skills were not loaded (writing, release), lifecycle steps were skipped (review, gate), and no trace existed to make the skips visible until post-hoc analysis.

**What fails if skipped:** Same failure repeats: steps get skipped with no visible evidence, review cannot verify CDD conformance, post-release assessment cannot trace back to cycle decisions.

## Changes

### Patch 1 — `docs/gamma/cdd/CDD.md`
- §5.3 Artifact manifest: table mapping each lifecycle step to required evidence + owner
- §5.4 CDD Trace: lightweight table format for primary branch artifact
- §5.5/§5.6 renumbered

### Patch 2 — `src/agent/skills/cdd/design/SKILL.md`
- CDD Trace added to output template (after Known Debt)
- §3.2 rule: primary branch artifact must carry the trace
- Checklist item: CDD Trace present and filled

### Patch 3 — `src/agent/skills/cdd/review/SKILL.md`
- §2.0.8: review verifies CDD execution trace exists and aligns with diff

### Patch 4 — `src/agent/skills/cdd/release/SKILL.md`
- §2.4: load writing skill for changelog/release notes authoring
- §2.9: CDD Trace update row after release

### Patch 5 — `src/agent/skills/cdd/post-release/SKILL.md`
- §6 CDD Closeout: trace table for steps 11–13 (observe/assess/close)
- Pre-publish gate updated to reference §6 and §7

## Process economics

**Failure class:** skipped CDD steps with no audit trail.
**Consumer:** reviewer (§2.0.8), releaser (trace update), post-release assessor (closeout).
**Cost:** one table per substantial branch (lightweight, rows added incrementally).
**Lighter alternatives considered:** commit messages alone (rejected — not structured, not reviewable as a unit). No new files — all patches go into existing surfaces.
**Sunset:** if CDD tooling (`cn cdd`) automates trace generation, the manual table becomes a verification target instead of an authoring burden.