### PR TITLE
normalize lifecycle step numbers in trace surfaces

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 | 9 Gate | — | — | Pending |
 | 10 Release | — | — | Pending |
 
-## Gap (§2.3)
+## Gap (step 4)
 
 **What:** <!-- named incoherence -->
 
@@ -19,7 +19,7 @@
 
 **What fails if skipped:** <!-- concrete failure -->
 
-## Mode + Active Skills (§2.4)
+## Mode + Active Skills (step 5)
 
 - **Mode:** MCA / MCI
 - **Work shape:** <!-- bugfix / feature / runtime / architecture / docs -->

--- a/packages/cnos.core/skills/cdd/review/SKILL.md
+++ b/packages/cnos.core/skills/cdd/review/SKILL.md
@@ -122,7 +122,7 @@ Review fails via **surface reading** — checking only what changed, missing wha
 2.0.8. **CDD execution trace (CDD §5.4)**
   - For substantial changes, verify that the primary branch artifact contains a CDD Trace.
   - Check that rows exist for all completed steps through the current review point.
-  - Check that step §2.4 records: mode, active skills, work shape, and level if level shorthand is used.
+  - Check that step 5 records: mode, active skills, work shape, and level if level shorthand is used.
   - Check that any lifecycle skill already used (review, writing, release) is recorded when relevant.
   - Missing or contradictory rows are findings.
   - ❌ "Design exists" but no visible trace of selection, mode, or loaded skills

--- a/src/agent/skills/cdd/review/SKILL.md
+++ b/src/agent/skills/cdd/review/SKILL.md
@@ -122,7 +122,7 @@ Review fails via **surface reading** — checking only what changed, missing wha
 2.0.8. **CDD execution trace (CDD §5.4)**
   - For substantial changes, verify that the primary branch artifact contains a CDD Trace.
   - Check that rows exist for all completed steps through the current review point.
-  - Check that step §2.4 records: mode, active skills, work shape, and level if level shorthand is used.
+  - Check that step 5 records: mode, active skills, work shape, and level if level shorthand is used.
   - Check that any lifecycle skill already used (review, writing, release) is recorded when relevant.
   - Missing or contradictory rows are findings.
   - ❌ "Design exists" but no visible trace of selection, mode, or loaded skills


### PR DESCRIPTION
## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | — | Review of trace surfaces after §5.3/§5.4 shipped |
| 1 Select | — | — | Step numbering collision between canonical spec and artifacts |
| 4 Gap | this PR | — | PR template and review skill still use §2.x as lifecycle step IDs, while §5.4 canonical trace uses 0–13 lifecycle numbers. Two numbering systems for the same concept. |
| 5 Mode | this PR | cdd | MCA, small change, L5 |
| 6 Artifacts | PR template, review/SKILL.md | — | 3 line changes across 2 files |
| 8 Review | PR #this | review | Pending |

## Gap (step 4)

**What:** PR template headings use `§2.3` / `§2.4` and review skill §2.0.8 uses `step §2.4` to refer to lifecycle steps, while the canonical trace format (§5.4) uses lifecycle numbers 0–13.

**Why it matters:** Two numbering systems for the same concept creates ambiguity about which step is being referenced.

**What fails if skipped:** Agents and reviewers reading trace artifacts see inconsistent step identifiers across the spec, PR template, and skill files.

## Mode + Active Skills (step 5)

- **Mode:** MCA
- **Work shape:** process normalization
- **Level:** L5
- **Active skills:** cdd
- **Dominant risk:** incomplete normalization (missing a surface)

## Changes

### Changed
- `.github/PULL_REQUEST_TEMPLATE.md`: `## Gap (§2.3)` → `## Gap (step 4)`, `## Mode + Active Skills (§2.4)` → `## Mode + Active Skills (step 5)`
- `src/agent/skills/cdd/review/SKILL.md` §2.0.8: `step §2.4` → `step 5`

### Not in scope
- Review skill internal section numbers (§2.0, §2.2.x) — these are review-skill sections, not lifecycle steps
- Post-release examples that reference review §2.0 — same: review-skill section, not lifecycle step
- §5.4, design/SKILL.md, post-release §6 — already normalized

## Acceptance Criteria

- [x] No §2.x used as lifecycle step identifier in any trace-carrying artifact
- [x] Review-skill internal §2.x section numbers preserved (not lifecycle refs)
- [ ] CI green

## Known Debt

None.