### PR TITLE
fix: redesign install.sh to match tsc v0.3.0 installer pattern (#158)

### DIFF
--- a/docs/gamma/cdd/3.33.0/README.md
+++ b/docs/gamma/cdd/3.33.0/README.md
@@ -49,3 +49,17 @@ atomic install -> verify.
 2. Verify all 8 ACs are met by code inspection
 3. Write SELF-COHERENCE.md
 4. Commit, push, create PR
+
+### CDD Trace
+
+| Step | Artifact | Decision |
+|------|----------|----------|
+| 0 Observe | CHANGELOG TSC, lag table, issue #158 | Gap: installer is bootstrap hack, not product surface |
+| 1 Select | #158 | MCA: targeted rewrite of install.sh |
+| 2 Design | README.md (this file) | Port tsc v0.3.0 pattern, preserve cnos 4-platform matrix |
+| 3 Contract | ACs 1-8 from issue | All 8 map to specific code sections |
+| 4 Plan | Plan section above | Single-file rewrite, no dependencies |
+| 5 Code | install.sh | Rewritten: 155 lines replacing 80 |
+| 6 Self-coherence | SELF-COHERENCE.md | Alpha A, Beta A, Gamma -- |
+| 7 Review | PR #159 | Pending |
+| 8 Gate | CI green | Pending |

--- a/docs/gamma/cdd/3.33.0/SELF-COHERENCE.md
+++ b/docs/gamma/cdd/3.33.0/SELF-COHERENCE.md
@@ -59,7 +59,9 @@ Shell script -- no type system. Structural clarity assessed instead:
 
 2. **Does the cnos installer match the tsc pattern structurally?** Yes. Same section order, same function signatures, same error format. Only differences are binary name, repo, platform matrix, and build-from-source instructions.
 
-3. **Are there any silent failure paths?** No. Every error calls `fail()` which exits with code 1. The `|| true` after release fetch is deliberate -- the empty-check on $LATEST catches the failure and calls fail(). The `2>/dev/null` on mv is deliberate -- the mv failure is caught and reported with actionable fix.
+3. **Is the atomicity claim true?** Yes. The temp file is created inside `${BIN_DIR}` via `mktemp "${BIN_DIR}/.cn.XXXXXX"`, guaranteeing same-filesystem `mv` which is atomic on POSIX. Writability of `${BIN_DIR}` is probed at mktemp time -- failure produces an actionable error before any download begins.
+
+4. **Are there any silent failure paths?** No. Every error calls `fail()` which exits with code 1. The `|| true` after release fetch is deliberate -- the empty-check on $LATEST catches the failure and calls fail(). The `2>/dev/null` on mv is deliberate -- the mv failure is caught and reported with actionable fix.
 
 ### Exit Criteria
 

--- a/install.sh
+++ b/install.sh
@@ -109,11 +109,30 @@ fi
 
 ok "Latest release: ${LATEST}"
 
-# --- Download to temp file ---
+# --- Probe BIN_DIR writability (early fail with actionable error) ---
+if [ ! -d "$BIN_DIR" ]; then
+  mkdir -p "$BIN_DIR" 2>/dev/null || \
+    fail "Cannot continue — ${BIN_DIR} does not exist and cannot be created" \
+      "" \
+      "Fix by running with elevated permissions:" \
+      "  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sudo sh" \
+      "" \
+      "Or override the install directory:" \
+      "  BIN_DIR=\$HOME/.local/bin curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
+fi
+
+# --- Download to temp file (same filesystem as BIN_DIR for atomic mv) ---
 ARTIFACT="${BINARY_NAME}-${TARGET}"
 URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARTIFACT}"
 
-TMPFILE="$(mktemp)" || fail "Cannot continue — mktemp failed"
+TMPFILE="$(mktemp "${BIN_DIR}/.cn.XXXXXX" 2>/dev/null)" || \
+  fail "Cannot continue — cannot create temp file in ${BIN_DIR}" \
+    "" \
+    "Fix by running with elevated permissions:" \
+    "  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sudo sh" \
+    "" \
+    "Or override the install directory:" \
+    "  BIN_DIR=\$HOME/.local/bin curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
 
 if ! curl -fsSL -o "$TMPFILE" "$URL"; then
   fail "Cannot download binary — HTTP request failed" \
@@ -146,7 +165,7 @@ if [ "$FILE_SIZE" -lt "$MIN_SIZE" ]; then
     "  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
 fi
 
-SIZE_MB=$(echo "scale=1; $FILE_SIZE / 1048576" | bc 2>/dev/null || echo "?")
+SIZE_MB=$((FILE_SIZE / 1048576))
 ok "Downloaded ${ARTIFACT} (${SIZE_MB} MB)"
 
 # --- Atomic install ---


### PR DESCRIPTION
## Summary

- **Atomic install:** Download to temp file (mktemp), then `mv` to final path. Interrupted download never touches installed binary (AC1).
- **Download validation:** Reject files < 1 MB with actionable error explaining likely cause (HTML error page, truncated download) (AC2).
- **Actionable errors:** Every `fail()` call follows cause -> fix -> rerun pattern. 7 fail sites, all consistent (AC3).
- **Cleanup trap:** `trap cleanup EXIT INT TERM` removes temp file on any exit path (AC4).
- **NO_COLOR / TTY:** Colors gated by `NO_COLOR` env var and `[ ! -t 1 ]` per https://no-color.org/ (AC5).
- **Platform rejection:** Unknown OS or ARCH fails explicitly with build-from-source instructions (AC6).
- **Symbol language:** `ok()` / `warn()` / `fail()` use consistent checkmark/warning/x symbols (AC7).
- **Verification:** `cn --version` runs after install (AC8, preserved from original).

Direct port of tsc v0.3.0 installer pattern, preserving cnos 4-platform matrix (linux-x64, linux-arm64, macos-x64, macos-arm64) and BIN_DIR override.

CDD artifacts in `docs/gamma/cdd/3.33.0/`.

Closes #158

## Test plan

- [ ] Read install.sh and verify each AC maps to specific code
- [ ] Verify `fail()` is the only exit path for errors (no bare `exit 1` except inside fail)
- [ ] Verify TMPFILE lifecycle: empty -> mktemp -> download -> mv (cleared) or cleanup (deleted)
- [ ] Verify NO_COLOR gating: `NO_COLOR=1 sh install.sh` should produce no ANSI codes
- [ ] Verify platform detection covers all 4 targets + explicit rejection for others

https://claude.ai/code/session_01D1QEUCw1CjD1uRfyMHGaRX