### PR TITLE
fix(review): add pre-gate — verify branch is unmerged before reviewing

### DIFF
--- a/packages/cnos.core/skills/cdd/review/SKILL.md
+++ b/packages/cnos.core/skills/cdd/review/SKILL.md
@@ -49,6 +49,10 @@ Review fails via **surface reading** — checking only what changed, missing wha
 
 ### 2.0. Issue — what was promised
 
+**PRE-GATE: Verify branch is unmerged.** Before any review work, confirm the branch has not already landed on main. Check PR state (`gh pr view <number> --json state,mergedAt`) or, for offline reviews, `git log main --oneline | grep -w <issue-number>`. If already merged: the branch is stale — either review the merged code on main, or skip. Do not review a dead branch. (If this check is added to the review subagent's preflight, this PRE-GATE becomes informational.)
+  - ❌ Read the diff, post findings, then discover the branch was merged two weeks ago
+  - ✅ "`gh pr view 145 --json state` → `MERGED` — branch is stale, redirecting review to main"
+
 **GATE: Complete §2.0 before reading the diff.** The review is structurally incomplete if these tables are absent.
 
 ```markdown

--- a/packages/cnos.eng/skills/eng/ocaml/SKILL.md
+++ b/packages/cnos.eng/skills/eng/ocaml/SKILL.md
@@ -14,22 +14,25 @@ Write native OCaml for cnos. Compiled to native binaries via dune.
 
 - Types — the primary safety mechanism. Design them so the compiler resolves ambiguity without help.
 - Modules — organize by purity boundary (pure lib vs I/O cmd vs FFI).
+- Fallbacks — every fallback/compatibility path is a policy decision, not a convenience.
 - Tests — ppx_expect inline tests. Expect-test output is the specification.
 - Build — dune. Native binary. No bytecode in production.
 
 ### 1.2 Articulate how they fit
 
-Types define the domain. Modules enforce the purity boundary: `cn_lib` is pure, `cn_ffi` does I/O, `cn_cmd` wires them. Tests verify behavior through expect-test snapshots. The build compiles everything to a single native binary.
+Types define the domain. Modules enforce the purity boundary: `cn_lib` is pure, `cn_ffi` does I/O, `cn_cmd` wires them. Fallbacks express what the system does when reality is missing, stale, or malformed. They must be explicit, bounded, and visible — not silent. Tests verify behavior through expect-test snapshots. The build compiles everything to a single native binary.
 
   - ❌ Put I/O in a pure parsing module
   - ✅ Parse returns `(value, string) result`; caller does I/O
 
 ### 1.3 Name the failure mode
 
-OCaml code fails through **type ambiguity** and **purity leaks**:
+OCaml code fails through **type ambiguity**, **purity leaks**, and **silent fallback**:
 - Two record types sharing field names cause cascading disambiguation errors across every use site
 - Exceptions used for control flow instead of Result types
 - Mutable state leaking outside a localized scope
+- Compatibility paths that silently swallow failure and fabricate an "empty" state
+- Readers/scans that turn missing or unreadable into `[]` / `None` without logging or classification
 
   - ❌ `type a = { kind: string; ... }` and `type b = { kind: string; ... }` in the same module → annotate every access
   - ✅ `type a = { op_kind: string; ... }` and `type b = { backend_kind: string; ... }` → no annotations needed
@@ -151,19 +154,81 @@ let code, output =
 Cn_trace.gemit ~status:(if bad then Degraded else Ok_)  (* ok *)
 ```
 
-### 2.6 Anti-patterns
+### 2.6 Fallback and compatibility discipline
+
+Every fallback path is a policy choice. Silent fallback is a bug unless explicitly justified.
+
+#### 2.6.1 Remove
+
+Default disposition. If the path exists only for backward compatibility and the migration grace period has passed, delete it.
+
+  - ❌ "Keep for safety"
+  - ✅ "Package namespace is the only layout since v3.25. Flat loaders deleted."
+
+#### 2.6.2 Convert
+
+If "empty/skip" is the safe semantic outcome but the original `with _ ->` swallows all exceptions silently, convert to log + fallback:
+
+```ocaml
+(* ✅ tolerated but explicit *)
+let collect_files_sorted dir =
+  try Sys.readdir dir |> Array.to_list |> List.sort String.compare
+  with Sys_error e ->
+    log_warn (Printf.sprintf "collect_files_sorted %s: %s" dir e);
+    []
+```
+
+Use this form only when "skip/empty" is a deliberately safe outcome.
+
+#### 2.6.3 Keep
+
+Keep a compatibility path only if all are true:
+
+- it protects a real still-live transition or bootstrapping condition
+- it is fail-closed or explicitly logged
+- it has a reason in code comments or design docs
+- it has an expiry or follow-up issue where appropriate
+
+  - ❌ "Keep for safety"
+  - ✅ "Keep until all peers use packet refs; reject loudly on ambiguity"
+
+#### 2.6.4 Resource discovery rule
+
+Any function that resolves binaries, config files, package contents, transport roots, or thread/event stores must either:
+
+- validate existence and return `Result`
+- or log a tolerated absence explicitly
+
+Never construct a path and defer discovery of absence to a later opaque exec/IO failure.
+
+#### 2.6.5 Audit rule
+
+When you touch one fallback path class, audit the sibling surfaces in the same module/family.
+
+Examples:
+- if you convert one `with _ -> []`, grep for the others
+- if you remove one compatibility helper, audit the other helpers in that layer
+- if one reader now validates existence, check the parallel readers/scanners too
+
+This is the same logic as type-disambiguation-at-definition: fix the class, not one symptom.
+
+### 2.7 Anti-patterns
 
 ```ocaml
 (* ❌ avoid *)
 let x = ref 0                  (* mutable state outside local scope *)
 for i = 0 to n do ... done     (* imperative loop *)
 with _ -> None                  (* swallow all exceptions *)
+with _ -> []                    (* fabricate empty state *)
+with _ -> ""                    (* fabricate content *)
 List.hd xs                      (* partial — use match *)
 Option.get opt                  (* partial — use match *)
 raise Parse_error               (* use Result.error *)
+(* compatibility shim with no reason / expiry *)
+let resolve_legacy = current_path
 ```
 
-### 2.7 FFI (native system bindings)
+### 2.8 FFI (native system bindings)
 
 ```ocaml
 (* cn_ffi.ml — I/O lives here, nowhere else *)
@@ -176,7 +241,7 @@ module Fs = struct
 end
 ```
 
-### 2.8 Build
+### 2.9 Build
 
 ```bash
 eval $(opam env)
@@ -200,24 +265,64 @@ When overlapping names are unavoidable, annotate **all** access sites in one pas
 
 `lib/` and `protocol/` modules must be pure — no I/O, no Unix, no Sys. I/O lives in `ffi/`. Business logic in `cmd/` wires pure and impure.
 
-### 3.3 Error handling rule
+### 3.3 Error and fallback rule
 
 Use `Result` types for expected failures. Reserve exceptions for truly unexpected conditions. Never `with _ ->`.
+
+Silent fallback is forbidden unless "empty/skip" is explicitly the safe semantic outcome. If a fallback is tolerated, it must be:
+- intentional
+- logged or made visible
+- and justified as keep rather than accidental residue
 
 Functions that resolve or construct paths to external resources (binaries, config files, package contents) should validate existence or return `Result` — don't construct a path and return it bare, deferring discovery of missing resources to the caller's opaque exec/IO failure.
 
   - ❌ `let resolve name = Path.join dir name` (caller gets `ENOENT` from exec)
   - ✅ `let resolve name = let p = Path.join dir name in if exists p then Ok p else Error (sprintf "not found: %s" p)`
 
-### 3.4 Test rule
+### 3.4 Compatibility-path rule
+
+Every compatibility path must be explicitly classified:
+- **remove** — delete it
+- **convert** — log + fallback
+- **keep** — justify, make fail-closed or operator-visible, record expiry/follow-up
+
+Do not leave ambiguous legacy behavior in place.
+
+### 3.5 Test rule
 
 Every module gets ppx_expect inline tests. The expect-test output is the behavioral contract. If the output changes, the test fails — review the diff.
 
-### 3.5 Build-before-push rule
+Every module gets ppx_expect inline tests. The expect-test output is the behavioral contract. If the output changes, the test fails — review the diff.
+
+For fallback conversions, test both:
+- the positive path
+- the degraded / missing / malformed path
+
+  - ❌ only test success
+  - ✅ test success and the explicit failure/fallback behavior
+
+### 3.6 Build-before-push rule
 
 Run `dune build` locally before pushing. If the toolchain is not available, treat type disambiguation as a project-wide audit: grep for all access sites of overlapping field names and annotate them in one pass.
 
-### 3.6 Toolchain
+If you changed fallback/compatibility behavior, perform the same class-wide audit:
+- grep for sibling `with _ ->`
+- grep for silent `[]` / `None` fabrication
+- grep for parallel resolver/scanner paths
+
+### 3.7 Mechanical fallback smell list
+
+Treat these as review smells that require justification or conversion:
+
+- `with _ -> []`
+- `with _ -> None`
+- `with _ -> ""`
+- swallowing `Sys_error`
+- swallowing directory-read failures
+- compatibility aliases with no comment or expiry
+- returning constructed external paths without checking existence
+
+### 3.8 Toolchain
 
 ```bash
 opam switch create cnos 4.14.1

--- a/src/agent/skills/cdd/review/SKILL.md
+++ b/src/agent/skills/cdd/review/SKILL.md
@@ -49,9 +49,9 @@ Review fails via **surface reading** — checking only what changed, missing wha
 
 ### 2.0. Issue — what was promised
 
-**PRE-GATE: Verify branch is unmerged.** Before any review work, confirm the branch has not already landed on main. Run `git log main --oneline | grep <issue-number>` (or check PR state). If already merged: the branch is stale — either review the merged code on main, or skip. Do not review a dead branch.
+**PRE-GATE: Verify branch is unmerged.** Before any review work, confirm the branch has not already landed on main. Check PR state (`gh pr view <number> --json state,mergedAt`) or, for offline reviews, `git log main --oneline | grep -w <issue-number>`. If already merged: the branch is stale — either review the merged code on main, or skip. Do not review a dead branch. (If this check is added to the review subagent's preflight, this PRE-GATE becomes informational.)
   - ❌ Read the diff, post findings, then discover the branch was merged two weeks ago
-  - ✅ "`git log main --oneline | grep 146` → `412414e fix: remove hardcoded paths` — already shipped, redirecting review to main"
+  - ✅ "`gh pr view 145 --json state` → `MERGED` — branch is stale, redirecting review to main"
 
 **GATE: Complete §2.0 before reading the diff.** The review is structurally incomplete if these tables are absent.
 


### PR DESCRIPTION
## Root cause

Reviewed stale branch `claude/execute-issue-146` that was already merged to main (commit `412414e`, released in 3.29.0). Full CDD review posted on a dead branch. Findings were valid but mis-targeted.

No review-skill step checked branch liveness before starting work.

## Change

Added **PRE-GATE** to review skill §2.0: verify branch is unmerged before any review work. Mechanical check (`git log main | grep <issue>`).

## Evidence

- Adhoc thread: `cn-sigma/threads/adhoc/20260406-review-stale-branch-146.md`
- Per review skill §2.3.7: divergence is a skill gap, not a reviewer gap — patch the skill

## Change class

Process/governance — single-step addition to existing gate.