### PR TITLE
fix(#146): address review findings on hardcoded-paths removal

### DIFF
--- a/src/cmd/cn_agent.ml
+++ b/src/cmd/cn_agent.ml
@@ -447,11 +447,13 @@ let resolve_bin_path () =
     match proc_self with
     | Some p when String.length p > 0 -> p
     | _ ->
-      (* macOS / fallback: resolve symlinks on Sys.executable_name *)
-      match Cn_ffi.Child_process.exec
-              (Printf.sprintf "readlink -f '%s' 2>/dev/null" Sys.executable_name) with
-      | Some p when String.length (String.trim p) > 0 -> String.trim p
-      | _ -> Sys.executable_name
+      (* macOS / fallback: resolve symlinks on Sys.executable_name via Unix.realpath
+         (OCaml 4.13+, cross-platform; avoids GNU-only `readlink -f` which does not
+         exist on stock macOS). *)
+      (try
+         let p = Unix.realpath Sys.executable_name in
+         if String.length p > 0 then p else Sys.executable_name
+       with Unix.Unix_error _ -> Sys.executable_name)
 
 let resolve_repo () =
   match Sys.getenv_opt "CN_REPO" with

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -18,4 +18,8 @@
 (rule
  (target cn_repo_info.ml)
  (deps ../../cn.json)
- (action (bash "repo=$(sed -n 's|.*github.com/\\([^\"]*\\)\".*|\\1|p' ../../cn.json | head -1 | sed 's/\\.git$//'); if [ -z \"$repo\" ]; then echo 'Error: no GitHub repo URL found in cn.json' >&2; exit 1; fi; echo \"let repo = \\\"${repo}\\\"\" > %{target}")))
+ ; Extract the first URL inside the `repo_urls` array specifically (rather than
+ ; grepping any github.com URL in the file, which would also match maintainer
+ ; hub URLs like usurobor/cn-sigma). awk scopes the match to lines between
+ ; `"repo_urls"` and the closing `]`.
+ (action (bash "repo=$(awk '/\"repo_urls\"/{flag=1;next} /\\]/{flag=0} flag' ../../cn.json | sed -n 's|.*github.com/\\([^\"]*\\)\".*|\\1|p' | head -1 | sed 's/\\.git$//'); if [ -z \"$repo\" ]; then echo 'Error: no GitHub repo URL found in cn.json repo_urls' >&2; exit 1; fi; echo \"let repo = \\\"${repo}\\\"\" > %{target}")))

--- a/test/cmd/cn_selfpath_test.ml
+++ b/test/cmd/cn_selfpath_test.ml
@@ -6,16 +6,22 @@
     3. No hardcoded literals remain in resolved values *)
 
 (* Helper: save, set, run, restore an env var.
-   OCaml stdlib has no unsetenv — empty string is treated as unset
-   by our resolution functions (String.length > 0 guard). *)
+   OCaml stdlib has no portable unsetenv. When the var was originally unset,
+   we restore it to the empty string — every consumer of these vars in this
+   project guards on `String.length > 0`, so empty == unset. If a future
+   consumer switches to `Sys.getenv_opt` directly (which returns `Some ""`
+   here), update both the consumer and this helper together. *)
 let with_env var value f =
   let saved = Sys.getenv_opt var in
   Unix.putenv var value;
-  let result = f () in
-  (match saved with
-   | Some v -> Unix.putenv var v
-   | None -> Unix.putenv var "");
-  result
+  let restore () =
+    match saved with
+    | Some v -> Unix.putenv var v
+    | None -> Unix.putenv var ""
+  in
+  match f () with
+  | result -> restore (); result
+  | exception e -> restore (); raise e
 
 (* ============================================================
    Invariant 1: resolve_bin_path respects $CN_BIN override


### PR DESCRIPTION
## Summary
Addresses the round-1 review on #146 (comment 4193856742).

- **F1 (D — `readlink -f` not on macOS)**: replace the GNU-only `readlink -f` shell call with `Unix.realpath` (OCaml 4.13+, cross-platform). Previously the silent `2>/dev/null` failure fell through to `Sys.executable_name`, which on macOS can be a relative path or unresolved symlink — self-update would write to the wrong location. (`src/cmd/cn_agent.ml`)
- **F3 (C — fragile sed)**: scope `cn_repo_info` dune extraction to the `repo_urls` array via awk, instead of grepping any `github.com` URL in `cn.json`. The previous regex also matched maintainer hub URLs like `usurobor/cn-sigma` and only worked because `head -1` happened to grab the right one. (`src/lib/dune`)
- **F2 (C — `with_env` restore)**: document the empty-string-as-unset contract explicitly and make restore exception-safe so a failing test can't leak env state into siblings. (`test/cmd/cn_selfpath_test.ml`)

## Test plan
- [ ] `dune build`
- [ ] `dune runtest` — `cn_selfpath_test` passes
- [ ] manual: `CN_BIN` override still wins; `resolve_bin_path` returns the real absolute path on macOS (no `readlink -f`)
- [ ] manual: `cn_repo_info.ml` still contains `usurobor/cnos` after build