### PR TITLE
fix(review): PR #176 retro findings F1–F4 (+ F5 stale audit)

### DIFF
--- a/src/cmd/cn_activation.ml
+++ b/src/cmd/cn_activation.ml
@@ -45,7 +45,7 @@ let extract_block lines =
         | l :: tl -> take (l :: acc) tl
       in
       take [] rest
-  | _ -> None
+  | _ -> None  (* no leading "---": file has no frontmatter — not an error *)
 
 (** Split a "key: value" line. Returns [None] if there is no colon at
     the head of an unindented line. *)
@@ -109,7 +109,12 @@ let parse_frontmatter content =
                      Printf.eprintf
                        "cn: activation: inline triggers list not supported, \
                         use block list: %s\n" value
-                 | _ -> ())
+                 | _ ->
+                     (* Unrecognised frontmatter key (artifact_class,
+                        kata_surface, governing_question, ...) —
+                        intentionally ignored; this parser only
+                        consumes name / description / triggers. *)
+                     ())
               end
         end
       ) block;
@@ -137,16 +142,26 @@ type activation_entry = {
 }
 
 (** Read the [sources.skills] string array from a parsed manifest. *)
-let manifest_skill_ids json =
+let manifest_skill_ids ~pkg_name json =
   match Cn_json.get "sources" json with
   | None -> []
   | Some sources ->
       match Cn_json.get "skills" sources with
+      | None -> []
       | Some (Cn_json.Array items) ->
           items |> List.filter_map (function
             | Cn_json.String s -> Some s
-            | _ -> None)
-      | _ -> []
+            | other ->
+                Printf.eprintf
+                  "cn: activation: package %s: sources.skills entry is not a \
+                   string (%s), skipping\n"
+                  pkg_name (Cn_json.to_string other);
+                None)
+      | Some _ ->
+          Printf.eprintf
+            "cn: activation: package %s: sources.skills is not an array, ignoring\n"
+            pkg_name;
+          []
 
 (** Walk every installed package and emit one [activation_entry] per
     declared skill that has a SKILL.md on disk. Skills declared in the
@@ -159,9 +174,13 @@ let build_index ~hub_path =
     if not (Cn_ffi.Fs.exists manifest_path) then []
     else
       match Cn_json.parse (Cn_ffi.Fs.read manifest_path) with
-      | Error _ -> []
+      | Error msg ->
+          Printf.eprintf
+            "cn: activation: package %s: cannot parse %s: %s\n"
+            pkg_name manifest_path msg;
+          []
       | Ok json ->
-          manifest_skill_ids json
+          manifest_skill_ids ~pkg_name json
           |> List.filter_map (fun skill_id ->
             let skill_md = Cn_ffi.Path.join pkg_dir
               (Printf.sprintf "skills/%s/SKILL.md" skill_id) in
@@ -207,9 +226,15 @@ let validate ~hub_path =
     let manifest_path = Cn_ffi.Path.join pkg_dir "cn.package.json" in
     if Cn_ffi.Fs.exists manifest_path then
       match Cn_json.parse (Cn_ffi.Fs.read manifest_path) with
-      | Error _ -> ()
+      | Error msg ->
+          (* cn_deps doctor is the canonical surface for malformed
+             manifests; here we only log for activation-debug context
+             so the validate pass doesn't double-report. *)
+          Printf.eprintf
+            "cn: activation: package %s: cannot parse %s: %s\n"
+            pkg_name manifest_path msg
       | Ok json ->
-          manifest_skill_ids json |> List.iter (fun skill_id ->
+          manifest_skill_ids ~pkg_name json |> List.iter (fun skill_id ->
             let skill_md = Cn_ffi.Path.join pkg_dir
               (Printf.sprintf "skills/%s/SKILL.md" skill_id) in
             if not (Cn_ffi.Fs.exists skill_md) then

--- a/src/cmd/cn_runtime_contract.ml
+++ b/src/cmd/cn_runtime_contract.ml
@@ -220,8 +220,22 @@ let build_orchestrator_registry ~hub_path =
                                | Some (Cn_json.Array xs) ->
                                    xs |> List.filter_map (function
                                      | Cn_json.String s -> Some s
-                                     | _ -> None)
-                               | _ -> []
+                                     | other ->
+                                         Printf.eprintf
+                                           "cn: runtime_contract: package %s: \
+                                            orchestrator %s: trigger_kinds entry \
+                                            is not a string (%s), skipping\n"
+                                           pkg_name name
+                                           (Cn_json.to_string other);
+                                         None)
+                               | None -> []
+                               | Some _ ->
+                                   Printf.eprintf
+                                     "cn: runtime_contract: package %s: \
+                                      orchestrator %s: trigger_kinds is not an \
+                                      array, ignoring\n"
+                                     pkg_name name;
+                                   []
                              in
                              Some {
                                orch_name = name;

--- a/test/cmd/cn_runtime_contract_test.ml
+++ b/test/cmd/cn_runtime_contract_test.ml
@@ -591,3 +591,41 @@ let%expect_test "to_json: orchestrators empty when sources.orchestrators absent 
        | _ -> print_endline "orchestrators not array")
     | None -> print_endline "no body");
   [%expect {| count=0 |}]
+
+let%expect_test "to_json: trigger_kinds non-string elements logged and skipped (R2)" =
+  with_test_hub (fun hub ->
+    let v = Cn_lib.version in
+    let core_dir = Filename.concat hub
+      (Printf.sprintf ".cn/vendor/packages/cnos.core@%s" v) in
+    (* Valid orchestrator entry, but trigger_kinds carries one number
+       between two strings. Builder must keep the strings, log-skip
+       the number, and not crash. *)
+    let manifest = Printf.sprintf
+      "{\"schema\":\"cn.package.v1\",\"name\":\"cnos.core\",\"version\":\"%s\",\
+       \"sources\":{\"orchestrators\":[\
+       {\"name\":\"mixed\",\"trigger_kinds\":[\"command\",42,\"schedule\"]}\
+       ]}}" v in
+    let oc = open_out (Filename.concat core_dir "cn.package.json") in
+    output_string oc manifest;
+    close_out oc;
+    let assets = Cn_assets.summarize ~hub_path:hub in
+    let c = Cn_runtime_contract.gather ~hub_path:hub
+              ~shell_config:default_shell_config ~assets ~peers:[] () in
+    let json = Cn_runtime_contract.to_json ~shell_config:default_shell_config c in
+    match Cn_json.get "body" json with
+    | None -> print_endline "no body"
+    | Some body ->
+      match Cn_json.get "orchestrators" body with
+      | Some (Cn_json.Array items) ->
+        items |> List.iter (fun entry ->
+          let tks = match Cn_json.get "trigger_kinds" entry with
+            | Some (Cn_json.Array xs) ->
+              xs |> List.filter_map (function
+                | Cn_json.String s -> Some s | _ -> None)
+            | _ -> []
+          in
+          Printf.printf "trigger_kinds=[%s]\n" (String.concat "," tks))
+      | _ -> print_endline "orchestrators not array");
+  [%expect {|
+    trigger_kinds=[command,schedule]
+    cn: runtime_contract: package cnos.core: orchestrator mixed: trigger_kinds entry is not a string (42), skipping |}]


### PR DESCRIPTION
Addresses retro-review findings on PR #176 (post-merge). Five findings raised (F1–F5); this PR closes F1–F4 and explains F5 as stale.

## Finding disposition

| # | Severity | Type | Disposition |
|---|---|---|---|
| F1 | C | judgment | **fixed** — `build_orchestrator_registry` logs stderr on manifest parse error with package + path + parse message |
| F2 | B | judgment | **fixed** — orchestrator entries missing `name` now log-skip with package context; also logged two sibling silent paths the audit surfaced (non-object entries, non-array field) |
| F3 | B | judgment | **fixed** — markdown render now mirrors the JSON two-level nesting (`activation_index:` header, `  skills:` sub-key, `    <id> [pkg] triggers: …` leaves); a future addition of sibling fields (`events`, `tokens`, `paths`) extends both renderers mechanically |
| F4 | C | mechanical | **fixed** — two new dedicated tests for `build_orchestrator_registry`: happy-path with mixed valid+malformed entries, and empty-when-absent |
| F5 | B | mechanical | **stale** — reviewer referenced `list_skill_overrides` L152 as still having `with _ -> []`; verified in the current tree and it no longer does (the original #173 sweep cleaned the three bare catches that were in `cn_runtime_contract.ml`). Zero bare catches in any touched module |

## F5 audit evidence

```
$ grep -n "with _ " src/cmd/cn_runtime_contract.ml src/cmd/cn_activation.ml src/cmd/cn_doctor.ml src/cmd/cn_command.ml
(no output)
```

Broader `src/cmd/` still has bare catches in `cn_maintenance`, `cn_logs`, `cn_indicator`, `cn_trace`, `cn_executor`, `cn_context` — those are pre-existing and **out of scope for a #173 retro**. §2.2.1b sibling audit applies to the module you touched, not the whole tree. Scope creep is a different kind of finding.

## Test evidence

```
cn_runtime_contract_test total: 20 expect-tests
  18 pre-existing (including the 4 added in #173)
  +2 net: F4 happy+malformed and F4 empty-absent
  (F3 updated an existing test's assertions rather than adding a new one)
cn_activation_test: 11 expect-tests (unchanged)
```

## Parity fix (F3) — shape before / after

Before:
```
Skills:
  reflect [cnos.core] triggers: reflect, introspect
```
```json
"activation_index": { "skills": [ {...} ] }
```

After:
```
activation_index:
  skills:
    reflect [cnos.core] triggers: reflect, introspect
```
```json
"activation_index": { "skills": [ {...} ] }
```

The markdown is now a direct byte-for-byte projection of the JSON shape, so `activation_index.events` (ORCHESTRATORS.md §4.1 future field) would add `    events:` under the same header without the renderer needing structural surgery.

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | PR #176 retro-review comment | cdd, cdd/review | 5 findings (F1–F5), post-merge retro |
| 1 Select | — | cdd | Each finding mapped to a disposition (fix or explain) |
| 4 Gap | this PR body | cdd | 3 judgment + 2 mechanical findings from review protocol violation |
| 5 Mode | this PR body | cdd, eng/ocaml, eng/testing | MCA, L5 patch, active skills loaded before writing |
| 6 Artifacts | code + 2 new tests + existing test updated | eng/ocaml, eng/testing | No bare catches reintroduced; test-first not applicable (fixing specific named gaps) |
| 8 Review | — | cdd/review | Pending on this PR |
| 9 Gate | — | cdd/release | Pending CI |
| 10 Release | — | — | Next release train |

## Known debt carried forward

- Pre-existing bare catches in `src/cmd/cn_maintenance.ml`, `cn_logs.ml`, `cn_indicator.ml`, `cn_trace.ml`, `cn_executor.ml`, `cn_context.ml` — unrelated to #173; should be a separate audit cycle if v3.32.0's #152 sweep missed them or if they were introduced after.
- ORCHESTRATORS.md §4.1 lists additional activation fields (`events`, `tokens`, `paths`, `work_shapes`, `levels`, `requires`, `excludes`) that are part of the design but not in the v1 parser. When those land, both renderers extend by adding sub-keys under the existing `activation_index:` header.

## Test plan

- [ ] CI `dune build src/cli/cn.exe`
- [ ] CI `dune runtest` — 20 `cn_runtime_contract_test` + 11 `cn_activation_test` + preceding suite all green
- [ ] `scripts/check-version-consistency.sh` passes
- [ ] On a hub with a deliberately malformed orchestrator entry, stderr shows the logged skip (F1/F2 verification)