### PR TITLE
feat(#174): orchestrator IR runtime — cn_workflow + content class + daily-review

### DIFF
--- a/docs/alpha/package-system/PACKAGE-SYSTEM.md
+++ b/docs/alpha/package-system/PACKAGE-SYSTEM.md
@@ -43,6 +43,7 @@ knows how to copy from `src/agent/<class>/` into `packages/<name>/<class>/`.
 | extensions | directory trees | `src/agent/extensions/` | `"extensions": ["ext.name"]` | Runtime capability providers |
 | templates | named files | `src/agent/templates/` | `"templates": ["FILE.md"]` | Identity/config scaffolding for new hubs |
 | commands | declared entries | `packages/<name>/commands/` | `"commands": { "<name>": { ... } }` | Operator-facing CLI commands |
+| orchestrators | directory trees | `src/agent/orchestrators/` | `"orchestrators": ["id", ...]` | Mechanical workflows executed by the `cn.orchestrator.v1` runtime |
 | (metadata) | implicit | `packages/<name>/` | `cn.package.json` | Package identity, version, engine constraint |
 
 Most content classes are copied from `src/agent/<class>/` by `cn build`.
@@ -53,6 +54,15 @@ mapping the command name to `{ entrypoint, summary }`, where
 `entrypoint` is a file path relative to the package root
 (e.g. `commands/cn-daily`) and `summary` is a one-line description
 shown by `cn help`.
+
+The `orchestrators` class follows the same on-disk layout as skills:
+each declared id in `sources.orchestrators` points at
+`src/agent/orchestrators/<id>/orchestrator.json`, which `cn build`
+copies to `packages/<name>/orchestrators/<id>/orchestrator.json`.
+The JSON is a `cn.orchestrator.v1` manifest with steps, permissions,
+and a trigger — see `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7–8
+for the full schema. The runtime loads, validates, and executes
+these via the workflow engine (`Cn_workflow`).
 
 Metadata (`cn.package.json`) is not a source-declared content class.
 It is always present and not copied from `src/agent/`.

--- a/docs/gamma/cdd/3.36.0/GATE.md
+++ b/docs/gamma/cdd/3.36.0/GATE.md
@@ -1,0 +1,49 @@
+# Gate — v3.36.0 (#174)
+
+## Pre-gate (authoring-side)
+
+- **CI status:** pending — not yet run
+- **Required artifacts present:**
+  - [x] Design: `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7–8
+  - [x] Plan: `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md` (committed at 29eeb29)
+  - [x] Bootstrap: `docs/gamma/cdd/3.36.0/README.md`
+  - [x] Tests: `test/cmd/cn_workflow_test.ml` (18) + updated `test/cmd/cn_runtime_contract_test.ml`
+  - [x] Code: `src/cmd/cn_workflow.ml` (new) + `cn_runtime_contract.ml` + `cn_doctor.ml` + `cn_build.ml`
+  - [x] Docs: `PACKAGE-SYSTEM.md` §1.1 extended with orchestrators class
+  - [x] Shipped asset: `src/agent/orchestrators/daily-review/orchestrator.json` + built copy
+  - [x] Self-coherence: `SELF-COHERENCE.md` (α A · β A · γ A−)
+- **ACs accounted for:** yes — SELF-COHERENCE §"Triadic Coherence Check" point 1 maps AC1–AC7. AC3 and AC7 carry the documented `llm` deferral.
+- **Docs and code agree:** yes — PACKAGE-SYSTEM.md §1.1 matches the source_decl additions matches the cn_build copy loop matches Cn_workflow.discover matches build_orchestrator_registry matches the daily-review manifest.
+- **Known debt explicit:** yes (SELF-COHERENCE §"Triadic Coherence Check" points 1/4 + PLAN §"Deferred to v2").
+- **Release decision:** **hold** until:
+  1. CI `dune build` + `dune runtest` green
+  2. PR review converges
+  3. v3.35.0 post-release closed (it is — PR #178 landed)
+
+## Gate checklist (at release time)
+
+- [ ] CI green on the merge commit
+- [ ] `dune build src/cli/cn.exe` succeeds on all 4 release targets
+- [ ] `dune runtest` green — 18 cn_workflow tests + updated cn_runtime_contract_test suite
+- [ ] `scripts/check-version-consistency.sh` passes
+- [ ] `cn build --check` passes (daily-review orchestrator mirrored between src/agent/ and packages/cnos.core/)
+- [ ] `cn doctor` on a hub with the shipped cnos.core reports "Orchestrators: 1 healthy"
+- [ ] `state/runtime-contract.json` on a real wake shows `body.orchestrators` with `daily-review` + `trigger_kinds: ["command"]`
+- [ ] PR review round 1 converged; no α/β findings outstanding
+- [ ] Known debt materialised as follow-up issues:
+  - `llm` step execution (mechanism for prompt + context injection)
+  - `parallel` step kind (needs async model)
+  - `match` step execution test (direct X-series test; today the branch is exercised only via validator V2 path)
+
+## §9.1 triggers — pre-assessment
+
+| Trigger | Status at gate |
+|---------|---------------|
+| Review rounds > 2 | TBD |
+| Mechanical ratio > 20% | TBD |
+| Avoidable tooling failure | **soft fired** — no OCaml toolchain locally; same as last two cycles |
+| Loaded skill failed to prevent a finding | TBD (baseline: skills loaded before writing, corrective from v3.34.0 post-release held) |
+
+## Release decision
+
+**hold** — pending CI + PR + review. Gate flips to *proceed* when every unchecked checklist item is green and review has converged.

--- a/docs/gamma/cdd/3.36.0/README.md
+++ b/docs/gamma/cdd/3.36.0/README.md
@@ -39,25 +39,28 @@ The handoff staging maps Stage A → AC1/2/6, Stage B → AC3/4/5, Stage C → A
 
 | Stage | ACs | Work | Commit |
 |-------|-----|------|--------|
-| A | AC1, AC2, AC6 | Content class in `cn_build`; IR types, parser, validator in new `cn_orchestrator.ml`; doctor validation wired into `cn_doctor.ml` | TBD |
+| A | AC1, AC2, AC6 | Content class in `cn_build`; IR types, parser, validator in new `cn_workflow.ml`; doctor validation wired into `cn_doctor.ml` | TBD |
 | B | AC3, AC4, AC5 | Execution engine: op dispatch via `Cn_executor.execute_op`, `if`/`match`/`return`/`fail` flow control, binding environment, permission enforcement before dispatch, receipts via `Cn_trace.gemit` | TBD |
 | C | AC7 | `src/agent/orchestrators/daily-review/orchestrator.json`; `packages/cnos.core/cn.package.json` declares it; `cn build` copies it | TBD |
 
 Each stage gets: tests first → implementation → `dune build` gate → commit. Full plan in `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md`.
 
+Naming note: the new module is `Cn_workflow`, not `Cn_orchestrator`. `Cn_orchestrator` already exists as the N-pass LLM bind-loop orchestrator — an unrelated runtime concern. Two different modules, documented in both `src/cmd/cn_workflow.ml`'s docstring and the self-coherence.
+
 ### Impact Graph
 
 **New files:**
-- `src/cmd/cn_orchestrator.ml` (types, parser, validator, executor)
-- `test/cmd/cn_orchestrator_test.ml`
-- `src/agent/orchestrators/daily-review/orchestrator.json`
+- `src/cmd/cn_workflow.ml` (types, parser, validator, discovery, executor)
+- `test/cmd/cn_workflow_test.ml`
+- `src/agent/orchestrators/daily-review/orchestrator.json` + mirrored into `packages/cnos.core/orchestrators/daily-review/`
 - `docs/gamma/cdd/3.36.0/` (this dir)
 
 **Touched modules:**
-- `src/cmd/cn_build.ml` — add `orchestrators` to `source_decl`, copy logic, summary count
-- `src/cmd/cn_doctor.ml` — add `report_orchestrators` using `Cn_orchestrator.validate`
-- `src/cmd/dune` — register `cn_orchestrator`
-- `test/cmd/dune` — register `cn_orchestrator_test`
+- `src/cmd/cn_build.ml` — add `orchestrators` to `source_decl`, copy logic, summary count, clean list; plus sibling audit (5 pre-existing bare catches cleaned)
+- `src/cmd/cn_doctor.ml` — add `report_orchestrators` using `Cn_workflow.doctor_issues`
+- `src/cmd/cn_runtime_contract.ml` — rewrite `build_orchestrator_registry` to consume `Cn_workflow.discover`, resolving the #173 dueling-schema problem; three obsolete orchestrator tests replaced in `test/cmd/cn_runtime_contract_test.ml`
+- `src/cmd/dune` — register `cn_workflow`
+- `test/cmd/dune` — register `cn_workflow_test`
 
 **Touched docs:**
 - `docs/alpha/package-system/PACKAGE-SYSTEM.md` — `orchestrators` as 8th content class
@@ -65,8 +68,8 @@ Each stage gets: tests first → implementation → `dune build` gate → commit
 **Touched manifests:**
 - `packages/cnos.core/cn.package.json` — declare `sources.orchestrators: ["daily-review"]`
 
-**Untouched (verified):**
-- `cn_deps.ml`, `cn_runtime_contract.ml`, `cn_command.ml`, `cn_activation.ml`, `cn_ext_host.ml`, `cn_extension.ml` — unrelated
+**Untouched (verified by grep):**
+- `cn_deps.ml`, `cn_command.ml`, `cn_activation.ml`, `cn_ext_host.ml`, `cn_extension.ml`, `cn_orchestrator.ml` — unrelated to the workflow surface
 - `cn_executor.ml` — **reused** via `execute_op`, not modified. The orchestrator is a caller, not an extension of the executor.
 
 ### CDD Trace (filled during execution)

--- a/docs/gamma/cdd/3.36.0/README.md
+++ b/docs/gamma/cdd/3.36.0/README.md
@@ -1,0 +1,86 @@
+## CDD Bootstrap — v3.36.0 (#174)
+
+**Issue:** #174 — Orchestrator IR runtime: `cn` executes `cn.orchestrator.v1` workflows
+**Parent:** #170 (orchestrator + command provider model)
+**Branch:** claude/174-orchestrator-runtime
+**Design:** `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7–8 (627 lines)
+**Plan:** `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md` (committed at 29eeb29)
+**Mode:** MCA
+**Level:** L7 — new execution surface, new content class, new runtime capability
+**Active skills loaded (and read) before code:** cdd, eng/ocaml, eng/testing
+
+### Gap
+
+cnos has no execution engine for mechanical workflows. The runtime contract (#173) exposes an orchestrator registry, but nothing can load, validate, or execute the `cn.orchestrator.v1` IR. CDD pipeline, daily review, weekly reflection — all are prose instructions the agent interprets, not deterministic workflows the runtime executes.
+
+### What fails if skipped
+
+Mechanical workflows stay as prose. Every new deterministic procedure is another point where the agent needs to infer control flow from text instead of executing a compiled step graph. The determinism rule (control flow deterministic, non-determinism at `llm`/`op` boundaries only) cannot be enforced structurally without a runtime that actually executes steps.
+
+### Acceptance Criteria
+
+- **AC1** `orchestrators/` is a recognised package content class in the manifest schema and `cn build`
+- **AC2** `cn.orchestrator.v1` JSON schema defined and validated by the runtime
+- **AC3** Step execution: `op` dispatches to typed ops, `llm` calls the agent, `if`/`match` branches
+- **AC4** Permission manifest enforced — if an op is not in `permissions.ops`, execution fails before dispatch
+- **AC5** Execution trace (receipts) written for deterministic replay of control flow
+- **AC6** `cn doctor` validates orchestrator manifests (missing steps, invalid refs, permission gaps)
+- **AC7** At least one real orchestrator shipped (daily-review)
+
+### Scope and deferrals (honest)
+
+The handoff staging maps Stage A → AC1/2/6, Stage B → AC3/4/5, Stage C → AC7. Three deferrals this cycle, all explicit:
+
+1. **`parallel` step kind** — deferred to v2 per plan §"Deferred to v2". cnos has no async model.
+2. **`llm` step execution** — the plan §"Risk" flags: "Requires calling the agent from within an orchestrator. The mechanism for this (prompt + context injection) needs design during Stage B. May simplify to 'call cn with a prompt template' initially." This cycle parses and validates `llm` steps (AC2 satisfied) and the executor emits a "not yet implemented in v3.36.0" error at runtime when it hits one. That is honest and covered by a test. The daily-review orchestrator JSON is shipped (AC7) including its `llm` step; `cn doctor` validates it. End-to-end execution of daily-review is therefore **not** part of AC7 in this cycle. **AC3 is met for `op`/`if`/`match`/`return`/`fail`** — five of six step kinds — and **not met for `llm`**. The next cycle closes the `llm` gap once the prompt-injection mechanism is designed.
+3. **`match` semantics** — v1 treats `match` as "exact equality on a bound scalar value against case patterns" (no structural patterns). Documented in the validator + renderer comments.
+
+### Plan (stage index)
+
+| Stage | ACs | Work | Commit |
+|-------|-----|------|--------|
+| A | AC1, AC2, AC6 | Content class in `cn_build`; IR types, parser, validator in new `cn_orchestrator.ml`; doctor validation wired into `cn_doctor.ml` | TBD |
+| B | AC3, AC4, AC5 | Execution engine: op dispatch via `Cn_executor.execute_op`, `if`/`match`/`return`/`fail` flow control, binding environment, permission enforcement before dispatch, receipts via `Cn_trace.gemit` | TBD |
+| C | AC7 | `src/agent/orchestrators/daily-review/orchestrator.json`; `packages/cnos.core/cn.package.json` declares it; `cn build` copies it | TBD |
+
+Each stage gets: tests first → implementation → `dune build` gate → commit. Full plan in `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md`.
+
+### Impact Graph
+
+**New files:**
+- `src/cmd/cn_orchestrator.ml` (types, parser, validator, executor)
+- `test/cmd/cn_orchestrator_test.ml`
+- `src/agent/orchestrators/daily-review/orchestrator.json`
+- `docs/gamma/cdd/3.36.0/` (this dir)
+
+**Touched modules:**
+- `src/cmd/cn_build.ml` — add `orchestrators` to `source_decl`, copy logic, summary count
+- `src/cmd/cn_doctor.ml` — add `report_orchestrators` using `Cn_orchestrator.validate`
+- `src/cmd/dune` — register `cn_orchestrator`
+- `test/cmd/dune` — register `cn_orchestrator_test`
+
+**Touched docs:**
+- `docs/alpha/package-system/PACKAGE-SYSTEM.md` — `orchestrators` as 8th content class
+
+**Touched manifests:**
+- `packages/cnos.core/cn.package.json` — declare `sources.orchestrators: ["daily-review"]`
+
+**Untouched (verified):**
+- `cn_deps.ml`, `cn_runtime_contract.ml`, `cn_command.ml`, `cn_activation.ml`, `cn_ext_host.ml`, `cn_extension.ml` — unrelated
+- `cn_executor.ml` — **reused** via `execute_op`, not modified. The orchestrator is a caller, not an extension of the executor.
+
+### CDD Trace (filled during execution)
+
+| Step | Artifact | Skills loaded | Decision |
+|------|----------|---------------|----------|
+| 0 Observe | #174, PLAN-174, ORCHESTRATORS.md §7–8 | cdd | No execution engine for mechanical workflows; plan already committed |
+| 1 Select | #174 | cdd | L7, depends on #173 (shipped v3.35.0) |
+| 2 Branch | claude/174-orchestrator-runtime | — | created from `main` at 29eeb29 |
+| 3 Bootstrap | `docs/gamma/cdd/3.36.0/` | — | README + (link to) PLAN + SELF-COHERENCE later + GATE later |
+| 4 Gap | this file §Gap | cdd | No runtime for cn.orchestrator.v1 |
+| 5 Mode | this file | cdd, eng/ocaml, eng/testing | MCA, L7, work shape "new execution surface"; active skills **loaded and read before writing** |
+| 6 Artifacts | tests → code → docs → self-coherence | cdd, eng/ocaml, eng/testing | Filled during Stages A/B/C |
+| 7 Self-coherence | `SELF-COHERENCE.md` | cdd | Written after C |
+| 8 Review | PR body | cdd/review | After gate |
+| 9 Gate | `GATE.md` | cdd/release | Set after self-coherence |
+| 10 Release | — | — | Next release train |

--- a/docs/gamma/cdd/3.36.0/SELF-COHERENCE.md
+++ b/docs/gamma/cdd/3.36.0/SELF-COHERENCE.md
@@ -1,0 +1,134 @@
+## Self-Coherence Report — v3.36.0 (#174)
+
+**Issue:** #174 — Orchestrator IR runtime: `cn` executes `cn.orchestrator.v1` workflows
+**Branch:** claude/174-orchestrator-runtime
+**Active skills loaded (and read) before code:** cdd, eng/ocaml, eng/testing
+
+### Alpha (type-level clarity)
+
+| Surface | Change | Type-level judgment |
+|---------|--------|--------------------|
+| `Cn_workflow.frontmatter`-style types (`trigger`, `permissions`, `step`, `orchestrator`) | new records + variant | Disambiguated fields (`trigger_kind/trigger_name`, `orch_source/orch_package`, etc.); variant tags (`Op_step`, `Llm_step`, `If_step`, `Match_step`, `Return_step`, `Fail_step`) are exhaustive and the compiler catches a new step kind landing without a dispatch arm. |
+| `Cn_workflow.issue_kind` | new variant | Six distinct validator categories; compiler forces doctor dispatch (and tests) to handle each case. |
+| `Cn_workflow.load_outcome` | new variant (`Loaded` / `Load_error`) | Discovery surfaces failure per-orchestrator without crashing the walk. |
+| `Cn_workflow.outcome` | `Completed of Cn_json.t \| Failed of string` | Terminal states are explicit; `execute` never raises on the caller's behalf. |
+| Execute step loop | polymorphic variant `` `Terminal \| `Continue \| `Jump `` | Local to `execute_step`; three clean states correspond to the three kinds of control flow (terminate, next-in-order, branch-by-id). |
+| `Cn_build.source_decl` | gains `orchestrators : string list` | Parallel to `skills`: a list of declared ids. Directory-tree copy shape. |
+| `Cn_runtime_contract.build_orchestrator_registry` | rewritten to consume `Cn_workflow.discover` | One source of truth for "what orchestrators exist" and "what are their trigger kinds". No dueling JSON schemas. |
+
+Name collision with the pre-existing `Cn_orchestrator` (the N-pass LLM bind loop): explicitly documented in `cn_workflow.ml`'s module doc and in this cycle's README. The module is named `Cn_workflow` to keep distance from the existing `Cn_orchestrator`. Two different concerns, two different modules.
+
+**Alpha score: A.** Every record field, every variant tag, every outcome case is consumed somewhere in the test suite. The parser is a pure function returning `(orchestrator, string) result`; exceptions never escape. Execution returns a bounded `outcome`; the stepper is tail-recursive over a polymorphic-variant pipe.
+
+### Beta (authority surface agreement)
+
+Every surface touched and its consumers:
+
+| Surface | Authority | Consumers updated? |
+|---------|-----------|--------------------|
+| `cn.orchestrator.v1` IR JSON | `Cn_workflow.parse` | `Cn_workflow.discover` (reads), `Cn_workflow.execute` (consumes), `Cn_doctor.report_orchestrators` (validates), `build_orchestrator_registry` (projects to runtime contract). Single pipeline end-to-end. |
+| `sources.orchestrators` string array | `Cn_workflow.manifest_orchestrator_ids` + `Cn_build.parse_sources` | Both functions read the same field with the same shape. ORCHESTRATORS.md §9 matches. `cn build` copies per id; discover walks per id. |
+| Workflow record types | `cn_workflow.ml` | `cn_runtime_contract.ml` references via `Cn_workflow.installed` / `Loaded` variant. Single module boundary; no duplication. |
+| Runtime contract `body.orchestrators` JSON shape | `to_json` in `cn_runtime_contract.ml` | Test in `cn_runtime_contract_test.ml` locks the field names and count. Doctor surface carries its own doctor-style output. |
+| Trace / receipt events | `Cn_trace.gemit` via local `trace_event` wrapper | 9 call sites, each with matching label set. Receipts fire on start + complete (success), complete (blocked), and complete (error). No-op in tests without a trace session, full trace in production. |
+| `PACKAGE-SYSTEM.md` content class table | `docs/alpha/package-system/PACKAGE-SYSTEM.md` §1.1 | Updated to list orchestrators as the 8th class with source location, declaration shape, and runtime role. |
+| `daily-review` orchestrator manifest | `src/agent/orchestrators/daily-review/orchestrator.json` → `packages/cnos.core/orchestrators/daily-review/orchestrator.json` | Both source and built copies present; cnos.core manifest declares `"orchestrators": ["daily-review"]`. |
+
+**Stale reference scan:**
+- Zero bare `with _ ->` in any touched module (`cn_workflow.ml`, `cn_runtime_contract.ml`, `cn_doctor.ml`, `cn_build.ml`, `cn_command.ml`). The §2.2 sibling audit caught 5 pre-existing bare catches in `cn_build.ml` — all fixed in this diff with logged context.
+- `Cn_workflow` exports — `parse`, `parse_file`, `validate`, `discover`, `doctor_issues`, `execute`, and the type aliases — each has at least one caller in src/ or test/.
+- The former inline `[{name, trigger_kinds}]` schema for `sources.orchestrators` (from #173) is fully gone; the three tests that asserted it were replaced with new-schema equivalents that load from `Cn_workflow.discover`.
+
+**Beta score: A.** Every downstream consumer of the touched authorities is updated in the same set of commits. The content-class table in PACKAGE-SYSTEM.md matches the ORCHESTRATORS.md §9 schema matches the parser matches the validator matches the doctor output matches the runtime contract JSON matches the installed `daily-review` manifest.
+
+### Gamma (cycle economics)
+
+**Test counts:**
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `cn_workflow_test.ml` (new) | 18 | F1–F5 parser, V1–V5 validator, D1–D3 discovery, X1–X5 executor |
+| `cn_runtime_contract_test.ml` | 21 (rewrote 3 to match new schema, added 0) | contract shape including orchestrators from discovery |
+
+**Line deltas (approximate):**
+
+| File | Insertions | Deletions |
+|------|------------|-----------|
+| `src/cmd/cn_workflow.ml` (new) | ~640 | 0 |
+| `src/cmd/cn_runtime_contract.ml` | ~20 | ~70 (rewrote build_orchestrator_registry, net shrink) |
+| `src/cmd/cn_doctor.ml` | ~20 | ~2 |
+| `src/cmd/cn_build.ml` | ~30 | ~10 (orchestrators class + sibling-catch fixes) |
+| `src/cmd/dune`, `test/cmd/dune` | ~10 | ~2 |
+| `test/cmd/cn_workflow_test.ml` (new) | ~450 | 0 |
+| `test/cmd/cn_runtime_contract_test.ml` | ~80 | ~130 (replaced 3 obsolete tests) |
+| `docs/alpha/package-system/PACKAGE-SYSTEM.md` | ~15 | 0 |
+| `docs/gamma/cdd/3.36.0/` | ~400 | 0 |
+| `packages/cnos.core/cn.package.json` | ~3 | 0 |
+| `src/agent/orchestrators/daily-review/orchestrator.json` (new) | ~45 | 0 |
+| `packages/cnos.core/orchestrators/daily-review/orchestrator.json` (new) | ~45 | 0 |
+
+**§9.1 triggers:**
+
+| Trigger | Fired | Note |
+|---------|-------|------|
+| Review rounds > 2 | TBD | PR not yet reviewed |
+| Mechanical ratio > 20% | TBD | Depends on review findings |
+| Avoidable tooling failure | **Yes (soft)** | No OCaml toolchain in the authoring sandbox. Same environment constraint as v3.34.0 and v3.35.0. Text-level review done; CI is the first compilation oracle. |
+| Loaded skill failed to prevent a finding | TBD | Baseline: skills were loaded and read before writing (v3.34.0 / v3.35.0 corrective held). |
+
+**Gamma score: A−.**
+- Test-first discipline held. Every production function has at least one expect test. The 5 step kinds (op, return, fail, if, llm) are each exercised; the 6th (match) is covered by the validator test V2 for reference integrity but its happy-path execution case is **deferred** as known debt — the `Match_step` branch in `execute_step` is covered by the parser/validator but not by a direct X-series execution test. Worth calling out explicitly rather than quietly counting it covered.
+- Sibling audit was performed properly this round: 5 pre-existing bare catches in `cn_build.ml` surfaced and fixed.
+- The minus is again the tooling gap (no local OCaml) — same cause as the prior two cycles.
+
+### Triadic Coherence Check
+
+1. **Does every AC have corresponding code?**
+   - **AC1** (orchestrators content class): `Cn_build.source_decl.orchestrators` + `parse_sources` + `build_one`/`check_one` loops + `clean_package_dir` list include `orchestrators`. `PACKAGE-SYSTEM.md` §1.1 table entry.
+   - **AC2** (`cn.orchestrator.v1` schema validated): `Cn_workflow.parse` + `validate` cover all field parsing and structural checks. Tests F1–F5 + V1–V5.
+   - **AC3** (step execution — `op`/`llm`/`if`/`match`/`return`/`fail`): `Cn_workflow.execute_step` has a branch per step kind. **`llm` is a deferred stub**: it's parsed, validated, permission-checked, and then emits a "not yet implemented in this release" failure at runtime. Honest about the deferral; the prompt + context injection mechanism is future design (PLAN §Risk). Five of six step kinds execute; the sixth is a guarded stub.
+   - **AC4** (permission manifest enforced before dispatch): `execute_step` checks `List.mem s.op o.permissions.ops` before constructing the typed op. Defence-in-depth with the validator's `Permission_gap` issue.
+   - **AC5** (execution trace for replay): `trace_event` wrapper emits `workflow.step.start` and `workflow.step.complete` at each step, with step id, branch target, reason (on failure), and op name. Writes to `Cn_trace` (existing ulog infrastructure). No-op under test when no session is initialised.
+   - **AC6** (`cn doctor` validates orchestrator manifests): `Cn_doctor.report_orchestrators` invokes `Cn_workflow.doctor_issues`, which combines load failures + validator issues per installed orchestrator. Doctor exits 1 on any orchestrator issue (fail-stop).
+   - **AC7** (real orchestrator shipped): `src/agent/orchestrators/daily-review/orchestrator.json` + built copy in `packages/cnos.core/orchestrators/daily-review/` + `"orchestrators": ["daily-review"]` in the cnos.core manifest. The orchestrator JSON **parses and validates** (AC6 covers this); it would **fail at runtime** today because step 2 is the `llm` stub. This is the honest state of AC7 under the AC3 deferral: shipped as code/data + schema-clean, not end-to-end runnable.
+
+2. **Is the dueling-schema problem resolved?** Yes. The #173 `build_orchestrator_registry` read `sources.orchestrators` as an array of inline objects `[{name, trigger_kinds}]`. That's inconsistent with ORCHESTRATORS.md §9 which specifies `sources.orchestrators` as an array of id strings. This PR rewrites `build_orchestrator_registry` to consume `Cn_workflow.discover`, which reads the id-array shape and loads the per-orchestrator JSON. The three #173 tests that asserted the inline schema are replaced with ones that match the spec. One schema, one reader, one set of tests.
+
+3. **Is the name collision with `Cn_orchestrator` benign?** Yes. `Cn_orchestrator` is the pre-existing N-pass LLM bind-loop orchestrator. `Cn_workflow` is the mechanical workflow engine. The domain concerns are different (LLM response resolution vs declarative step graph execution). The naming clarifies the difference. The CDD README and the `cn_workflow.ml` module docstring both call this out.
+
+4. **Is the `llm` stub honest about its deferral?** Yes. The step kind is parsed (`Llm_step` variant exists). The validator flags `Llm_without_permission` when `permissions.llm=false`. The executor enters the Llm_step branch and produces `Failed "llm step not yet implemented in this release"` with a matching trace event. Test X5 locks that behaviour. AC3 is met for five of six step kinds; AC7's daily-review orchestrator parses and doctor-validates cleanly but its step 2 would terminate the run on execution. Next cycle closes the gap.
+
+5. **Do the runtime extensions and the N-pass orchestrator remain untouched?** Yes. No edits to `cn_extension.ml`, `cn_ext_host.ml`, or `cn_orchestrator.ml`. grep confirms.
+
+### Pointers
+
+| What | Where |
+|------|-------|
+| Issue | https://github.com/usurobor/cnos/issues/174 |
+| Handoff | Comment on #174 |
+| Design | `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7–8 |
+| Plan | `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md` |
+| Bootstrap | `docs/gamma/cdd/3.36.0/README.md` |
+| Module | `src/cmd/cn_workflow.ml` |
+| Runtime contract wiring | `src/cmd/cn_runtime_contract.ml::build_orchestrator_registry` |
+| Doctor wiring | `src/cmd/cn_doctor.ml::report_orchestrators` |
+| Build wiring | `src/cmd/cn_build.ml::{source_decl, parse_sources, build_one, check_one, clean_package_dir}` |
+| Tests | `test/cmd/cn_workflow_test.ml`, `test/cmd/cn_runtime_contract_test.ml` |
+| Shipped orchestrator | `src/agent/orchestrators/daily-review/orchestrator.json` |
+| Content class docs | `docs/alpha/package-system/PACKAGE-SYSTEM.md` §1.1 |
+
+### Exit Criteria
+
+- [x] AC1: orchestrators content class in build + schema + docs
+- [x] AC2: cn.orchestrator.v1 schema parsed and validated
+- [x] AC3: op/return/fail/if/match executable; llm deferred with honest stub
+- [x] AC4: permission manifest enforced before dispatch
+- [x] AC5: trace events emitted via Cn_trace.gemit
+- [x] AC6: cn doctor surfaces load failures + validator issues
+- [x] AC7: daily-review orchestrator shipped, parses + validates; full execution deferred with AC3
+- [x] Zero bare `with _ ->` in touched files; §2.2 sibling audit completed on `cn_build.ml`
+- [x] Test-first discipline held
+- [x] `scripts/check-version-consistency.sh` passes
+- [ ] `dune build && dune runtest` — deferred to CI
+- [ ] PR review round 1 — pending
+- [ ] CI green on branch — pending

--- a/packages/cnos.core/cn.package.json
+++ b/packages/cnos.core/cn.package.json
@@ -57,6 +57,9 @@
     "templates": [
       "SOUL.md",
       "USER.md"
+    ],
+    "orchestrators": [
+      "daily-review"
     ]
   }
 }

--- a/packages/cnos.core/orchestrators/daily-review/orchestrator.json
+++ b/packages/cnos.core/orchestrators/daily-review/orchestrator.json
@@ -1,0 +1,44 @@
+{
+  "kind": "cn.orchestrator.v1",
+  "name": "daily-review",
+  "trigger": {
+    "kind": "command",
+    "name": "daily-review"
+  },
+  "inputs": {
+    "requires_hub": true
+  },
+  "permissions": {
+    "llm": true,
+    "ops": ["fs_read", "fs_write"],
+    "external_effects": false
+  },
+  "steps": [
+    {
+      "id": "load-context",
+      "kind": "op",
+      "op": "fs_read",
+      "args": { "path": "threads/reflections/daily/today.md" },
+      "bind": "today"
+    },
+    {
+      "id": "summarize",
+      "kind": "llm",
+      "prompt": "daily-review-v1",
+      "inputs": ["today"],
+      "bind": "summary"
+    },
+    {
+      "id": "write-output",
+      "kind": "op",
+      "op": "fs_write",
+      "args": { "path": "threads/adhoc/daily-summary.md" },
+      "inputs": ["summary"]
+    },
+    {
+      "id": "done",
+      "kind": "return",
+      "value": { "artifact": "threads/adhoc/daily-summary.md" }
+    }
+  ]
+}

--- a/packages/cnos.core/orchestrators/daily-review/orchestrator.json
+++ b/packages/cnos.core/orchestrators/daily-review/orchestrator.json
@@ -5,9 +5,6 @@
     "kind": "command",
     "name": "daily-review"
   },
-  "inputs": {
-    "requires_hub": true
-  },
   "permissions": {
     "llm": true,
     "ops": ["fs_read", "fs_write"],

--- a/src/agent/orchestrators/daily-review/orchestrator.json
+++ b/src/agent/orchestrators/daily-review/orchestrator.json
@@ -1,0 +1,44 @@
+{
+  "kind": "cn.orchestrator.v1",
+  "name": "daily-review",
+  "trigger": {
+    "kind": "command",
+    "name": "daily-review"
+  },
+  "inputs": {
+    "requires_hub": true
+  },
+  "permissions": {
+    "llm": true,
+    "ops": ["fs_read", "fs_write"],
+    "external_effects": false
+  },
+  "steps": [
+    {
+      "id": "load-context",
+      "kind": "op",
+      "op": "fs_read",
+      "args": { "path": "threads/reflections/daily/today.md" },
+      "bind": "today"
+    },
+    {
+      "id": "summarize",
+      "kind": "llm",
+      "prompt": "daily-review-v1",
+      "inputs": ["today"],
+      "bind": "summary"
+    },
+    {
+      "id": "write-output",
+      "kind": "op",
+      "op": "fs_write",
+      "args": { "path": "threads/adhoc/daily-summary.md" },
+      "inputs": ["summary"]
+    },
+    {
+      "id": "done",
+      "kind": "return",
+      "value": { "artifact": "threads/adhoc/daily-summary.md" }
+    }
+  ]
+}

--- a/src/agent/orchestrators/daily-review/orchestrator.json
+++ b/src/agent/orchestrators/daily-review/orchestrator.json
@@ -5,9 +5,6 @@
     "kind": "command",
     "name": "daily-review"
   },
-  "inputs": {
-    "requires_hub": true
-  },
   "permissions": {
     "llm": true,
     "ops": ["fs_read", "fs_write"],

--- a/src/cmd/cn_build.ml
+++ b/src/cmd/cn_build.ml
@@ -17,13 +17,17 @@
     Maps asset categories to paths relative to src/agent/<category>/.
     Commands are authored directly under packages/<name>/commands/
     and are not assembled by cn build; they are consumed by
-    Cn_command during dispatch and are ignored here. *)
+    Cn_command during dispatch and are ignored here.
+    Orchestrators follow the same on-disk layout: authored under
+    src/agent/orchestrators/<id>/orchestrator.json and copied
+    mechanically to packages/<name>/orchestrators/<id>/. *)
 type source_decl = {
   doctrine : string list;
   mindsets : string list;
   skills : string list;
   extensions : string list;
   templates : string list;
+  orchestrators : string list;
 }
 
 type package_manifest = {
@@ -68,6 +72,7 @@ let parse_sources json =
         skills = parse_string_array src_json "skills";
         extensions = parse_string_array src_json "extensions";
         templates = parse_string_array src_json "templates";
+        orchestrators = parse_string_array src_json "orchestrators";
       }
 
 let parse_package_json path =
@@ -98,7 +103,9 @@ let rec copy_tree src_dir dst_dir =
           copy_tree src dst
         else
           Cn_ffi.Fs.write dst (Cn_ffi.Fs.read src))
-    with _ -> ())
+    with exn ->
+      Printf.eprintf "cn: build: copy_tree %s: %s\n"
+        src_dir (Printexc.to_string exn))
   end
 
 (** Remove a directory tree. *)
@@ -111,7 +118,9 @@ let rec rm_tree path =
         Unix.rmdir path
       end else
         Sys.remove path
-    with _ -> ())
+    with exn ->
+      Printf.eprintf "cn: build: rm_tree %s: %s\n"
+        path (Printexc.to_string exn))
   end
 
 (** Copy a single source entry for a given category.
@@ -132,7 +141,9 @@ let copy_source ~agent_root ~pkg_dir ~category entry =
           let dst = Cn_ffi.Path.join dst_category_dir f in
           if not (Sys.is_directory src) then
             Cn_ffi.Fs.write dst (Cn_ffi.Fs.read src))
-      with _ -> ())
+      with exn ->
+        Printf.eprintf "cn: build: wildcard copy %s: %s\n"
+          src_category_dir (Printexc.to_string exn))
     end
   end else if category = "mindsets" || category = "templates" then begin
     (* Individual file copy *)
@@ -152,14 +163,14 @@ let copy_source ~agent_root ~pkg_dir ~category entry =
 
 (** Clean built content from a package directory. Removes every
     content-class subdirectory that cn build assembles from
-    src/agent/ (doctrine, mindsets, skills, extensions, templates).
-    Preserves cn.package.json and any hand-authored subdirectories
-    such as commands/. *)
+    src/agent/: doctrine, mindsets, skills, extensions, templates,
+    orchestrators. Preserves cn.package.json and any hand-authored
+    subdirectories such as commands/. *)
 let clean_package_dir pkg_dir =
   List.iter (fun sub ->
     let path = Cn_ffi.Path.join pkg_dir sub in
     if Cn_ffi.Fs.exists path then rm_tree path
-  ) ["doctrine"; "mindsets"; "skills"; "extensions"; "templates"]
+  ) ["doctrine"; "mindsets"; "skills"; "extensions"; "templates"; "orchestrators"]
 
 (* === Build === *)
 
@@ -177,7 +188,10 @@ let discover_packages root =
         match parse_package_json manifest_path with
         | Some pkg -> Some (dir_name, pkg)
         | None -> None)
-    with _ -> []
+    with exn ->
+      Printf.eprintf "cn: build: discover_packages %s: %s\n"
+        pkgs_dir (Printexc.to_string exn);
+      []
 
 (** Build a single package: clean then copy sources. *)
 let build_one ~agent_root ~pkgs_dir (dir_name, pkg) =
@@ -198,6 +212,9 @@ let build_one ~agent_root ~pkgs_dir (dir_name, pkg) =
   (* Copy templates *)
   pkg.sources.templates |> List.iter (fun entry ->
     copy_source ~agent_root ~pkg_dir ~category:"templates" entry);
+  (* Copy orchestrators (directory tree per declared id) *)
+  pkg.sources.orchestrators |> List.iter (fun entry ->
+    copy_source ~agent_root ~pkg_dir ~category:"orchestrators" entry);
   pkg
 
 (** Compare file content between two paths. Returns list of mismatches. *)
@@ -232,7 +249,9 @@ let rec diff_tree src dst prefix =
           let rel = if prefix = "" then entry else prefix ^ "/" ^ entry in
           if not (Cn_ffi.Fs.exists src_path) then
             add (Printf.sprintf "extra: %s" rel))
-      with _ -> add (Printf.sprintf "error reading: %s" prefix))
+      with exn ->
+        add (Printf.sprintf "error reading: %s: %s"
+          prefix (Printexc.to_string exn)))
     end
   end;
   !mismatches
@@ -255,6 +274,8 @@ let check_one ~agent_root ~pkgs_dir (dir_name, pkg) =
     copy_source ~agent_root ~pkg_dir:tmp_dir ~category:"extensions" entry);
   pkg.sources.templates |> List.iter (fun entry ->
     copy_source ~agent_root ~pkg_dir:tmp_dir ~category:"templates" entry);
+  pkg.sources.orchestrators |> List.iter (fun entry ->
+    copy_source ~agent_root ~pkg_dir:tmp_dir ~category:"orchestrators" entry);
   (* Compare *)
   let mismatches =
     List.concat_map (fun cat ->
@@ -263,7 +284,7 @@ let check_one ~agent_root ~pkgs_dir (dir_name, pkg) =
       if Cn_ffi.Fs.exists tmp_cat || Cn_ffi.Fs.exists pkg_cat then
         diff_tree tmp_cat pkg_cat cat
       else []
-    ) ["doctrine"; "mindsets"; "skills"; "extensions"; "templates"]
+    ) ["doctrine"; "mindsets"; "skills"; "extensions"; "templates"; "orchestrators"]
   in
   rm_tree tmp_dir;
   (pkg.name, mismatches)
@@ -323,13 +344,17 @@ let run_build () =
         let n_skills = List.length pkg.sources.skills in
         let n_extensions = List.length pkg.sources.extensions in
         let n_templates = List.length pkg.sources.templates in
+        let n_orchestrators = List.length pkg.sources.orchestrators in
         let ext_str = if n_extensions > 0
           then Printf.sprintf ", %d extensions" n_extensions else "" in
         let tpl_str = if n_templates > 0
           then Printf.sprintf ", %d templates" n_templates else "" in
+        let orch_str = if n_orchestrators > 0
+          then Printf.sprintf ", %d orchestrators" n_orchestrators else "" in
         print_endline (Cn_fmt.ok (Printf.sprintf
-          "%s@%s: %d doctrine, %d mindsets, %d skills%s%s"
-          pkg.name pkg.version n_doctrine n_mindsets n_skills ext_str tpl_str)));
+          "%s@%s: %d doctrine, %d mindsets, %d skills%s%s%s"
+          pkg.name pkg.version n_doctrine n_mindsets n_skills
+          ext_str tpl_str orch_str)));
       print_endline (Cn_fmt.ok (Printf.sprintf
         "Built %d packages" (List.length packages)))
 

--- a/src/cmd/cn_doctor.ml
+++ b/src/cmd/cn_doctor.ml
@@ -1,8 +1,11 @@
 (** cn_doctor.ml — Doctor command entry point.
 
-    Runs the system doctor (Cn_system.run_doctor), then validates the
-    external-command surface (Cn_command.validate), then validates the
-    activation surface (Cn_activation.validate). Trigger conflicts are
+    Runs the system doctor (Cn_system.run_doctor), then validates each
+    user-facing content surface:
+      - Cn_command.validate  — external command integrity
+      - Cn_activation.validate — exposed-skill triggers
+      - Cn_workflow.doctor_issues — orchestrator IR integrity
+    Activation trigger conflicts and any orchestrator issue are
     fail-stop (exit 1); other categories are warnings. *)
 
 let report_commands ~hub_path =
@@ -46,9 +49,26 @@ let report_activation ~hub_path =
              print_endline (Cn_fmt.warn line)));
   any_conflict
 
+let report_orchestrators ~hub_path =
+  let installed = Cn_workflow.discover ~hub_path in
+  let issues = Cn_workflow.doctor_issues ~hub_path in
+  match installed, issues with
+  | [], [] -> false
+  | _ :: _, [] ->
+      print_endline (Cn_fmt.ok
+        (Printf.sprintf "Orchestrators: %d healthy"
+           (List.length installed)));
+      false
+  | _, _ :: _ ->
+      print_endline (Cn_fmt.warn "Orchestrators:");
+      issues |> List.iter (fun msg ->
+        print_endline (Cn_fmt.fail (Printf.sprintf "  %s" msg)));
+      true
+
 let run_doctor ~hub_path =
   Cn_system.run_doctor hub_path;
-  let cmd_failed  = report_commands   ~hub_path in
-  let act_failed  = report_activation ~hub_path in
-  if cmd_failed || act_failed then
+  let cmd_failed  = report_commands      ~hub_path in
+  let act_failed  = report_activation    ~hub_path in
+  let orch_failed = report_orchestrators ~hub_path in
+  if cmd_failed || act_failed || orch_failed then
     Cn_ffi.Process.exit 1

--- a/src/cmd/cn_runtime_contract.ml
+++ b/src/cmd/cn_runtime_contract.ml
@@ -181,81 +181,25 @@ let build_command_registry ~hub_path =
       cmd_summary = c.summary;
     })
 
-(** Read [sources.orchestrators] from each installed package's manifest.
-    Schema per entry:
-      { "name": "...", "trigger_kinds": ["command", "schedule", ...] }
-    Malformed manifests and entries without a [name] are logged to
-    stderr with package context, not silently dropped. The logged
-    message is informational only; cn doctor / cn_deps remain the
-    canonical validation surfaces. *)
+(** Project each installed orchestrator (per Cn_workflow.discover) to
+    a runtime-contract registry entry. The trigger_kinds field is a
+    single-element list carrying the orchestrator's declared
+    [trigger.kind] — v1 workflows have one trigger; the list shape
+    is preserved for forward compatibility with multi-trigger
+    orchestrators. Load failures are omitted from the registry and
+    surfaced separately by [Cn_doctor] via [Cn_workflow.doctor_issues]. *)
 let build_orchestrator_registry ~hub_path =
-  Cn_assets.list_installed_packages hub_path
-  |> List.concat_map (fun (pkg_name, pkg_dir) ->
-    let manifest_path = Cn_ffi.Path.join pkg_dir "cn.package.json" in
-    if not (Cn_ffi.Fs.exists manifest_path) then []
-    else
-      match Cn_json.parse (Cn_ffi.Fs.read manifest_path) with
-      | Error msg ->
-          Printf.eprintf
-            "cn: runtime_contract: package %s: cannot parse %s: %s\n"
-            pkg_name manifest_path msg;
-          []
-      | Ok json ->
-          match Cn_json.get "sources" json with
-          | None -> []
-          | Some sources ->
-              match Cn_json.get "orchestrators" sources with
-              | Some (Cn_json.Array items) ->
-                  items |> List.filter_map (function
-                    | Cn_json.Object _ as entry ->
-                        (match Cn_json.get_string "name" entry with
-                         | None ->
-                             Printf.eprintf
-                               "cn: runtime_contract: package %s: orchestrator \
-                                entry missing 'name' field, skipping\n"
-                               pkg_name;
-                             None
-                         | Some name ->
-                             let trigger_kinds = match Cn_json.get "trigger_kinds" entry with
-                               | Some (Cn_json.Array xs) ->
-                                   xs |> List.filter_map (function
-                                     | Cn_json.String s -> Some s
-                                     | other ->
-                                         Printf.eprintf
-                                           "cn: runtime_contract: package %s: \
-                                            orchestrator %s: trigger_kinds entry \
-                                            is not a string (%s), skipping\n"
-                                           pkg_name name
-                                           (Cn_json.to_string other);
-                                         None)
-                               | None -> []
-                               | Some _ ->
-                                   Printf.eprintf
-                                     "cn: runtime_contract: package %s: \
-                                      orchestrator %s: trigger_kinds is not an \
-                                      array, ignoring\n"
-                                     pkg_name name;
-                                   []
-                             in
-                             Some {
-                               orch_name = name;
-                               orch_source = "package";
-                               orch_package = pkg_name;
-                               orch_trigger_kinds = trigger_kinds;
-                             })
-                    | _ ->
-                        Printf.eprintf
-                          "cn: runtime_contract: package %s: orchestrator \
-                           entry is not an object, skipping\n"
-                          pkg_name;
-                        None)
-              | Some _ ->
-                  Printf.eprintf
-                    "cn: runtime_contract: package %s: sources.orchestrators \
-                     is not an array, ignoring\n"
-                    pkg_name;
-                  []
-              | None -> [])
+  Cn_workflow.discover ~hub_path
+  |> List.filter_map (fun (i : Cn_workflow.installed) ->
+    match i.outcome with
+    | Cn_workflow.Load_error _ -> None
+    | Cn_workflow.Loaded o ->
+        Some {
+          orch_name = o.name;
+          orch_source = "package";
+          orch_package = i.package;
+          orch_trigger_kinds = [o.trigger.trigger_kind];
+        })
 
 (** Build the runtime contract from current hub state. *)
 let gather ~hub_path ~(shell_config : Cn_shell.shell_config)

--- a/src/cmd/cn_workflow.ml
+++ b/src/cmd/cn_workflow.ml
@@ -1,0 +1,641 @@
+(** cn_workflow.ml — Orchestrator IR runtime (`cn.orchestrator.v1`).
+
+    Implements the mechanical workflow engine specified in
+    `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7-8.
+
+    Responsibilities:
+    - Parse an orchestrator manifest (`cn.orchestrator.v1` JSON)
+      into typed IR.
+    - Validate it structurally: no duplicate step ids, all step
+      refs resolve, every dispatched op is in `permissions.ops`,
+      every `llm` step requires `permissions.llm = true`.
+    - Discover installed orchestrators under
+      `.cn/vendor/packages/*/orchestrators/<id>/orchestrator.json`
+      per the package-system content-class rule (§10.3).
+    - Execute a loaded IR step by step: deterministic control
+      flow (`if`, `match`, `return`, `fail`) plus typed `op`
+      dispatch via [Cn_executor.execute_op]. Receipts/events are
+      emitted to the global trace session (no-op when no session).
+
+    Deferred to a later cycle (documented in ORCHESTRATORS.md §8.2):
+    - [parallel] step kind (cnos has no async model)
+    - [llm] step execution (prompt + context injection mechanism
+      not yet designed)
+
+    Naming: this module is distinct from the pre-existing
+    [Cn_orchestrator] which implements the N-pass LLM bind loop.
+    Two orthogonal orchestration concerns, two modules. *)
+
+(* === Types === *)
+
+type trigger = {
+  trigger_kind : string;       (** "command" | "schedule" | "event" *)
+  trigger_name : string;
+}
+
+type permissions = {
+  llm : bool;
+  ops : string list;           (** allowed op kind names *)
+  external_effects : bool;
+}
+
+type step =
+  | Op_step of {
+      id : string;
+      op : string;             (** op kind name e.g. "fs_read" *)
+      args : (string * Cn_json.t) list;
+      bind : string option;
+      inputs : string list;
+    }
+  | Llm_step of {
+      id : string;
+      prompt : string;
+      inputs : string list;
+      bind : string option;
+    }
+  | If_step of {
+      id : string;
+      cond : string;           (** name of bound boolean *)
+      then_ref : string;       (** step id to jump to on true *)
+      else_ref : string;       (** step id to jump to on false *)
+    }
+  | Match_step of {
+      id : string;
+      input : string;          (** bound value name to match on *)
+      cases : (string * string) list;  (** literal-value -> step id *)
+      default : string option; (** step id when no case matches *)
+    }
+  | Return_step of {
+      id : string;
+      value : Cn_json.t;
+    }
+  | Fail_step of {
+      id : string;
+      message : string;
+    }
+
+type orchestrator = {
+  kind : string;
+  name : string;
+  trigger : trigger;
+  permissions : permissions;
+  steps : step list;
+}
+
+(* === Parser === *)
+
+let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e
+
+let require_string key json =
+  match Cn_json.get_string key json with
+  | Some s -> Ok s
+  | None -> Error (Printf.sprintf "missing or non-string field '%s'" key)
+
+let parse_string_list key json =
+  match Cn_json.get key json with
+  | None -> []
+  | Some (Cn_json.Array xs) ->
+      xs |> List.filter_map (function
+        | Cn_json.String s -> Some s
+        | _ -> None)
+  | Some _ -> []
+
+let parse_trigger json =
+  match Cn_json.get "trigger" json with
+  | None -> Error "missing 'trigger'"
+  | Some t ->
+      let* tk = require_string "kind" t in
+      let* tn = require_string "name" t in
+      Ok { trigger_kind = tk; trigger_name = tn }
+
+let parse_permissions json =
+  match Cn_json.get "permissions" json with
+  | None -> Error "missing 'permissions'"
+  | Some p ->
+      let llm = match Cn_json.get "llm" p with
+        | Some (Cn_json.Bool b) -> b
+        | _ -> false in
+      let ops = parse_string_list "ops" p in
+      let external_effects = match Cn_json.get "external_effects" p with
+        | Some (Cn_json.Bool b) -> b
+        | _ -> false in
+      Ok { llm; ops; external_effects }
+
+let parse_step json =
+  let* id = require_string "id" json in
+  let* kind = require_string "kind" json in
+  match kind with
+  | "op" ->
+      let* op = require_string "op" json in
+      let args = match Cn_json.get "args" json with
+        | Some (Cn_json.Object fields) -> fields
+        | _ -> []
+      in
+      let bind = Cn_json.get_string "bind" json in
+      let inputs = parse_string_list "inputs" json in
+      Ok (Op_step { id; op; args; bind; inputs })
+  | "llm" ->
+      let* prompt = require_string "prompt" json in
+      let inputs = parse_string_list "inputs" json in
+      let bind = Cn_json.get_string "bind" json in
+      Ok (Llm_step { id; prompt; inputs; bind })
+  | "if" ->
+      let* cond = require_string "cond" json in
+      let* then_ref = require_string "then" json in
+      let* else_ref = require_string "else" json in
+      Ok (If_step { id; cond; then_ref; else_ref })
+  | "match" ->
+      let* input = require_string "input" json in
+      let cases = match Cn_json.get "cases" json with
+        | Some (Cn_json.Object fields) ->
+            fields |> List.filter_map (function
+              | (k, Cn_json.String v) -> Some (k, v)
+              | _ -> None)
+        | _ -> []
+      in
+      let default = Cn_json.get_string "default" json in
+      Ok (Match_step { id; input; cases; default })
+  | "return" ->
+      let value = match Cn_json.get "value" json with
+        | Some v -> v
+        | None -> Cn_json.Object []
+      in
+      Ok (Return_step { id; value })
+  | "fail" ->
+      let message = Cn_json.get_string "message" json
+        |> Option.value ~default:"" in
+      Ok (Fail_step { id; message })
+  | other ->
+      Error (Printf.sprintf
+        "step '%s': unknown kind '%s' (supported: op, llm, if, match, return, fail)"
+        id other)
+
+let parse json =
+  let* kind = require_string "kind" json in
+  if kind <> "cn.orchestrator.v1" then
+    Error (Printf.sprintf "unsupported schema kind '%s' \
+      (expected 'cn.orchestrator.v1')" kind)
+  else
+    let* name = require_string "name" json in
+    let* trigger = parse_trigger json in
+    let* permissions = parse_permissions json in
+    let* steps =
+      match Cn_json.get "steps" json with
+      | None -> Error "missing 'steps'"
+      | Some (Cn_json.Array items) ->
+          let rec collect acc = function
+            | [] -> Ok (List.rev acc)
+            | s :: rest ->
+                (match parse_step s with
+                 | Ok step -> collect (step :: acc) rest
+                 | Error e -> Error e)
+          in
+          collect [] items
+      | Some _ -> Error "'steps' is not an array"
+    in
+    Ok { kind; name; trigger; permissions; steps }
+
+let parse_file path =
+  if not (Cn_ffi.Fs.exists path) then
+    Error (Printf.sprintf "missing orchestrator file: %s" path)
+  else
+    match Cn_json.parse (Cn_ffi.Fs.read path) with
+    | Error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+    | Ok json -> parse json
+
+(* === Validation === *)
+
+type issue_kind =
+  | Missing_field of string
+  | Unknown_step_kind of string
+  | Duplicate_step_id of string
+  | Invalid_step_ref of string
+  | Permission_gap of string
+  | Llm_without_permission
+  | Empty_steps
+
+type issue = {
+  issue_kind : issue_kind;
+  message : string;
+}
+
+let step_id = function
+  | Op_step s -> s.id
+  | Llm_step s -> s.id
+  | If_step s -> s.id
+  | Match_step s -> s.id
+  | Return_step s -> s.id
+  | Fail_step s -> s.id
+
+let validate (o : orchestrator) =
+  let issues = ref [] in
+  let add kind message =
+    issues := { issue_kind = kind; message } :: !issues
+  in
+
+  if o.steps = [] then
+    add Empty_steps "orchestrator has no steps"
+  else begin
+    (* Duplicate step ids *)
+    let seen = Hashtbl.create 16 in
+    o.steps |> List.iter (fun s ->
+      let id = step_id s in
+      if Hashtbl.mem seen id then
+        add (Duplicate_step_id id)
+          (Printf.sprintf "duplicate step id: %s" id)
+      else
+        Hashtbl.add seen id ());
+
+    (* Invalid step refs: if/match targets must exist *)
+    let all_ids = Hashtbl.create 16 in
+    o.steps |> List.iter (fun s ->
+      Hashtbl.replace all_ids (step_id s) ());
+    let check_ref target =
+      if not (Hashtbl.mem all_ids target) then
+        add (Invalid_step_ref target)
+          (Printf.sprintf "step ref '%s' does not resolve" target)
+    in
+    o.steps |> List.iter (function
+      | If_step s ->
+          check_ref s.then_ref;
+          check_ref s.else_ref
+      | Match_step s ->
+          List.iter (fun (_, ref) -> check_ref ref) s.cases;
+          (match s.default with
+           | Some ref -> check_ref ref
+           | None -> ())
+      | _ -> ());
+
+    (* Permission gaps *)
+    o.steps |> List.iter (function
+      | Op_step s ->
+          if not (List.mem s.op o.permissions.ops) then
+            add (Permission_gap s.op)
+              (Printf.sprintf "step '%s' uses op '%s' not in permissions.ops"
+                 s.id s.op)
+      | Llm_step s when not o.permissions.llm ->
+          add Llm_without_permission
+            (Printf.sprintf "step '%s' is an llm step but permissions.llm=false"
+               s.id)
+      | _ -> ())
+  end;
+
+  List.rev !issues
+
+(* === Discovery === *)
+
+type load_outcome =
+  | Loaded of orchestrator
+  | Load_error of string
+
+type installed = {
+  package : string;
+  id : string;
+  path : string;
+  outcome : load_outcome;
+}
+
+(** Read the list of declared orchestrator ids from a package manifest.
+    Returns [] when the field is missing or malformed (cn_deps doctor
+    covers malformed-manifest reporting). *)
+let manifest_orchestrator_ids ~pkg_name json =
+  match Cn_json.get "sources" json with
+  | None -> []
+  | Some sources ->
+      match Cn_json.get "orchestrators" sources with
+      | None -> []
+      | Some (Cn_json.Array items) ->
+          items |> List.filter_map (function
+            | Cn_json.String s -> Some s
+            | other ->
+                Printf.eprintf
+                  "cn: workflow: package %s: sources.orchestrators entry is \
+                   not a string (%s), skipping\n"
+                  pkg_name (Cn_json.to_string other);
+                None)
+      | Some _ ->
+          Printf.eprintf
+            "cn: workflow: package %s: sources.orchestrators is not an array, ignoring\n"
+            pkg_name;
+          []
+
+let discover ~hub_path =
+  Cn_assets.list_installed_packages hub_path
+  |> List.concat_map (fun (pkg_name, pkg_dir) ->
+    let manifest_path = Cn_ffi.Path.join pkg_dir "cn.package.json" in
+    if not (Cn_ffi.Fs.exists manifest_path) then []
+    else
+      match Cn_json.parse (Cn_ffi.Fs.read manifest_path) with
+      | Error msg ->
+          Printf.eprintf
+            "cn: workflow: package %s: cannot parse %s: %s\n"
+            pkg_name manifest_path msg;
+          []
+      | Ok json ->
+          manifest_orchestrator_ids ~pkg_name json
+          |> List.map (fun orch_id ->
+            let path = Cn_ffi.Path.join pkg_dir
+              (Printf.sprintf "orchestrators/%s/orchestrator.json" orch_id) in
+            let outcome = match parse_file path with
+              | Ok o -> Loaded o
+              | Error msg -> Load_error msg
+            in
+            { package = pkg_name; id = orch_id; path; outcome }))
+
+(* === Doctor validation === *)
+
+(** Collect a doctor-facing summary of every installed orchestrator:
+    load failures and schema-level issues each become a line. *)
+let doctor_issues ~hub_path =
+  discover ~hub_path
+  |> List.concat_map (fun i ->
+    match i.outcome with
+    | Load_error msg ->
+        [ Printf.sprintf "%s/%s: %s" i.package i.id msg ]
+    | Loaded o ->
+        validate o
+        |> List.map (fun (iss : issue) ->
+          Printf.sprintf "%s/%s: %s" i.package i.id iss.message))
+
+(* === Execution === *)
+
+type outcome =
+  | Completed of Cn_json.t
+  | Failed of string
+
+(** Build a [Cn_shell.typed_op] from an [Op_step] invocation. *)
+let typed_op_of_op_step ~op_kind (op_name : string) (args : (string * Cn_json.t) list) =
+  { Cn_shell.kind = op_kind;
+    op_id = Some (Printf.sprintf "orch-%s" op_name);
+    fields = args }
+
+let trace_event ~component ~event ~status ~reason ~details =
+  let reason_opt = if reason = "" then None else Some reason in
+  Cn_trace.gemit
+    ~component
+    ~layer:Cn_trace.Body
+    ~event
+    ~severity:Cn_trace.Info
+    ~status
+    ?reason:reason_opt
+    ~details
+    ()
+
+(** Look up a step by id. Returns [None] if not found. *)
+let find_step orch id =
+  List.find_opt (fun s -> step_id s = id) orch.steps
+
+(** Render a bound-value reference in an [if]/[match] step. The
+    environment holds JSON values, and the condition/input names refer
+    to either a previously bound name or the literal string in the IR.
+    v1 keeps this simple: look up by name, return [None] if not bound. *)
+let env_get (env : (string * Cn_json.t) list) name =
+  List.assoc_opt name env
+
+(** Convert a bound value to a boolean for [if]-step cond. *)
+let as_bool = function
+  | Cn_json.Bool b -> b
+  | Cn_json.String "true" -> true
+  | Cn_json.String "false" -> false
+  | Cn_json.Int 0 -> false
+  | Cn_json.Int _ -> true
+  | Cn_json.Null -> false
+  | _ -> true
+
+(** Convert a bound value to a string for [match]-step input. *)
+let as_string = function
+  | Cn_json.String s -> s
+  | Cn_json.Bool true -> "true"
+  | Cn_json.Bool false -> "false"
+  | Cn_json.Int i -> string_of_int i
+  | Cn_json.Null -> "null"
+  | v -> Cn_json.to_string v
+
+(** Execute one step, producing either a new environment + next step
+    id, or a terminal outcome. *)
+let rec execute_step ~hub_path ~shell_config (o : orchestrator) env step =
+  let name = o.name in
+  let id = step_id step in
+  trace_event
+    ~component:"workflow"
+    ~event:"workflow.step.start"
+    ~status:Cn_trace.Ok_
+    ~reason:""
+    ~details:[
+      "workflow", Cn_json.String name;
+      "step_id", Cn_json.String id;
+    ];
+  match step with
+  | Return_step s ->
+      trace_event
+        ~component:"workflow"
+        ~event:"workflow.step.complete"
+        ~status:Cn_trace.Ok_
+        ~reason:""
+        ~details:[
+          "workflow", Cn_json.String name;
+          "step_id", Cn_json.String s.id;
+          "terminal", Cn_json.String "return";
+        ];
+      `Terminal (Completed s.value)
+
+  | Fail_step s ->
+      trace_event
+        ~component:"workflow"
+        ~event:"workflow.step.complete"
+        ~status:Cn_trace.Error_status
+        ~reason:s.message
+        ~details:[
+          "workflow", Cn_json.String name;
+          "step_id", Cn_json.String s.id;
+          "terminal", Cn_json.String "fail";
+        ];
+      `Terminal (Failed (Printf.sprintf "workflow fail at step '%s': %s"
+                           s.id s.message))
+
+  | Op_step s ->
+      (* Permission gate — defence in depth; validator also flags. *)
+      if not (List.mem s.op o.permissions.ops) then begin
+        trace_event
+          ~component:"workflow"
+          ~event:"workflow.step.complete"
+          ~status:Cn_trace.Blocked
+          ~reason:"permission_gap"
+          ~details:[
+            "workflow", Cn_json.String name;
+            "step_id", Cn_json.String s.id;
+            "op", Cn_json.String s.op;
+          ];
+        `Terminal (Failed (Printf.sprintf
+          "workflow '%s' step '%s': op '%s' not permitted by permissions.ops"
+          name s.id s.op))
+      end else
+        (match Cn_shell.op_kind_of_string s.op with
+         | None ->
+             `Terminal (Failed (Printf.sprintf
+               "workflow '%s' step '%s': unknown op '%s'"
+               name s.id s.op))
+         | Some op_kind ->
+             let top = typed_op_of_op_step ~op_kind s.op s.args in
+             let trigger_id = Printf.sprintf "workflow-%s-%s" name s.id in
+             let receipt =
+               Cn_executor.execute_op
+                 ~hub_path
+                 ~trigger_id
+                 ~config:shell_config
+                 top
+             in
+             (match receipt.status with
+              | Cn_shell.Ok_status ->
+                  let artifacts_json =
+                    receipt.artifacts
+                    |> List.map (fun (a : Cn_shell.artifact) ->
+                      Cn_json.Object [
+                        "path", Cn_json.String a.path;
+                        "hash", Cn_json.String a.hash;
+                        "size", Cn_json.Int a.size;
+                      ])
+                  in
+                  let bound =
+                    Cn_json.Object [
+                      "status", Cn_json.String "ok";
+                      "kind", Cn_json.String receipt.kind;
+                      "artifacts", Cn_json.Array artifacts_json;
+                    ]
+                  in
+                  let env' = match s.bind with
+                    | Some key -> (key, bound) :: env
+                    | None -> env
+                  in
+                  trace_event
+                    ~component:"workflow"
+                    ~event:"workflow.step.complete"
+                    ~status:Cn_trace.Ok_
+                    ~reason:""
+                    ~details:[
+                      "workflow", Cn_json.String name;
+                      "step_id", Cn_json.String s.id;
+                      "op", Cn_json.String s.op;
+                      "bind", Cn_json.String (Option.value s.bind ~default:"");
+                    ];
+                  `Continue (env', next_step_after o s.id)
+              | _ ->
+                  trace_event
+                    ~component:"workflow"
+                    ~event:"workflow.step.complete"
+                    ~status:Cn_trace.Error_status
+                    ~reason:receipt.reason
+                    ~details:[
+                      "workflow", Cn_json.String name;
+                      "step_id", Cn_json.String s.id;
+                      "op", Cn_json.String s.op;
+                    ];
+                  `Terminal (Failed (Printf.sprintf
+                    "workflow '%s' step '%s': op '%s' failed: %s"
+                    name s.id s.op receipt.reason))))
+
+  | Llm_step s ->
+      (* v1 stub: parsed + validated + permission-checked, but not
+         executed. The prompt + context injection mechanism is still
+         being designed (PLAN-174 §Risk). *)
+      trace_event
+        ~component:"workflow"
+        ~event:"workflow.step.complete"
+        ~status:Cn_trace.Error_status
+        ~reason:"llm_not_implemented"
+        ~details:[
+          "workflow", Cn_json.String name;
+          "step_id", Cn_json.String s.id;
+        ];
+      `Terminal (Failed (Printf.sprintf
+        "workflow '%s' step '%s': llm step not yet implemented in this release"
+        name s.id))
+
+  | If_step s ->
+      let cond_val = env_get env s.cond in
+      let branch = match cond_val with
+        | Some v -> if as_bool v then s.then_ref else s.else_ref
+        | None ->
+            (* Unbound cond → treat as false, take else branch. This
+               is explicit default behaviour, not a silent skip. *)
+            s.else_ref
+      in
+      (match find_step o branch with
+       | Some target ->
+           trace_event
+             ~component:"workflow"
+             ~event:"workflow.step.complete"
+             ~status:Cn_trace.Ok_
+             ~reason:""
+             ~details:[
+               "workflow", Cn_json.String name;
+               "step_id", Cn_json.String s.id;
+               "branch", Cn_json.String branch;
+             ];
+           `Jump (env, target)
+       | None ->
+           `Terminal (Failed (Printf.sprintf
+             "workflow '%s' step '%s': branch target '%s' not found"
+             name s.id branch)))
+
+  | Match_step s ->
+      let input_val = env_get env s.input in
+      let key = match input_val with
+        | Some v -> as_string v
+        | None -> ""
+      in
+      let branch = match List.assoc_opt key s.cases, s.default with
+        | Some target, _ -> Some target
+        | None, Some d -> Some d
+        | None, None -> None
+      in
+      (match branch with
+       | None ->
+           `Terminal (Failed (Printf.sprintf
+             "workflow '%s' step '%s': no case for input '%s' and no default"
+             name s.id key))
+       | Some target ->
+           match find_step o target with
+           | Some tgt ->
+               trace_event
+                 ~component:"workflow"
+                 ~event:"workflow.step.complete"
+                 ~status:Cn_trace.Ok_
+                 ~reason:""
+                 ~details:[
+                   "workflow", Cn_json.String name;
+                   "step_id", Cn_json.String s.id;
+                   "branch", Cn_json.String target;
+                 ];
+               `Jump (env, tgt)
+           | None ->
+               `Terminal (Failed (Printf.sprintf
+                 "workflow '%s' step '%s': match target '%s' not found"
+                 name s.id target)))
+
+(** Return the step immediately following the given step id in the
+    manifest's step list, or [None] if this was the last step. *)
+and next_step_after o id =
+  let rec walk = function
+    | [] -> None
+    | s :: next :: _ when step_id s = id -> Some next
+    | _ :: rest -> walk rest
+  in
+  walk o.steps
+
+(** Execute the orchestrator from its first step. *)
+let execute ~hub_path ?(shell_config = Cn_shell.default_shell_config) o =
+  match o.steps with
+  | [] -> Failed (Printf.sprintf "workflow '%s' has no steps" o.name)
+  | first :: _ ->
+      let rec loop env step =
+        match execute_step ~hub_path ~shell_config o env step with
+        | `Terminal outcome -> outcome
+        | `Continue (env', Some next) -> loop env' next
+        | `Continue (_, None) ->
+            Failed (Printf.sprintf
+              "workflow '%s' step '%s' fell off the end without return/fail"
+              o.name (step_id step))
+        | `Jump (env', next) -> loop env' next
+      in
+      loop [] first

--- a/src/cmd/cn_workflow.ml
+++ b/src/cmd/cn_workflow.ml
@@ -45,12 +45,10 @@ type step =
       op : string;             (** op kind name e.g. "fs_read" *)
       args : (string * Cn_json.t) list;
       bind : string option;
-      inputs : string list;
     }
   | Llm_step of {
       id : string;
       prompt : string;
-      inputs : string list;
       bind : string option;
     }
   | If_step of {
@@ -132,13 +130,23 @@ let parse_step json =
         | _ -> []
       in
       let bind = Cn_json.get_string "bind" json in
-      let inputs = parse_string_list "inputs" json in
-      Ok (Op_step { id; op; args; bind; inputs })
+      (* Note: the `inputs` field (a string list referencing bound
+         names from prior steps) is accepted by the wire schema
+         (ORCHESTRATORS.md §8) but not yet consumed by the executor.
+         The binding-substitution mechanism is part of the `llm`
+         step design work deferred from this cycle. Once `llm` is
+         wired, `inputs` is re-added to the Op_step record with a
+         resolution pass from the environment into args. For now it
+         is silently accepted at parse time to preserve
+         forward-compatibility at the wire level. *)
+      ignore (parse_string_list "inputs" json);
+      Ok (Op_step { id; op; args; bind })
   | "llm" ->
       let* prompt = require_string "prompt" json in
-      let inputs = parse_string_list "inputs" json in
+      (* Same deferral as Op_step: inputs is accepted but not stored. *)
+      ignore (parse_string_list "inputs" json);
       let bind = Cn_json.get_string "bind" json in
-      Ok (Llm_step { id; prompt; inputs; bind })
+      Ok (Llm_step { id; prompt; bind })
   | "if" ->
       let* cond = require_string "cond" json in
       let* then_ref = require_string "then" json in
@@ -623,8 +631,14 @@ and next_step_after o id =
   in
   walk o.steps
 
-(** Execute the orchestrator from its first step. *)
-let execute ~hub_path ?(shell_config = Cn_shell.default_shell_config) o =
+(** Execute the orchestrator from its first step.
+
+    [env] supplies a pre-seeded binding environment; the default
+    [[]] starts clean. Tests use this to pre-bind scalars so the
+    [if] and [match] branches can be exercised directly without
+    needing a working [llm] step (which is deferred in v1). *)
+let execute ~hub_path ?(shell_config = Cn_shell.default_shell_config)
+            ?(env = []) o =
   match o.steps with
   | [] -> Failed (Printf.sprintf "workflow '%s' has no steps" o.name)
   | first :: _ ->
@@ -638,4 +652,4 @@ let execute ~hub_path ?(shell_config = Cn_shell.default_shell_config) o =
               o.name (step_id step))
         | `Jump (env', next) -> loop env' next
       in
-      loop [] first
+      loop env first

--- a/src/cmd/dune
+++ b/src/cmd/dune
@@ -8,6 +8,6 @@
           cn_orchestrator cn_indicator cn_projection cn_capabilities
           cn_assets cn_deps cn_trace cn_trace_state cn_build cn_output
           cn_runtime_contract cn_extension cn_ext_host
-          cn_activation cn_command cn_help cn_doctor
+          cn_activation cn_workflow cn_command cn_help cn_doctor
           cn_ulog cn_logs)
  (libraries cn_ffi cn_lib cn_protocol inbox_lib git cn_io cn_packet unix))

--- a/test/cmd/cn_runtime_contract_test.ml
+++ b/test/cmd/cn_runtime_contract_test.ml
@@ -416,21 +416,23 @@ let%expect_test "to_json: exec_enabled reflects shell_config" =
 (* ============================================================ *)
 
 (** Augment the with_test_hub fixture: declare commands + skills with
-    triggers in the cnos.core manifest, and create a SKILL.md with a
-    triggers frontmatter so the activation index is non-empty. *)
+    triggers + one orchestrator in the cnos.core manifest, and create
+    the backing SKILL.md / command script / orchestrator.json so the
+    activation index, command registry, and orchestrator registry are
+    each non-empty. *)
 let with_activation_hub f =
   with_test_hub (fun hub ->
     let v = Cn_lib.version in
     let core = Printf.sprintf ".cn/vendor/packages/cnos.core@%s" v in
     let core_dir = Filename.concat hub core in
-    (* Override the manifest with one that declares commands +
-       orchestrators + skills (so the activation index has something). *)
+    (* New-schema manifest: orchestrators is a string array of ids;
+       the per-id metadata lives in orchestrators/<id>/orchestrator.json. *)
     let manifest = Printf.sprintf
       "{\"schema\":\"cn.package.v1\",\"name\":\"cnos.core\",\"version\":\"%s\",\
        \"sources\":{\
        \"skills\":[\"reflect\"],\
        \"commands\":{\"daily\":{\"entrypoint\":\"commands/cn-daily\",\"summary\":\"daily\"}},\
-       \"orchestrators\":[{\"name\":\"daily-review\",\"trigger_kinds\":[\"command\",\"schedule\"]}]}}"
+       \"orchestrators\":[\"daily-review\"]}}"
       v in
     let oc = open_out (Filename.concat core_dir "cn.package.json") in
     output_string oc manifest;
@@ -445,6 +447,16 @@ let with_activation_hub f =
     output_string oc "#!/bin/sh\necho daily\n";
     close_out oc;
     Unix.chmod (Filename.concat core_dir "commands/cn-daily") 0o755;
+    Cn_ffi.Fs.ensure_dir
+      (Filename.concat core_dir "orchestrators/daily-review");
+    let oc = open_out
+      (Filename.concat core_dir "orchestrators/daily-review/orchestrator.json") in
+    output_string oc
+      "{\"kind\":\"cn.orchestrator.v1\",\"name\":\"daily-review\",\
+       \"trigger\":{\"kind\":\"command\",\"name\":\"daily\"},\
+       \"permissions\":{\"llm\":false,\"ops\":[],\"external_effects\":false},\
+       \"steps\":[{\"id\":\"done\",\"kind\":\"return\",\"value\":{\"ok\":true}}]}";
+    close_out oc;
     f hub)
 
 let%expect_test "to_json: cognition.activation_index includes exposed skills (#173)" =
@@ -521,24 +533,11 @@ let%expect_test "render_markdown: activation_index nests under skills header (#1
     has_reflect=true
     has_trigger=true |}]
 
-let%expect_test "to_json: orchestrators include declared entries and skip malformed (#173, F4)" =
-  with_test_hub (fun hub ->
-    let v = Cn_lib.version in
-    let core_dir = Filename.concat hub
-      (Printf.sprintf ".cn/vendor/packages/cnos.core@%s" v) in
-    (* Manifest declaring two orchestrators: one well-formed, one
-       missing the required "name" field. Builder must emit the first
-       and log-skip the second. *)
-    let manifest = Printf.sprintf
-      "{\"schema\":\"cn.package.v1\",\"name\":\"cnos.core\",\"version\":\"%s\",\
-       \"sources\":{\"orchestrators\":[\
-       {\"name\":\"daily-review\",\"trigger_kinds\":[\"command\",\"schedule\"]},\
-       {\"trigger_kinds\":[\"command\"]}\
-       ]}}"
-      v in
-    let oc = open_out (Filename.concat core_dir "cn.package.json") in
-    output_string oc manifest;
-    close_out oc;
+let%expect_test "to_json: orchestrators populated from Cn_workflow.discover (#174)" =
+  (* with_activation_hub installs a one-step daily-review orchestrator
+     that parses and validates cleanly. Registry should carry one entry
+     with trigger_kinds derived from the orchestrator's trigger.kind. *)
+  with_activation_hub (fun hub ->
     let assets = Cn_assets.summarize ~hub_path:hub in
     let c = Cn_runtime_contract.gather ~hub_path:hub
               ~shell_config:default_shell_config ~assets ~peers:[] () in
@@ -565,10 +564,9 @@ let%expect_test "to_json: orchestrators include declared entries and skip malfor
       | _ -> print_endline "orchestrators not array");
   [%expect {|
     count=1
-    name=daily-review pkg=cnos.core trigger_kinds=[command,schedule]
-    cn: runtime_contract: package cnos.core: orchestrator entry missing 'name' field, skipping |}]
+    name=daily-review pkg=cnos.core trigger_kinds=[command] |}]
 
-let%expect_test "to_json: orchestrators empty when sources.orchestrators absent (#173, F4)" =
+let%expect_test "to_json: orchestrators empty when sources.orchestrators absent (#174)" =
   with_test_hub (fun hub ->
     let v = Cn_lib.version in
     let core_dir = Filename.concat hub
@@ -592,40 +590,30 @@ let%expect_test "to_json: orchestrators empty when sources.orchestrators absent 
     | None -> print_endline "no body");
   [%expect {| count=0 |}]
 
-let%expect_test "to_json: trigger_kinds non-string elements logged and skipped (R2)" =
+let%expect_test "to_json: orchestrator load failures omitted from registry (#174)" =
+  (* A declared orchestrator with a missing orchestrator.json must
+     not crash the registry build; it is simply omitted (doctor
+     surfaces the gap separately). *)
   with_test_hub (fun hub ->
     let v = Cn_lib.version in
     let core_dir = Filename.concat hub
       (Printf.sprintf ".cn/vendor/packages/cnos.core@%s" v) in
-    (* Valid orchestrator entry, but trigger_kinds carries one number
-       between two strings. Builder must keep the strings, log-skip
-       the number, and not crash. *)
     let manifest = Printf.sprintf
       "{\"schema\":\"cn.package.v1\",\"name\":\"cnos.core\",\"version\":\"%s\",\
-       \"sources\":{\"orchestrators\":[\
-       {\"name\":\"mixed\",\"trigger_kinds\":[\"command\",42,\"schedule\"]}\
-       ]}}" v in
+       \"sources\":{\"orchestrators\":[\"ghost\"]}}" v in
     let oc = open_out (Filename.concat core_dir "cn.package.json") in
     output_string oc manifest;
     close_out oc;
+    (* No orchestrators/ghost/orchestrator.json on disk. *)
     let assets = Cn_assets.summarize ~hub_path:hub in
     let c = Cn_runtime_contract.gather ~hub_path:hub
               ~shell_config:default_shell_config ~assets ~peers:[] () in
     let json = Cn_runtime_contract.to_json ~shell_config:default_shell_config c in
     match Cn_json.get "body" json with
-    | None -> print_endline "no body"
     | Some body ->
-      match Cn_json.get "orchestrators" body with
-      | Some (Cn_json.Array items) ->
-        items |> List.iter (fun entry ->
-          let tks = match Cn_json.get "trigger_kinds" entry with
-            | Some (Cn_json.Array xs) ->
-              xs |> List.filter_map (function
-                | Cn_json.String s -> Some s | _ -> None)
-            | _ -> []
-          in
-          Printf.printf "trigger_kinds=[%s]\n" (String.concat "," tks))
-      | _ -> print_endline "orchestrators not array");
-  [%expect {|
-    trigger_kinds=[command,schedule]
-    cn: runtime_contract: package cnos.core: orchestrator mixed: trigger_kinds entry is not a string (42), skipping |}]
+      (match Cn_json.get "orchestrators" body with
+       | Some (Cn_json.Array xs) ->
+         Printf.printf "count=%d\n" (List.length xs)
+       | _ -> print_endline "orchestrators not array")
+    | None -> print_endline "no body");
+  [%expect {| count=0 |}]

--- a/test/cmd/cn_workflow_test.ml
+++ b/test/cmd/cn_workflow_test.ml
@@ -1,0 +1,417 @@
+(** cn_workflow_test: ppx_expect tests for the orchestrator IR runtime.
+
+    Module under test: [Cn_workflow]. The module implements the
+    [cn.orchestrator.v1] IR specified in ORCHESTRATORS.md §7-8 as
+    types + parser + validator + discovery + executor.
+
+    Naming note: the existing [Cn_orchestrator] module is the N-pass
+    LLM bind-loop orchestrator. [Cn_workflow] is the mechanical
+    workflow runtime. Two different concerns, two different modules.
+
+    Stages (per PLAN-174-orchestrator-runtime.md):
+      F* / V* / D* — Stage A (parser, validator, discovery)
+      X*          — Stage B (execution)
+      S*          — Stage C (shipped orchestrator) *)
+
+(* === Temp dir + file helpers === *)
+
+let mk_temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  Random.self_init ();
+  let rec attempt k =
+    if k = 0 then failwith "mk_temp_dir: exhausted";
+    let dir = Filename.concat base
+      (Printf.sprintf "%s-%d-%06d" prefix (Unix.getpid ()) (Random.int 1_000_000)) in
+    try Unix.mkdir dir 0o700; dir
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> attempt (k - 1)
+  in
+  attempt 50
+
+let rec rm_tree path =
+  if Sys.file_exists path then begin
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun e ->
+        rm_tree (Filename.concat path e));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  end
+
+let ensure_dir path =
+  let rec mk p =
+    if not (Sys.file_exists p) then begin
+      mk (Filename.dirname p);
+      try Unix.mkdir p 0o755
+      with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  mk path
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let with_test_hub f =
+  let hub = mk_temp_dir "cn-wf-test" in
+  Fun.protect ~finally:(fun () ->
+    try rm_tree hub
+    with exn ->
+      Printf.eprintf "test cleanup: %s: %s\n" hub (Printexc.to_string exn))
+    (fun () -> f hub)
+
+(** Install a vendored package declaring one orchestrator. The
+    orchestrator JSON content is supplied by the caller so
+    tests can construct malformed cases. *)
+let install_orch ~hub ~pkg_name ~pkg_version ~orch_id ~content =
+  let pkg_dir = Filename.concat hub
+    (Printf.sprintf ".cn/vendor/packages/%s@%s" pkg_name pkg_version) in
+  ensure_dir pkg_dir;
+  let manifest = Printf.sprintf
+    "{\"schema\":\"cn.package.v1\",\"name\":\"%s\",\"version\":\"%s\",\
+     \"sources\":{\"orchestrators\":[\"%s\"]}}"
+    pkg_name pkg_version orch_id in
+  write_file (Filename.concat pkg_dir "cn.package.json") manifest;
+  let path = Filename.concat pkg_dir
+    (Printf.sprintf "orchestrators/%s/orchestrator.json" orch_id) in
+  write_file path content;
+  pkg_dir
+
+let minimal_json =
+  {|{
+    "kind": "cn.orchestrator.v1",
+    "name": "sample",
+    "trigger": { "kind": "command", "name": "sample" },
+    "permissions": { "llm": false, "ops": ["fs_read"], "external_effects": false },
+    "steps": [
+      { "id": "read", "kind": "op", "op": "fs_read",
+        "args": { "path": "README.md" }, "bind": "body" },
+      { "id": "done", "kind": "return", "value": { "artifact": "README.md" } }
+    ]
+  }|}
+
+let has_substring s sub =
+  let sl = String.length s and bl = String.length sub in
+  let rec check i =
+    if i > sl - bl then false
+    else if String.sub s i bl = sub then true
+    else check (i + 1)
+  in bl <= sl && check 0
+
+let ok_exn = function
+  | Ok v -> v
+  | Error msg -> failwith ("expected Ok, got Error: " ^ msg)
+
+(* === Stage A: parser === *)
+
+let%expect_test "F1 parse minimal orchestrator" =
+  let json = Cn_json.parse minimal_json |> ok_exn in
+  let o = Cn_workflow.parse json |> ok_exn in
+  Printf.printf "kind=%s\n" o.kind;
+  Printf.printf "name=%s\n" o.name;
+  Printf.printf "steps=%d\n" (List.length o.steps);
+  Printf.printf "llm_permitted=%b\n" o.permissions.llm;
+  Printf.printf "ops_permitted=%s\n" (String.concat "," o.permissions.ops);
+  [%expect {|
+    kind=cn.orchestrator.v1
+    name=sample
+    steps=2
+    llm_permitted=false
+    ops_permitted=fs_read |}]
+
+let%expect_test "F2 parse rejects missing name" =
+  let bad = {|{"kind":"cn.orchestrator.v1","steps":[]}|} in
+  let json = Cn_json.parse bad |> ok_exn in
+  (match Cn_workflow.parse json with
+   | Ok _ -> print_endline "UNEXPECTED ok"
+   | Error msg ->
+     Printf.printf "mentions_name=%b\n" (has_substring msg "name"));
+  [%expect {| mentions_name=true |}]
+
+let%expect_test "F3 parse rejects unknown step kind" =
+  let bad = {|{
+    "kind":"cn.orchestrator.v1","name":"x",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":[{"id":"a","kind":"telepathy"}]
+  }|} in
+  let json = Cn_json.parse bad |> ok_exn in
+  (match Cn_workflow.parse json with
+   | Ok _ -> print_endline "UNEXPECTED ok"
+   | Error msg ->
+     Printf.printf "mentions_telepathy=%b\n" (has_substring msg "telepathy"));
+  [%expect {| mentions_telepathy=true |}]
+
+let%expect_test "F4 parse rejects non-array steps" =
+  let bad = {|{
+    "kind":"cn.orchestrator.v1","name":"x",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":"not an array"
+  }|} in
+  let json = Cn_json.parse bad |> ok_exn in
+  (match Cn_workflow.parse json with
+   | Ok _ -> print_endline "UNEXPECTED ok"
+   | Error _ -> print_endline "rejected");
+  [%expect {| rejected |}]
+
+let%expect_test "F5 parse accepts llm + if + match + fail step shapes" =
+  let src = {|{
+    "kind":"cn.orchestrator.v1","name":"all",
+    "trigger":{"kind":"command","name":"all"},
+    "permissions":{"llm":true,"ops":[],"external_effects":false},
+    "steps":[
+      {"id":"ask","kind":"llm","prompt":"demo","inputs":["today"],"bind":"a"},
+      {"id":"branch","kind":"if","cond":"a","then":"done","else":"err"},
+      {"id":"pick","kind":"match","input":"a","cases":{"one":"done","two":"err"},"default":"err"},
+      {"id":"done","kind":"return","value":{"ok":true}},
+      {"id":"err","kind":"fail","message":"boom"}
+    ]
+  }|} in
+  let json = Cn_json.parse src |> ok_exn in
+  let o = Cn_workflow.parse json |> ok_exn in
+  let kinds = o.steps |> List.map (function
+    | Cn_workflow.Op_step _ -> "op"
+    | Cn_workflow.Llm_step _ -> "llm"
+    | Cn_workflow.If_step _ -> "if"
+    | Cn_workflow.Match_step _ -> "match"
+    | Cn_workflow.Return_step _ -> "return"
+    | Cn_workflow.Fail_step _ -> "fail") in
+  Printf.printf "kinds=%s\n" (String.concat "," kinds);
+  [%expect {| kinds=llm,if,match,return,fail |}]
+
+(* === Stage A: validator === *)
+
+let parse_or_fail src =
+  Cn_workflow.parse (Cn_json.parse src |> ok_exn) |> ok_exn
+
+let any_issue ~kind (issues : Cn_workflow.issue list) =
+  List.exists (fun (i : Cn_workflow.issue) -> i.issue_kind = kind) issues
+
+let%expect_test "V1 validate flags duplicate step ids" =
+  let o = parse_or_fail {|{
+    "kind":"cn.orchestrator.v1","name":"dup",
+    "trigger":{"kind":"command","name":"dup"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":[
+      {"id":"same","kind":"return","value":{}},
+      {"id":"same","kind":"fail","message":"never"}
+    ]
+  }|} in
+  let issues = Cn_workflow.validate o in
+  let has = List.exists (fun (i : Cn_workflow.issue) ->
+    match i.issue_kind with
+    | Cn_workflow.Duplicate_step_id _ -> true
+    | _ -> false) issues in
+  Printf.printf "duplicate_reported=%b\n" has;
+  [%expect {| duplicate_reported=true |}]
+
+let%expect_test "V2 validate flags if-step pointing at nonexistent step" =
+  let o = parse_or_fail {|{
+    "kind":"cn.orchestrator.v1","name":"badref",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":[
+      {"id":"choose","kind":"if","cond":"flag","then":"ghost","else":"done"},
+      {"id":"done","kind":"return","value":{}}
+    ]
+  }|} in
+  let issues = Cn_workflow.validate o in
+  let has = List.exists (fun (i : Cn_workflow.issue) ->
+    match i.issue_kind with
+    | Cn_workflow.Invalid_step_ref _ -> true
+    | _ -> false) issues in
+  Printf.printf "invalid_ref_reported=%b\n" has;
+  [%expect {| invalid_ref_reported=true |}]
+
+let%expect_test "V3 validate flags op not in permissions.ops" =
+  let o = parse_or_fail {|{
+    "kind":"cn.orchestrator.v1","name":"permgap",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":["fs_read"],"external_effects":false},
+    "steps":[
+      {"id":"write","kind":"op","op":"fs_write","args":{"path":"x","content":"y"}},
+      {"id":"done","kind":"return","value":{}}
+    ]
+  }|} in
+  let issues = Cn_workflow.validate o in
+  let has = List.exists (fun (i : Cn_workflow.issue) ->
+    match i.issue_kind with
+    | Cn_workflow.Permission_gap _ -> true
+    | _ -> false) issues in
+  Printf.printf "perm_gap_reported=%b\n" has;
+  [%expect {| perm_gap_reported=true |}]
+
+let%expect_test "V4 validate flags llm step when permissions.llm=false" =
+  let o = parse_or_fail {|{
+    "kind":"cn.orchestrator.v1","name":"llmgap",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":[
+      {"id":"ask","kind":"llm","prompt":"p","inputs":[],"bind":"a"},
+      {"id":"done","kind":"return","value":{}}
+    ]
+  }|} in
+  let issues = Cn_workflow.validate o in
+  let has = any_issue ~kind:Cn_workflow.Llm_without_permission issues in
+  Printf.printf "llm_perm_reported=%b\n" has;
+  [%expect {| llm_perm_reported=true |}]
+
+let%expect_test "V5 validate flags empty steps list" =
+  let o = parse_or_fail {|{
+    "kind":"cn.orchestrator.v1","name":"empty",
+    "trigger":{"kind":"command","name":"x"},
+    "permissions":{"llm":false,"ops":[],"external_effects":false},
+    "steps":[]
+  }|} in
+  let issues = Cn_workflow.validate o in
+  let has = any_issue ~kind:Cn_workflow.Empty_steps issues in
+  Printf.printf "empty_reported=%b\n" has;
+  [%expect {| empty_reported=true |}]
+
+(* === Stage A: discovery === *)
+
+let%expect_test "D1 discover reads orchestrator from vendored package" =
+  with_test_hub (fun hub ->
+    let _ = install_orch
+      ~hub ~pkg_name:"cnos.demo" ~pkg_version:"1.0.0"
+      ~orch_id:"sample" ~content:minimal_json in
+    let items = Cn_workflow.discover ~hub_path:hub in
+    Printf.printf "count=%d\n" (List.length items);
+    items |> List.iter (fun (i : Cn_workflow.installed) ->
+      let loaded = match i.outcome with
+        | Cn_workflow.Loaded _ -> true | _ -> false in
+      Printf.printf "%s/%s loaded=%b\n" i.package i.id loaded));
+  [%expect {|
+    count=1
+    cnos.demo/sample loaded=true |}]
+
+let%expect_test "D2 discover surfaces parse error per orchestrator" =
+  with_test_hub (fun hub ->
+    let _ = install_orch
+      ~hub ~pkg_name:"cnos.demo" ~pkg_version:"1.0.0"
+      ~orch_id:"broken" ~content:"{ not json" in
+    let items = Cn_workflow.discover ~hub_path:hub in
+    Printf.printf "count=%d\n" (List.length items);
+    items |> List.iter (fun (i : Cn_workflow.installed) ->
+      let failed = match i.outcome with
+        | Cn_workflow.Load_error _ -> true | _ -> false in
+      Printf.printf "%s/%s failed=%b\n" i.package i.id failed));
+  [%expect {|
+    count=1
+    cnos.demo/broken failed=true |}]
+
+let%expect_test "D3 discover surfaces missing orchestrator file" =
+  with_test_hub (fun hub ->
+    let pkg_dir = Filename.concat hub
+      ".cn/vendor/packages/cnos.demo@1.0.0" in
+    ensure_dir pkg_dir;
+    write_file (Filename.concat pkg_dir "cn.package.json")
+      "{\"schema\":\"cn.package.v1\",\"name\":\"cnos.demo\",\"version\":\"1.0.0\",\
+       \"sources\":{\"orchestrators\":[\"ghost\"]}}";
+    (* No orchestrators/ghost/orchestrator.json created. *)
+    let items = Cn_workflow.discover ~hub_path:hub in
+    Printf.printf "count=%d\n" (List.length items);
+    items |> List.iter (fun (i : Cn_workflow.installed) ->
+      let is_missing = match i.outcome with
+        | Cn_workflow.Load_error msg -> has_substring msg "missing"
+        | _ -> false in
+      Printf.printf "missing_reported=%b\n" is_missing));
+  [%expect {|
+    count=1
+    missing_reported=true |}]
+
+(* === Stage B: executor === *)
+
+let%expect_test "X1 execute: op step reads a file and binds the result" =
+  with_test_hub (fun hub ->
+    write_file (Filename.concat hub "hello.txt") "hi there\n";
+    let src = Printf.sprintf {|{
+      "kind":"cn.orchestrator.v1","name":"read-hello",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":["fs_read"],"external_effects":false},
+      "steps":[
+        {"id":"load","kind":"op","op":"fs_read","args":{"path":"hello.txt"},"bind":"body"},
+        {"id":"done","kind":"return","value":{"bound":"body"}}
+      ]
+    }|} in
+    let _ = src in
+    let o = parse_or_fail src in
+    let outcome = Cn_workflow.execute ~hub_path:hub o in
+    match outcome with
+    | Cn_workflow.Completed _ -> print_endline "completed"
+    | Cn_workflow.Failed msg -> Printf.printf "failed: %s\n" msg);
+  [%expect {| completed |}]
+
+let%expect_test "X2 execute: return step emits its value" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"just-return",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"done","kind":"return","value":{"k":"v"}}
+      ]
+    }|} in
+    match Cn_workflow.execute ~hub_path:hub o with
+    | Cn_workflow.Completed v ->
+      (match Cn_json.get_string "k" v with
+       | Some s -> Printf.printf "k=%s\n" s
+       | None -> print_endline "no k")
+    | Cn_workflow.Failed msg -> Printf.printf "failed: %s\n" msg);
+  [%expect {| k=v |}]
+
+let%expect_test "X3 execute: fail step → Failed outcome" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"just-fail",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"boom","kind":"fail","message":"intentional"}
+      ]
+    }|} in
+    match Cn_workflow.execute ~hub_path:hub o with
+    | Cn_workflow.Completed _ -> print_endline "UNEXPECTED completed"
+    | Cn_workflow.Failed msg ->
+      Printf.printf "mentions_intentional=%b\n" (has_substring msg "intentional"));
+  [%expect {| mentions_intentional=true |}]
+
+let%expect_test "X4 execute: permission gap — op not in permissions.ops" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"sneaky",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":["fs_read"],"external_effects":false},
+      "steps":[
+        {"id":"write","kind":"op","op":"fs_write",
+         "args":{"path":"evil.txt","content":"oops"}},
+        {"id":"done","kind":"return","value":{}}
+      ]
+    }|} in
+    (* The validator should already flag this; but execute() must
+       also refuse to dispatch the op — defence-in-depth. *)
+    match Cn_workflow.execute ~hub_path:hub o with
+    | Cn_workflow.Completed _ -> print_endline "UNEXPECTED completed"
+    | Cn_workflow.Failed msg ->
+      Printf.printf "mentions_permission=%b\n" (has_substring msg "permission"));
+  [%expect {| mentions_permission=true |}]
+
+let%expect_test "X5 execute: llm step — deferred, emits 'not implemented' failure" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"llm-demo",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":true,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"ask","kind":"llm","prompt":"demo","inputs":[],"bind":"a"},
+        {"id":"done","kind":"return","value":{}}
+      ]
+    }|} in
+    match Cn_workflow.execute ~hub_path:hub o with
+    | Cn_workflow.Completed _ -> print_endline "UNEXPECTED completed"
+    | Cn_workflow.Failed msg ->
+      Printf.printf "mentions_not_implemented=%b\n"
+        (has_substring msg "not yet implemented"));
+  [%expect {| mentions_not_implemented=true |}]

--- a/test/cmd/cn_workflow_test.ml
+++ b/test/cmd/cn_workflow_test.ml
@@ -415,3 +415,72 @@ let%expect_test "X5 execute: llm step — deferred, emits 'not implemented' fail
       Printf.printf "mentions_not_implemented=%b\n"
         (has_substring msg "not yet implemented"));
   [%expect {| mentions_not_implemented=true |}]
+
+let%expect_test "X6 execute: match step selects a case by bound scalar" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"match-case",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"pick","kind":"match","input":"flavor",
+         "cases":{"vanilla":"v","chocolate":"c"},"default":"d"},
+        {"id":"v","kind":"return","value":{"chose":"vanilla"}},
+        {"id":"c","kind":"return","value":{"chose":"chocolate"}},
+        {"id":"d","kind":"return","value":{"chose":"default"}}
+      ]
+    }|} in
+    match Cn_workflow.execute ~hub_path:hub
+            ~env:[("flavor", Cn_json.String "vanilla")] o with
+    | Cn_workflow.Failed msg -> Printf.printf "failed: %s\n" msg
+    | Cn_workflow.Completed v ->
+      Printf.printf "chose=%s\n"
+        (Cn_json.get_string "chose" v |> Option.value ~default:"?"));
+  [%expect {| chose=vanilla |}]
+
+let%expect_test "X7 execute: match step falls back to default when no case matches" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"match-default",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"pick","kind":"match","input":"flavor",
+         "cases":{"vanilla":"v","chocolate":"c"},"default":"d"},
+        {"id":"v","kind":"return","value":{"chose":"vanilla"}},
+        {"id":"c","kind":"return","value":{"chose":"chocolate"}},
+        {"id":"d","kind":"return","value":{"chose":"default"}}
+      ]
+    }|} in
+    match Cn_workflow.execute ~hub_path:hub
+            ~env:[("flavor", Cn_json.String "strawberry")] o with
+    | Cn_workflow.Failed msg -> Printf.printf "failed: %s\n" msg
+    | Cn_workflow.Completed v ->
+      Printf.printf "chose=%s\n"
+        (Cn_json.get_string "chose" v |> Option.value ~default:"?"));
+  [%expect {| chose=default |}]
+
+let%expect_test "X8 execute: if step branches on bound bool" =
+  with_test_hub (fun hub ->
+    let o = parse_or_fail {|{
+      "kind":"cn.orchestrator.v1","name":"if-branch",
+      "trigger":{"kind":"command","name":"x"},
+      "permissions":{"llm":false,"ops":[],"external_effects":false},
+      "steps":[
+        {"id":"choose","kind":"if","cond":"flag","then":"t","else":"f"},
+        {"id":"t","kind":"return","value":{"branch":"then"}},
+        {"id":"f","kind":"return","value":{"branch":"else"}}
+      ]
+    }|} in
+    let true_outcome = Cn_workflow.execute ~hub_path:hub
+      ~env:[("flag", Cn_json.Bool true)] o in
+    let false_outcome = Cn_workflow.execute ~hub_path:hub
+      ~env:[("flag", Cn_json.Bool false)] o in
+    let show outcome =
+      match outcome with
+      | Cn_workflow.Failed msg -> "fail:" ^ msg
+      | Cn_workflow.Completed v ->
+        Cn_json.get_string "branch" v |> Option.value ~default:"?"
+    in
+    Printf.printf "true=%s false=%s\n" (show true_outcome) (show false_outcome));
+  [%expect {| true=then false=else |}]

--- a/test/cmd/dune
+++ b/test/cmd/dune
@@ -168,6 +168,14 @@
  (inline_tests)
  (preprocess (pps ppx_expect)))
 
+; cn_workflow tests (ppx_expect) — orchestrator IR parser, validator, discovery, executor
+(library
+ (name cn_workflow_test)
+ (modules cn_workflow_test)
+ (libraries cn_cmd cn_ffi cn_lib unix)
+ (inline_tests)
+ (preprocess (pps ppx_expect)))
+
 ; cn_extension tests (ppx_expect) — extension manifest, registry, dispatch (Issue #73)
 (library
  (name cn_extension_test)


### PR DESCRIPTION
Closes #174. Parent: #170.

Implements `docs/alpha/agent-runtime/ORCHESTRATORS.md` §7–8 per the plan at `docs/alpha/agent-runtime/PLAN-174-orchestrator-runtime.md` and the §2.5a handoff posted on #174.

## What ships

**New module `src/cmd/cn_workflow.ml`** — the mechanical workflow engine for `cn.orchestrator.v1`. Parser + validator + discovery + executor in one module. Distinct from the pre-existing `Cn_orchestrator` (N-pass LLM bind loop). Different concern, different module.

**Content class** — `orchestrators` is now the 8th package content class. Declared as a string-id array in `sources.orchestrators`, copied by `cn build` from `src/agent/orchestrators/<id>/` to `packages/<name>/orchestrators/<id>/`.

**Runtime contract integration** — `build_orchestrator_registry` rewritten to consume `Cn_workflow.discover`, resolving the dueling-schema problem from #173 (the inline `[{name, trigger_kinds}]` array is replaced with the id-array + per-orchestrator JSON shape that ORCHESTRATORS.md §9 actually specifies).

**Doctor wiring** — `Cn_doctor.report_orchestrators` surfaces load failures + validator issues; any orchestrator issue is fail-stop.

**Shipped asset** — `src/agent/orchestrators/daily-review/orchestrator.json` (the §8.1 example from ORCHESTRATORS.md made real), mirrored into `packages/cnos.core/orchestrators/daily-review/`, declared in cnos.core's manifest.

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | #174 + ORCHESTRATORS.md §7–8 + PLAN-174 | cdd | No execution engine for mechanical workflows |
| 1 Select | #174 | cdd | L7, depends on #173 (shipped v3.35.0) |
| 2 Branch | `claude/174-orchestrator-runtime` | — | created from main at 29eeb29 |
| 3 Bootstrap | `docs/gamma/cdd/3.36.0/` | — | README + SELF-COHERENCE + GATE (PLAN lives in docs/alpha/) |
| 4 Gap | README §Gap | cdd | No runtime for cn.orchestrator.v1 |
| 5 Mode | README | cdd, eng/ocaml, eng/testing | MCA, L7; active skills loaded and read before writing |
| 6 Artifacts | tests → code → docs → self-coherence | eng/ocaml, eng/testing | Tests first per §2.5 artifact order |
| 7 Self-coherence | SELF-COHERENCE.md | cdd | α A · β A · γ A− |
| 8 Review | this PR body | cdd/review | Pending |
| 9 Gate | GATE.md | cdd/release | HOLD |
| 10 Release | — | — | Next release train |

## Acceptance Criteria

- [x] **AC1** `orchestrators/` content class in manifest + `cn build` (directory-tree copy like `skills`)
- [x] **AC2** `cn.orchestrator.v1` JSON schema defined and validated (parser + 5 validator categories)
- [x] **AC3** Step execution: `op`, `if`, `match`, `return`, `fail` run deterministically. **`llm` is a guarded stub** — parsed, validated, permission-checked, emits "not yet implemented in this release" at runtime. 5 of 6 step kinds executable. Honest debt.
- [x] **AC4** Permission manifest enforced before dispatch (defence in depth; validator also flags)
- [x] **AC5** Execution trace via `Cn_trace.gemit`: `workflow.step.start` + `workflow.step.complete` with step id, branch target, reason on failure, op name. No-op when no trace session (tests).
- [x] **AC6** `cn doctor` validates orchestrator manifests via `Cn_workflow.doctor_issues`
- [x] **AC7** `daily-review` orchestrator shipped (parses + doctor-validates cleanly; full execution deferred under AC3's `llm` stub)

## Self-coherence

α A · β A · γ A− — see `docs/gamma/cdd/3.36.0/SELF-COHERENCE.md`.

Honest minuses:
- **γ−**: same tooling gap as v3.34.0 / v3.35.0 — no OCaml toolchain in the authoring sandbox. Text-level review done (record field exhaustiveness, polymorphic-variant completeness, nested-match bracketing, cross-module references, grep for removed fields). **CI is the first compilation oracle.**

## Sibling audit (v3.32.0 convention)

Touching `cn_build.ml` triggered the sibling sweep: 5 pre-existing bare `with _ ->` catches surfaced (`copy_tree`, `rm_tree`, wildcard copy, `discover_packages`, `diff_tree` error path). All fixed with logged context.

Touched modules with zero bare catches: `cn_workflow.ml`, `cn_runtime_contract.ml`, `cn_doctor.ml`, `cn_build.ml`, `cn_command.ml`.

## Dueling-schema fix (#173 legacy)

#173's `build_orchestrator_registry` read `sources.orchestrators` as an array of inline objects `[{name, trigger_kinds}]` — inconsistent with ORCHESTRATORS.md §9 which specifies a string-id array. This PR rewrites `build_orchestrator_registry` to consume `Cn_workflow.discover`, matching the spec end-to-end. Three #173 tests that asserted the inline schema are replaced with equivalents that match the new shape:
- `to_json: orchestrators populated from Cn_workflow.discover (#174)`
- `to_json: orchestrators empty when sources.orchestrators absent (#174)`
- `to_json: orchestrator load failures omitted from registry (#174)`

`with_activation_hub` fixture updated to ship a real `daily-review` orchestrator.json so the registry has something to find.

## Test plan

Tests counted by `grep -c '%expect_test'`:

| File | Count | Covers |
|------|-------|--------|
| `test/cmd/cn_workflow_test.ml` (new) | 18 | F1–F5 parser, V1–V5 validator, D1–D3 discovery, X1–X5 executor |
| `test/cmd/cn_runtime_contract_test.ml` | 21 | Contract shape with registry projection |

- [ ] CI matrix builds `src/cli/cn.exe` on all 4 release targets
- [ ] `dune runtest` — all 18 new cn_workflow tests + 3 rewritten runtime_contract tests green
- [ ] `scripts/check-version-consistency.sh` passes
- [ ] On a hub with cnos.core installed: `cn doctor` → `Orchestrators: 1 healthy`
- [ ] `state/runtime-contract.json` body.orchestrators contains `{name: "daily-review", trigger_kinds: ["command"]}`
- [ ] Manually attempting to run daily-review end-to-end fails at the `llm` step with the "not yet implemented" message (AC3 deferral confirmed)

## Deferred / known debt

Documented in `SELF-COHERENCE.md` and `GATE.md`:
- **`llm` step execution** — needs prompt + context injection design. Parses, validates, permission-checks; runtime stub emits a clear failure message. **Next cycle's headline work.**
- **`parallel` step kind** — cnos has no async model. Deferred per plan.
- **`match` direct execution test** — branch is exercised by validator V2 for reference integrity; a direct X-series execution test for the `Match_step` happy path would tighten coverage.

## Self-verification gate

1. `grep -n "with _ " src/cmd/cn_workflow.ml src/cmd/cn_runtime_contract.ml src/cmd/cn_doctor.ml src/cmd/cn_build.ml src/cmd/cn_command.ml` → **0 matches**
2. Test count per new/touched module: **cn_workflow_test 18**, **cn_runtime_contract_test 21**
3. Frontmatter/IR parser handles: valid (F1/F5), missing required field (F2), unknown step kind (F3), malformed steps array (F4)
4. `cn build` — not runnable locally (no OCaml), but `src/agent/orchestrators/daily-review/orchestrator.json` is mirrored by hand into `packages/cnos.core/orchestrators/daily-review/` so CI's `cn build --check` should report clean
5. `dune build && dune runtest` — deferred to CI as the first compilation oracle