### PR TITLE
feat(#212): Go kernel Phase 3 Slice A — init + status commands

### DIFF
--- a/go/cmd/cn/main.go
+++ b/go/cmd/cn/main.go
@@ -15,6 +15,9 @@ import (
 	"github.com/usurobor/cnos/go/internal/cli"
 )
 
+// version is set at build time via -ldflags or defaults to "dev".
+var version = "dev"
+
 func main() {
 	ctx := context.Background()
 
@@ -22,7 +25,9 @@ func main() {
 	reg := cli.NewRegistry()
 	helpCmd := &cli.HelpCmd{Registry: reg}
 	reg.Register(helpCmd)
+	reg.Register(&cli.InitCmd{})
 	reg.Register(&cli.DepsCmd{})
+	reg.Register(&cli.StatusCmd{Version: version})
 
 	// Discover hub: walk up from cwd to find .cn/.
 	hubPath := discoverHub()

--- a/go/internal/cli/cmd_init.go
+++ b/go/internal/cli/cmd_init.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// InitCmd implements the "init" command — creates a new hub.
+type InitCmd struct{}
+
+func (c *InitCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "init",
+		Summary:  "Initialize a new hub",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: false,
+	}
+}
+
+func (c *InitCmd) Run(ctx context.Context, inv Invocation) error {
+	// Determine hub name from args or cwd.
+	var hubName string
+	if len(inv.Args) > 0 {
+		hubName = inv.Args[0]
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("init: cannot determine current directory: %w", err)
+		}
+		hubName = filepath.Base(cwd)
+	}
+
+	hubDir := "cn-" + hubName
+
+	// Check if directory already exists.
+	if _, err := os.Stat(hubDir); err == nil {
+		fmt.Fprintf(inv.Stderr, "✗ Directory %s already exists\n", hubDir)
+		return fmt.Errorf("init: directory %s already exists", hubDir)
+	}
+
+	fmt.Fprintf(inv.Stdout, "→ Initializing hub: %s\n", hubName)
+
+	// Create directory structure mirroring OCaml cn_system.ml::run_init.
+	dirs := []string{
+		".cn",
+		"spec",
+		"state",
+		"threads/in",
+		"threads/mail/inbox",
+		"threads/mail/outbox",
+		"threads/mail/sent",
+		"threads/reflections/daily",
+		"threads/reflections/weekly",
+		"threads/reflections/monthly",
+		"threads/adhoc",
+		"threads/archived",
+		"logs",
+		"agent",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(hubDir, d), 0755); err != nil {
+			return fmt.Errorf("init: create %s: %w", d, err)
+		}
+	}
+
+	// Write .cn/config.json.
+	config := map[string]string{
+		"name":    hubName,
+		"version": "1.0.0",
+		"created": time.Now().UTC().Format(time.RFC3339),
+	}
+	configData, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("init: marshal config: %w", err)
+	}
+	configPath := filepath.Join(hubDir, ".cn", "config.json")
+	if err := os.WriteFile(configPath, append(configData, '\n'), 0644); err != nil {
+		return fmt.Errorf("init: write config: %w", err)
+	}
+
+	// Write state/peers.md.
+	peersContent := `# Peers
+
+Agents and repos this hub communicates with.
+
+- name: cn-agent
+  hub: https://github.com/usurobor/cn-agent.git
+  kind: template
+`
+	peersPath := filepath.Join(hubDir, "state", "peers.md")
+	if err := os.WriteFile(peersPath, []byte(peersContent), 0644); err != nil {
+		return fmt.Errorf("init: write peers: %w", err)
+	}
+
+	// Write spec/SOUL.md stub.
+	soulContent := fmt.Sprintf(`# SOUL.md - Core Contract
+
+*%s is an agent on the Coherent Network.*
+
+## Identity
+
+- **Name:** %s
+- **Role:** (define your role)
+- **Mode:** Collaborative
+
+## Conduct
+
+- Be genuinely helpful
+`, hubName, hubName)
+	soulPath := filepath.Join(hubDir, "spec", "SOUL.md")
+	if err := os.WriteFile(soulPath, []byte(soulContent), 0644); err != nil {
+		return fmt.Errorf("init: write SOUL.md: %w", err)
+	}
+
+	// Initialize git repo.
+	gitCmd := exec.CommandContext(ctx, "git", "init", "-b", "main")
+	gitCmd.Dir = hubDir
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(inv.Stderr, "⚠ git init failed: %s\n", string(out))
+		// Non-fatal — hub is usable without git.
+	}
+
+	fmt.Fprintf(inv.Stdout, "✓ Hub initialized at %s\n", hubDir)
+	return nil
+}

--- a/go/internal/cli/cmd_init.go
+++ b/go/internal/cli/cmd_init.go
@@ -36,6 +36,9 @@ func (c *InitCmd) Run(ctx context.Context, inv Invocation) error {
 		hubName = filepath.Base(cwd)
 	}
 
+	// Hub directory uses the "cn-" prefix convention, matching OCaml
+	// cn_system.ml::run_init. This is the standard cnos hub naming:
+	// cn-<agent-name> (e.g., cn-sigma, cn-omega).
 	hubDir := "cn-" + hubName
 
 	// Check if directory already exists.
@@ -84,14 +87,16 @@ func (c *InitCmd) Run(ctx context.Context, inv Invocation) error {
 		return fmt.Errorf("init: write config: %w", err)
 	}
 
-	// Write state/peers.md.
+	// Write state/peers.md — minimal scaffold. Operators add peers
+	// manually; no hardcoded template peers that may not exist.
 	peersContent := `# Peers
 
 Agents and repos this hub communicates with.
+Add entries in the form:
 
-- name: cn-agent
-  hub: https://github.com/usurobor/cn-agent.git
-  kind: template
+  - name: <agent-name>
+    hub: <repo-url>
+    kind: peer
 `
 	peersPath := filepath.Join(hubDir, "state", "peers.md")
 	if err := os.WriteFile(peersPath, []byte(peersContent), 0644); err != nil {

--- a/go/internal/cli/cmd_init_test.go
+++ b/go/internal/cli/cmd_init_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitCreatesHub(t *testing.T) {
+	// Run init in a temp dir.
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
+	var stdout, stderr bytes.Buffer
+	inv := Invocation{
+		Args:   []string{"testbot"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	cmd := &InitCmd{}
+	if err := cmd.Run(context.Background(), inv); err != nil {
+		t.Fatalf("init: %v\nstderr: %s", err, stderr.String())
+	}
+
+	hubDir := filepath.Join(tmp, "cn-testbot")
+
+	// Check directory structure.
+	for _, d := range []string{".cn", "spec", "state", "threads/in", "logs", "agent"} {
+		if _, err := os.Stat(filepath.Join(hubDir, d)); err != nil {
+			t.Errorf("missing directory: %s", d)
+		}
+	}
+
+	// Check config.json.
+	configPath := filepath.Join(hubDir, ".cn", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"name": "testbot"`)) {
+		t.Errorf("config missing name: %s", string(data))
+	}
+
+	// Check SOUL.md.
+	soul, err := os.ReadFile(filepath.Join(hubDir, "spec", "SOUL.md"))
+	if err != nil {
+		t.Fatalf("read SOUL.md: %v", err)
+	}
+	if !bytes.Contains(soul, []byte("testbot")) {
+		t.Error("SOUL.md missing hub name")
+	}
+
+	// Check success message.
+	if !bytes.Contains(stdout.Bytes(), []byte("✓ Hub initialized")) {
+		t.Error("expected success message in stdout")
+	}
+}
+
+func TestInitAlreadyExists(t *testing.T) {
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
+	// Pre-create the directory.
+	os.MkdirAll(filepath.Join(tmp, "cn-existing"), 0755)
+
+	var stdout, stderr bytes.Buffer
+	inv := Invocation{
+		Args:   []string{"existing"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	cmd := &InitCmd{}
+	err := cmd.Run(context.Background(), inv)
+	if err == nil {
+		t.Fatal("expected error for existing directory")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("already exists")) {
+		t.Error("expected 'already exists' in stderr")
+	}
+}

--- a/go/internal/cli/cmd_init_test.go
+++ b/go/internal/cli/cmd_init_test.go
@@ -10,10 +10,13 @@ import (
 
 func TestInitCreatesHub(t *testing.T) {
 	// Run init in a temp dir.
+	// Note: os.Chdir mutates global state and is not parallel-safe.
+	// These tests must not use t.Parallel(). Acceptable because init
+	// is inherently a cwd-relative operation.
 	tmp := t.TempDir()
 	origDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origDir) })
 	os.Chdir(tmp)
-	defer os.Chdir(origDir)
 
 	var stdout, stderr bytes.Buffer
 	inv := Invocation{
@@ -64,8 +67,8 @@ func TestInitCreatesHub(t *testing.T) {
 func TestInitAlreadyExists(t *testing.T) {
 	tmp := t.TempDir()
 	origDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origDir) })
 	os.Chdir(tmp)
-	defer os.Chdir(origDir)
 
 	// Pre-create the directory.
 	os.MkdirAll(filepath.Join(tmp, "cn-existing"), 0755)

--- a/go/internal/cli/cmd_status.go
+++ b/go/internal/cli/cmd_status.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StatusCmd implements the "status" command — shows hub info + installed packages.
+type StatusCmd struct {
+	Version string // cnos version for drift detection
+}
+
+func (c *StatusCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "status",
+		Summary:  "Show hub status",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: true,
+	}
+}
+
+func (c *StatusCmd) Run(_ context.Context, inv Invocation) error {
+	hubName := filepath.Base(inv.HubPath)
+
+	fmt.Fprintf(inv.Stdout, "cn hub: %s\n\n", hubName)
+	fmt.Fprintf(inv.Stdout, "hub..................... ✓\n")
+	fmt.Fprintf(inv.Stdout, "name.................... ✓ %s\n", hubName)
+	fmt.Fprintf(inv.Stdout, "path.................... ✓ %s\n", inv.HubPath)
+
+	// List installed packages with version drift detection.
+	vendorDir := filepath.Join(inv.HubPath, ".cn", "vendor", "packages")
+	entries, err := os.ReadDir(vendorDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(inv.Stdout, "\nNo packages installed.\n")
+			return nil
+		}
+		return fmt.Errorf("status: read vendor dir: %w", err)
+	}
+
+	hasDrift := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		atIdx := strings.LastIndex(name, "@")
+		if atIdx < 0 {
+			continue
+		}
+		pkgName := name[:atIdx]
+		pkgVersion := name[atIdx+1:]
+
+		if c.Version != "" && pkgVersion != c.Version {
+			hasDrift = true
+			fmt.Fprintf(inv.Stdout, "%s................. ✗ %s (expected %s)\n",
+				pkgName, pkgVersion, c.Version)
+		} else {
+			fmt.Fprintf(inv.Stdout, "%s................. ✓ %s\n",
+				pkgName, pkgVersion)
+		}
+	}
+
+	fmt.Fprintln(inv.Stdout)
+	if hasDrift {
+		fmt.Fprintf(inv.Stdout, "⚠ version_drift version=%s\n", c.Version)
+	} else {
+		fmt.Fprintf(inv.Stdout, "ok version=%s\n", c.Version)
+	}
+
+	return nil
+}

--- a/go/internal/cli/cmd_status.go
+++ b/go/internal/cli/cmd_status.go
@@ -32,6 +32,10 @@ func (c *StatusCmd) Run(_ context.Context, inv Invocation) error {
 	fmt.Fprintf(inv.Stdout, "path.................... ✓ %s\n", inv.HubPath)
 
 	// List installed packages with version drift detection.
+	// Note: drift detection assumes all installed packages are first-party
+	// (version should match the binary version). This matches OCaml behavior
+	// in cn_system.ml::run_status. Third-party packages would need their
+	// own version authority — not yet supported.
 	vendorDir := filepath.Join(inv.HubPath, ".cn", "vendor", "packages")
 	entries, err := os.ReadDir(vendorDir)
 	if err != nil {

--- a/go/internal/cli/cmd_status_test.go
+++ b/go/internal/cli/cmd_status_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStatusShowsPackages(t *testing.T) {
+	hub := t.TempDir()
+
+	// Create fake installed packages.
+	for _, pkg := range []string{"cnos.core@3.45.0", "cnos.eng@3.45.0"} {
+		os.MkdirAll(filepath.Join(hub, ".cn", "vendor", "packages", pkg), 0755)
+	}
+
+	var stdout bytes.Buffer
+	inv := Invocation{
+		HubPath: hub,
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+
+	cmd := &StatusCmd{Version: "3.45.0"}
+	if err := cmd.Run(context.Background(), inv); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "cnos.core") {
+		t.Error("expected cnos.core in output")
+	}
+	if !strings.Contains(out, "cnos.eng") {
+		t.Error("expected cnos.eng in output")
+	}
+	if !strings.Contains(out, "✓ 3.45.0") {
+		t.Error("expected ✓ for matching version")
+	}
+	if strings.Contains(out, "version_drift") {
+		t.Error("should not show drift when versions match")
+	}
+}
+
+func TestStatusVersionDrift(t *testing.T) {
+	hub := t.TempDir()
+	os.MkdirAll(filepath.Join(hub, ".cn", "vendor", "packages", "cnos.core@3.42.0"), 0755)
+
+	var stdout bytes.Buffer
+	inv := Invocation{
+		HubPath: hub,
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+
+	cmd := &StatusCmd{Version: "3.45.0"}
+	cmd.Run(context.Background(), inv)
+
+	out := stdout.String()
+	if !strings.Contains(out, "✗ 3.42.0") {
+		t.Error("expected ✗ for version mismatch")
+	}
+	if !strings.Contains(out, "expected 3.45.0") {
+		t.Error("expected drift message")
+	}
+	if !strings.Contains(out, "version_drift") {
+		t.Error("expected version_drift warning")
+	}
+}
+
+func TestStatusNoPackages(t *testing.T) {
+	hub := t.TempDir()
+	// No .cn/vendor/packages/ dir at all.
+
+	var stdout bytes.Buffer
+	inv := Invocation{
+		HubPath: hub,
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+
+	cmd := &StatusCmd{Version: "3.45.0"}
+	if err := cmd.Run(context.Background(), inv); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "No packages installed") {
+		t.Error("expected 'No packages installed' message")
+	}
+}


### PR DESCRIPTION
**DRAFT — §2.5b check 8.** All 25 Go tests pass locally + binary builds + vet clean.

---

Phase 3 Slice A of #212: `init` + `status` commands. Hub lifecycle pair (create + inspect).

Partial close of #212 (Slice A only — ACs 1, 2, 7, 8, 9).

## What shipped

| Command | Summary | NeedsHub | Tests |
|---|---|---|---|
| `init <name>` | Creates `cn-<name>/` with full hub structure + config + SOUL.md stub + git init | false | 2 (creates hub, already-exists error) |
| `status` | Shows hub info + installed packages with version drift detection (✓/✗/⚠) | true | 3 (packages shown, version drift, no packages) |

## ACs (from #212, Slice A subset)

- [x] **AC1** `cn init <name>` creates a new hub
- [x] **AC2** `cn status` shows hub path, installed packages, version
- [x] **AC7** Each command follows Command interface (Spec + Run with Invocation)
- [x] **AC8** Tests: init happy + error, status happy + drift + empty
- [x] **AC9** `cn help` now lists 4 kernel commands (help, init, deps, status)
- [ ] AC3–AC6 deferred to slices B–D (doctor, build, update, setup)

## CLI-UX compliance

- `init`: → progress, ✓ success, ✗ already-exists
- `status`: ✓ matching version, ✗ mismatched + expected version, ⚠ version_drift warning
- `status` without packages: "No packages installed" (graceful)

## §2.5b

| # | Check | State |
|---|---|---|
| 1–7 | All green | ✅ |
| 8 | **CI green before review** | **⏳ DRAFT** |

## CDD §7.0 note

All review findings must be resolved on-branch before merge. No "approved with follow-up."

https://claude.ai/code/session_01N7JZcRm5u9eoS9ysnDt7sL