### PR TITLE
fix(#214): validate hubName in init — close confinement gap

### DIFF
--- a/go/internal/cli/cmd_init.go
+++ b/go/internal/cli/cmd_init.go
@@ -36,6 +36,15 @@ func (c *InitCmd) Run(ctx context.Context, inv Invocation) error {
 		hubName = filepath.Base(cwd)
 	}
 
+	// Validate hub name: bare names only (alphanumeric, hyphens,
+	// underscores, dots). Reject path separators, "..", or empty
+	// to prevent directory traversal or unexpected paths.
+	if !validHubName(hubName) {
+		fmt.Fprintf(inv.Stderr, "✗ Invalid hub name: %q\n\n", hubName)
+		fmt.Fprintf(inv.Stderr, "Hub names must contain only letters, digits, hyphens, underscores, or dots.\n")
+		return fmt.Errorf("init: invalid hub name %q", hubName)
+	}
+
 	// Hub directory uses the "cn-" prefix convention, matching OCaml
 	// cn_system.ml::run_init. This is the standard cnos hub naming:
 	// cn-<agent-name> (e.g., cn-sigma, cn-omega).
@@ -133,4 +142,19 @@ Add entries in the form:
 
 	fmt.Fprintf(inv.Stdout, "✓ Hub initialized at %s\n", hubDir)
 	return nil
+}
+
+// validHubName returns true iff name is a bare name suitable for use
+// as a directory component: non-empty, contains only alphanumeric
+// characters, hyphens, underscores, and dots.
+func validHubName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
 }

--- a/go/internal/cli/cmd_init_test.go
+++ b/go/internal/cli/cmd_init_test.go
@@ -89,3 +89,47 @@ func TestInitAlreadyExists(t *testing.T) {
 		t.Error("expected 'already exists' in stderr")
 	}
 }
+
+func TestInitValidatesHubName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid bare name", "sigma", false},
+		{"with hyphens", "my-agent", false},
+		{"with underscores", "my_agent", false},
+		{"with dots", "agent.v2", false},
+		{"with digits", "bot42", false},
+		{"empty string", "", true},
+		{"path separator", "foo/bar", true},
+		{"parent traversal", "../bad", true},
+		{"backslash", `foo\bar`, true},
+		{"space", "foo bar", true},
+		{"special chars", "foo@bar", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			origDir, _ := os.Getwd()
+			t.Cleanup(func() { os.Chdir(origDir) })
+			os.Chdir(tmp)
+
+			var stdout, stderr bytes.Buffer
+			inv := Invocation{
+				Args:   []string{tt.input},
+				Stdout: &stdout,
+				Stderr: &stderr,
+			}
+
+			err := (&InitCmd{}).Run(context.Background(), inv)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for input %q, got nil", tt.input)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for input %q: %v", tt.input, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**DRAFT — §2.5b check 8.** All tests pass locally.

Closes #214. C-level confinement gap: `cn init` accepted raw user input without validation.

## Fix

`validHubName()` rejects any name that isn't bare alphanumeric + hyphens + underscores + dots. Called before the `cn-` prefix is applied.

- `cn init foo` → ✓
- `cn init ../bad` → `✗ Invalid hub name: "../bad"`
- `cn init ""` → `✗ Invalid hub name: ""`
- `cn init foo/bar` → `✗ Invalid hub name: "foo/bar"`

## ACs

- [x] `cn init foo` works
- [x] `cn init ../bad` returns error
- [x] `cn init ""` returns error
- [x] `cn init foo/bar` returns error
- [x] 11-case table-driven test (5 positive + 6 negative)

https://claude.ai/code/session_01N7JZcRm5u9eoS9ysnDt7sL