### PR TITLE
feat(#212): Go kernel Phase 3 Slice D — update + setup commands

### DIFF
--- a/go/cmd/cn/main.go
+++ b/go/cmd/cn/main.go
@@ -15,8 +15,12 @@ import (
 	"github.com/usurobor/cnos/go/internal/cli"
 )
 
-// version is set at build time via -ldflags or defaults to "dev".
-var version = "dev"
+// version and commit are set at build time via -ldflags. They default
+// to placeholders so `go build ./cmd/cn` works without extra flags.
+var (
+	version = "dev"
+	commit  = ""
+)
 
 func main() {
 	ctx := context.Background()
@@ -26,10 +30,12 @@ func main() {
 	helpCmd := &cli.HelpCmd{Registry: reg}
 	reg.Register(helpCmd)
 	reg.Register(&cli.InitCmd{})
+	reg.Register(&cli.SetupCmd{Version: version})
 	reg.Register(&cli.DepsCmd{})
 	reg.Register(&cli.StatusCmd{Version: version})
 	reg.Register(&cli.DoctorCmd{Version: version})
 	reg.Register(&cli.BuildCmd{})
+	reg.Register(&cli.UpdateCmd{Version: version, Commit: commit})
 
 	// Discover hub: walk up from cwd to find .cn/.
 	hubPath := discoverHub()

--- a/go/internal/binupdate/binupdate.go
+++ b/go/internal/binupdate/binupdate.go
@@ -1,0 +1,493 @@
+// Package binupdate implements `cn update` — check GitHub Releases
+// for a newer cnos binary, download it, verify it, and replace the
+// running binary on disk.
+//
+// Scope (Phase 3 Slice D):
+//
+//   - fetch latest release metadata from the GitHub API
+//   - compare version + commit against the current binary
+//   - download the platform binary to <bin>.new
+//   - verify SHA-256 against checksums.txt from the release
+//   - atomic rename into place
+//
+// Explicitly out of scope for this slice (mirrors OCaml Phase 5
+// territory):
+//
+//   - re-exec into the new binary (requires platform-specific execve)
+//   - package reconciliation after binary replace (requires
+//     default_manifest_for_profile in Go, not yet ported)
+//   - auto-update cooldown + background self-update checks
+//   - runtime.md / state auto-update + git auto-commit
+//
+// These belong to a later slice. The user is told to restart cn
+// after a successful update.
+//
+// This package is cli/-boundary compliant per eng/go §2.18: all
+// logic lives here, and cli/cmd_update.go is a thin wrapper.
+package binupdate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// defaultBaseURL is the GitHub API base for releases.
+const defaultBaseURL = "https://api.github.com"
+
+// defaultDownloadBase is the GitHub releases download base.
+const defaultDownloadBase = "https://github.com"
+
+// defaultHTTPClient matches the timeout from internal/restore/restore.go
+// (mirrors OCaml curl flags: --connect-timeout 10 --max-time 300).
+var defaultHTTPClient = &http.Client{Timeout: 300 * time.Second}
+
+// Release is the minimal subset of the GitHub release payload we need.
+type Release struct {
+	Tag    string // version tag, e.g. "3.50.0"
+	Commit string // first 7 chars of the target SHA, or "" if not a SHA
+}
+
+// Options carries runtime context for an update run.
+type Options struct {
+	// Version is the currently running cnos version.
+	Version string
+	// Commit is the currently running cnos commit short hash ("" if unknown).
+	Commit string
+	// Repo is the GitHub "owner/repo" — defaults to "usurobor/cnos".
+	Repo string
+
+	// CheckOnly reports the result without downloading or installing.
+	CheckOnly bool
+
+	// BinPath overrides the target binary path. If empty, the path is
+	// derived from os.Executable(). Tests set this to a temp file.
+	BinPath string
+
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// HTTPClient and BaseURL allow tests to point at an httptest.Server.
+	// When nil/empty, real defaults are used.
+	HTTPClient *http.Client
+	BaseURL    string
+	// DownloadBase overrides the releases download base URL (GitHub by default).
+	DownloadBase string
+}
+
+// Run executes the update flow.
+func Run(ctx context.Context, opts Options) error {
+	if opts.Repo == "" {
+		opts.Repo = "usurobor/cnos"
+	}
+	if opts.BaseURL == "" {
+		opts.BaseURL = defaultBaseURL
+	}
+	if opts.DownloadBase == "" {
+		opts.DownloadBase = defaultDownloadBase
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = defaultHTTPClient
+	}
+
+	fmt.Fprintf(opts.Stdout, "→ Checking for updates...\n")
+	fmt.Fprintf(opts.Stdout, "  Current version: %s", opts.Version)
+	if opts.Commit != "" {
+		fmt.Fprintf(opts.Stdout, " (%s)", opts.Commit)
+	}
+	fmt.Fprintln(opts.Stdout)
+
+	rel, err := FetchLatestRelease(ctx, client, opts.BaseURL, opts.Repo)
+	if err != nil {
+		return fmt.Errorf("update: fetch latest release: %w", err)
+	}
+
+	decision := classify(opts.Version, opts.Commit, rel)
+	switch decision.kind {
+	case decisionUpToDate:
+		fmt.Fprintf(opts.Stdout, "✓ Already up to date (%s", opts.Version)
+		if opts.Commit != "" {
+			fmt.Fprintf(opts.Stdout, " %s", opts.Commit)
+		}
+		fmt.Fprintln(opts.Stdout, ")")
+		return nil
+
+	case decisionVersionBump:
+		fmt.Fprintf(opts.Stdout, "→ New version available: %s\n", rel.Tag)
+
+	case decisionPatch:
+		fmt.Fprintf(opts.Stdout, "→ Patch available: %s (commit %s → %s)\n",
+			rel.Tag, opts.Commit, rel.Commit)
+	}
+
+	if opts.CheckOnly {
+		fmt.Fprintln(opts.Stdout, "  (--check: skipping download)")
+		return nil
+	}
+
+	return applyUpdate(ctx, client, opts, rel)
+}
+
+// applyUpdate downloads, verifies, and installs the new binary.
+func applyUpdate(ctx context.Context, client *http.Client, opts Options, rel *Release) error {
+	binName, err := platformBinaryName(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+
+	target, err := resolveBinPath(opts.BinPath)
+	if err != nil {
+		return fmt.Errorf("update: resolve binary path: %w", err)
+	}
+
+	// Writability check — fail fast if we cannot replace the binary.
+	// Uses access on the parent directory, matching the OCaml check.
+	if !dirWritable(target) {
+		return fmt.Errorf("update: %s is not writable (try sudo or reinstall)", target)
+	}
+
+	downloadURL := fmt.Sprintf("%s/%s/releases/download/%s/%s",
+		opts.DownloadBase, opts.Repo, rel.Tag, binName)
+	tmpPath := target + ".new"
+
+	fmt.Fprintf(opts.Stdout, "→ Downloading %s...\n", binName)
+	if err := downloadBinary(ctx, client, downloadURL, tmpPath); err != nil {
+		return fmt.Errorf("update: download: %w", err)
+	}
+	// cleanup on failure — successful install removes the tmp file via rename.
+	defer os.Remove(tmpPath)
+
+	checksumURL := fmt.Sprintf("%s/%s/releases/download/%s/checksums.txt",
+		opts.DownloadBase, opts.Repo, rel.Tag)
+	fmt.Fprintf(opts.Stdout, "→ Verifying checksum...\n")
+	if err := verifyChecksum(ctx, client, checksumURL, binName, tmpPath); err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+
+	fmt.Fprintf(opts.Stdout, "→ Installing to %s...\n", target)
+	if err := installBinary(tmpPath, target); err != nil {
+		return fmt.Errorf("update: install: %w", err)
+	}
+
+	fmt.Fprintf(opts.Stdout, "✓ Updated to %s\n", rel.Tag)
+	fmt.Fprintln(opts.Stdout, "  Restart cn to use the new version.")
+	return nil
+}
+
+// --- Decision model ---
+
+type decisionKind int
+
+const (
+	decisionUpToDate decisionKind = iota
+	decisionVersionBump
+	decisionPatch
+)
+
+type updateDecision struct {
+	kind decisionKind
+}
+
+// classify compares the current version/commit against the latest
+// release and returns the update decision. Mirrors OCaml
+// check_for_update semantics (#37: same-version patch detection).
+func classify(currentVersion, currentCommit string, rel *Release) updateDecision {
+	if IsNewerVersion(rel.Tag, currentVersion) {
+		return updateDecision{kind: decisionVersionBump}
+	}
+	if rel.Commit != "" && currentCommit != "" && rel.Commit != currentCommit {
+		return updateDecision{kind: decisionPatch}
+	}
+	return updateDecision{kind: decisionUpToDate}
+}
+
+// --- GitHub API ---
+
+// FetchLatestRelease calls the GitHub releases/latest endpoint and
+// returns the parsed tag + commit. Commit is truncated to 7 chars
+// when it looks like a hex SHA; otherwise it is left empty (the
+// target_commitish can be a branch name for manual releases).
+func FetchLatestRelease(ctx context.Context, client *http.Client, baseURL, repo string) (*Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", baseURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var payload struct {
+		TagName         string `json:"tag_name"`
+		TargetCommitish string `json:"target_commitish"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse release json: %w", err)
+	}
+	if payload.TagName == "" {
+		return nil, errors.New("release response missing tag_name")
+	}
+
+	commit := ""
+	if isHexSHA(payload.TargetCommitish) {
+		commit = payload.TargetCommitish[:7]
+	}
+	return &Release{
+		Tag:    strings.TrimSpace(payload.TagName),
+		Commit: commit,
+	}, nil
+}
+
+// isHexSHA returns true if s looks like a full Git SHA (>= 40 hex chars).
+func isHexSHA(s string) bool {
+	if len(s) < 40 {
+		return false
+	}
+	for _, c := range s {
+		if !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Version comparison ---
+
+// IsNewerVersion reports whether a is strictly newer than b under
+// dot-separated numeric semver. Non-numeric components sort as 0.
+// An unparseable or empty version is treated as older than any
+// parseable one (matches OCaml Cn_lib.is_newer_version).
+func IsNewerVersion(a, b string) bool {
+	ta := parseVersion(a)
+	tb := parseVersion(b)
+	for i := 0; i < 3; i++ {
+		if ta[i] > tb[i] {
+			return true
+		}
+		if ta[i] < tb[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// parseVersion returns the (major, minor, patch) tuple of a
+// dot-separated version string, padding missing components with 0.
+// Unparseable components become 0.
+func parseVersion(v string) [3]int {
+	var out [3]int
+	parts := strings.Split(v, ".")
+	for i := 0; i < 3 && i < len(parts); i++ {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil {
+			return [3]int{0, 0, 0}
+		}
+		out[i] = n
+	}
+	return out
+}
+
+// --- Platform detection ---
+
+// platformBinaryName returns the release asset name for a (os, arch)
+// pair. Keeping the parameters explicit makes the function pure and
+// table-testable — the runtime call site passes runtime.GOOS/GOARCH.
+func platformBinaryName(goos, goarch string) (string, error) {
+	var os, arch string
+	switch goos {
+	case "linux":
+		os = "linux"
+	case "darwin":
+		os = "macos"
+	default:
+		return "", fmt.Errorf("unsupported OS: %s", goos)
+	}
+	switch goarch {
+	case "amd64":
+		arch = "x64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		return "", fmt.Errorf("unsupported arch: %s", goarch)
+	}
+	return fmt.Sprintf("cn-%s-%s", os, arch), nil
+}
+
+// --- Download ---
+
+// downloadBinary fetches url and writes it to dest with exec bits set.
+// On non-200 or IO failure, the destination file is removed before
+// returning.
+func downloadBinary(ctx context.Context, client *http.Client, url, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	f, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(dest)
+		return fmt.Errorf("write file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(dest)
+		return fmt.Errorf("close file: %w", err)
+	}
+	return nil
+}
+
+// --- Checksum verification ---
+
+// verifyChecksum downloads checksums.txt from checksumURL and verifies
+// that the SHA-256 of the file at path matches the entry for binaryName.
+// A missing entry is an error — when the kernel cannot verify, it does
+// not install, matching eng/go §3.5 ("every fallback is a policy
+// decision, and silent fallback is forbidden").
+func verifyChecksum(ctx context.Context, client *http.Client, checksumURL, binaryName, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, nil)
+	if err != nil {
+		return fmt.Errorf("create checksum request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch checksums: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch checksums: http status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read checksums: %w", err)
+	}
+
+	expected, ok := lookupChecksum(body, binaryName)
+	if !ok {
+		return fmt.Errorf("no checksum entry for %s", binaryName)
+	}
+
+	actual, err := fileSHA256(path)
+	if err != nil {
+		return fmt.Errorf("compute sha256: %w", err)
+	}
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("sha256 mismatch for %s: expected %s, got %s",
+			binaryName, expected, actual)
+	}
+	return nil
+}
+
+// lookupChecksum parses a sha256sum-formatted checksums body
+// ("<hex>  <filename>" lines) and returns the hex digest for name.
+func lookupChecksum(body []byte, name string) (string, bool) {
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// sha256sum tolerates a leading "*" before the filename (binary mode).
+		fname := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if fname == name {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+// fileSHA256 computes the hex SHA-256 of a file.
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// --- Install ---
+
+// installBinary renames src over dest (atomic on POSIX filesystems).
+func installBinary(src, dest string) error {
+	return os.Rename(src, dest)
+}
+
+// resolveBinPath returns override if set, otherwise os.Executable().
+func resolveBinPath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	return os.Executable()
+}
+
+// dirWritable returns true if the directory containing path is
+// writable by the current process. Used as an early guard so the
+// download step does not spend time on a binary we cannot install.
+func dirWritable(path string) bool {
+	dir := path
+	if idx := strings.LastIndex(path, string(os.PathSeparator)); idx >= 0 {
+		dir = path[:idx]
+	}
+	return unix_W_OK(dir) == nil
+}
+
+// unix_W_OK is a minimal portable writability check. We avoid pulling
+// in golang.org/x/sys to keep dependencies stdlib-only (eng/go §2.11).
+func unix_W_OK(dir string) error {
+	// os.Stat gives us the mode bits; we also need to know that we
+	// can create a file. The cheapest portable test is to try to
+	// create a temp file in the directory and remove it.
+	f, err := os.CreateTemp(dir, ".cn-update-probe-*")
+	if err != nil {
+		return err
+	}
+	_ = f.Close()
+	_ = os.Remove(f.Name())
+	return nil
+}

--- a/go/internal/binupdate/binupdate_test.go
+++ b/go/internal/binupdate/binupdate_test.go
@@ -1,0 +1,408 @@
+package binupdate
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- IsNewerVersion ---
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		a, b  string
+		newer bool
+	}{
+		{"3.50.0", "3.49.0", true},
+		{"3.50.1", "3.50.0", true},
+		{"4.0.0", "3.99.0", true},
+		{"3.50.0", "3.50.0", false},
+		{"3.49.0", "3.50.0", false},
+		{"3.9.0", "3.10.0", false}, // semver: 3.10.0 > 3.9.0
+		{"3.10.0", "3.9.0", true},
+		{"dev", "3.50.0", false}, // unparseable treated as older
+		{"3.50.0", "dev", true},
+		{"", "3.50.0", false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s vs %s", tt.a, tt.b), func(t *testing.T) {
+			got := IsNewerVersion(tt.a, tt.b)
+			if got != tt.newer {
+				t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.newer)
+			}
+		})
+	}
+}
+
+// --- platformBinaryName (pure helper over an OS/arch pair) ---
+
+func TestPlatformBinaryName(t *testing.T) {
+	tests := []struct {
+		os, arch string
+		want     string
+		wantErr  bool
+	}{
+		{"linux", "amd64", "cn-linux-x64", false},
+		{"linux", "arm64", "cn-linux-arm64", false},
+		{"darwin", "amd64", "cn-macos-x64", false},
+		{"darwin", "arm64", "cn-macos-arm64", false},
+		{"windows", "amd64", "", true},
+		{"linux", "386", "", true},
+		{"", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.os+"/"+tt.arch, func(t *testing.T) {
+			got, err := platformBinaryName(tt.os, tt.arch)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- FetchLatestRelease against an httptest server ---
+
+func TestFetchLatestReleaseParsesTagAndCommit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/releases/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"tag_name": "3.50.0",
+			"target_commitish": "abc1234def5678901234567890abcdef12345678"
+		}`)
+	}))
+	defer srv.Close()
+
+	rel, err := FetchLatestRelease(context.Background(), srv.Client(), srv.URL, "owner/repo")
+	if err != nil {
+		t.Fatalf("FetchLatestRelease: %v", err)
+	}
+	if rel.Tag != "3.50.0" {
+		t.Errorf("Tag = %q, want 3.50.0", rel.Tag)
+	}
+	// Commit is truncated to 7 characters when it looks like a hex SHA.
+	if rel.Commit != "abc1234" {
+		t.Errorf("Commit = %q, want abc1234", rel.Commit)
+	}
+}
+
+func TestFetchLatestReleaseIgnoresNonSHACommitish(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"tag_name": "3.50.0", "target_commitish": "main"}`)
+	}))
+	defer srv.Close()
+
+	rel, err := FetchLatestRelease(context.Background(), srv.Client(), srv.URL, "owner/repo")
+	if err != nil {
+		t.Fatalf("FetchLatestRelease: %v", err)
+	}
+	if rel.Commit != "" {
+		t.Errorf("Commit = %q, want empty (branch name, not SHA)", rel.Commit)
+	}
+}
+
+func TestFetchLatestReleaseHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := FetchLatestRelease(context.Background(), srv.Client(), srv.URL, "owner/repo")
+	if err == nil {
+		t.Fatal("expected error on 429 response")
+	}
+}
+
+func TestFetchLatestReleaseMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{not json`)
+	}))
+	defer srv.Close()
+
+	_, err := FetchLatestRelease(context.Background(), srv.Client(), srv.URL, "owner/repo")
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+func TestFetchLatestReleaseMissingTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"target_commitish": "abc1234def5678901234567890abcdef12345678"}`)
+	}))
+	defer srv.Close()
+
+	_, err := FetchLatestRelease(context.Background(), srv.Client(), srv.URL, "owner/repo")
+	if err == nil {
+		t.Fatal("expected error on missing tag_name")
+	}
+}
+
+// --- downloadBinary atomic flow ---
+
+func TestDownloadBinary(t *testing.T) {
+	content := []byte("fake-binary-bytes-0123456789")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(content)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "cn.new")
+	if err := downloadBinary(context.Background(), srv.Client(), srv.URL, dest); err != nil {
+		t.Fatalf("downloadBinary: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("downloaded bytes mismatch")
+	}
+
+	// File should be executable.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&0100 == 0 {
+		t.Errorf("downloaded binary is not executable: mode=%v", info.Mode())
+	}
+}
+
+func TestDownloadBinaryHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "cn.new")
+	err := downloadBinary(context.Background(), srv.Client(), srv.URL, dest)
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	// Temp file should not be left behind on failure.
+	if _, statErr := os.Stat(dest); statErr == nil {
+		t.Errorf("partial download file was left behind: %s", dest)
+	}
+}
+
+// --- verifyChecksum against a synthesized checksums.txt ---
+
+func TestVerifyChecksumMatch(t *testing.T) {
+	// Create a real file, compute its SHA, and construct a checksums body.
+	content := []byte("binary payload")
+	path := filepath.Join(t.TempDir(), "cn-linux-x64")
+	if err := os.WriteFile(path, content, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	hexSum := hex.EncodeToString(sum[:])
+	body := fmt.Sprintf("%s  cn-linux-x64\n%s  cn-macos-x64\n", hexSum, strings.Repeat("0", 64))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	err := verifyChecksum(context.Background(), srv.Client(), srv.URL, "cn-linux-x64", path)
+	if err != nil {
+		t.Errorf("verifyChecksum: %v", err)
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cn-linux-x64")
+	if err := os.WriteFile(path, []byte("binary payload"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Wrong expected hash.
+	body := strings.Repeat("0", 64) + "  cn-linux-x64\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	err := verifyChecksum(context.Background(), srv.Client(), srv.URL, "cn-linux-x64", path)
+	if err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch: %v", err)
+	}
+}
+
+func TestVerifyChecksumMissingEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cn-linux-x64")
+	if err := os.WriteFile(path, []byte("binary payload"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// checksums.txt does not mention our binary.
+	body := strings.Repeat("0", 64) + "  other-binary\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	err := verifyChecksum(context.Background(), srv.Client(), srv.URL, "cn-linux-x64", path)
+	if err == nil {
+		t.Fatal("expected error when checksum entry is missing")
+	}
+}
+
+// --- installBinary atomic rename ---
+
+func TestInstallBinaryAtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "cn")
+	src := filepath.Join(dir, "cn.new")
+
+	// Pre-existing "installed" binary.
+	if err := os.WriteFile(dest, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("new"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBinary(src, dest); err != nil {
+		t.Fatalf("installBinary: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("dest = %q, want %q", string(got), "new")
+	}
+
+	// src should be gone after atomic rename.
+	if _, err := os.Stat(src); err == nil {
+		t.Error("src file still exists after rename")
+	}
+}
+
+// --- Run (check-only mode) ---
+
+func TestRunCheckOnlyUpToDate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"tag_name": "3.50.0", "target_commitish": "abc1234def5678901234567890abcdef12345678"}`)
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		Version:    "3.50.0",
+		Commit:     "abc1234",
+		Repo:       "owner/repo",
+		CheckOnly:  true,
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "up to date") {
+		t.Errorf("expected 'up to date' in stdout:\n%s", stdout.String())
+	}
+}
+
+func TestRunCheckOnlyAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"tag_name": "3.51.0", "target_commitish": "fedcba9876543210fedcba9876543210fedcba98"}`)
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		Version:    "3.50.0",
+		Commit:     "abc1234",
+		Repo:       "owner/repo",
+		CheckOnly:  true,
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "3.51.0") {
+		t.Errorf("expected new version in stdout:\n%s", out)
+	}
+	if !strings.Contains(out, "available") {
+		t.Errorf("expected 'available' in stdout:\n%s", out)
+	}
+}
+
+func TestRunCheckOnlySameVersionPatch(t *testing.T) {
+	// Same tag, different commit hash — OCaml treats this as a patch.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"tag_name": "3.50.0", "target_commitish": "fedcba9876543210fedcba9876543210fedcba98"}`)
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		Version:    "3.50.0",
+		Commit:     "abc1234",
+		Repo:       "owner/repo",
+		CheckOnly:  true,
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out := strings.ToLower(stdout.String())
+	if !strings.Contains(out, "patch") {
+		t.Errorf("expected 'patch' in stdout:\n%s", stdout.String())
+	}
+}
+
+func TestRunCheckOnlyFetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		Version:    "3.50.0",
+		Commit:     "abc1234",
+		Repo:       "owner/repo",
+		CheckOnly:  true,
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		HTTPClient: srv.Client(),
+		BaseURL:    srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error on fetch failure")
+	}
+}

--- a/go/internal/cli/cmd_setup.go
+++ b/go/internal/cli/cmd_setup.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/usurobor/cnos/go/internal/hubsetup"
+)
+
+// SetupCmd implements the "setup" command — makes a hub wake-ready.
+//
+// Per GO-KERNEL-COMMANDS.md §2.8, setup is listed as needs_hub=false
+// (available without a hub) because it is a bootstrap-tier command.
+// Operationally it still requires a hub path — hubsetup.Run rejects
+// the empty path cleanly so help can list setup before a hub exists
+// without hiding the hard requirement.
+type SetupCmd struct {
+	Version string
+}
+
+func (c *SetupCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "setup",
+		Summary:  "Configure cnos hub",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: false,
+	}
+}
+
+func (c *SetupCmd) Run(ctx context.Context, inv Invocation) error {
+	return hubsetup.Run(ctx, hubsetup.Options{
+		HubPath: inv.HubPath,
+		Version: c.Version,
+		Stdout:  inv.Stdout,
+		Stderr:  inv.Stderr,
+	})
+}

--- a/go/internal/cli/cmd_update.go
+++ b/go/internal/cli/cmd_update.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/usurobor/cnos/go/internal/binupdate"
+)
+
+// UpdateCmd implements the "update" command — checks GitHub Releases
+// and replaces the running binary when a newer version is available.
+// Uses "--check" to report without downloading.
+type UpdateCmd struct {
+	Version string
+	Commit  string
+}
+
+func (c *UpdateCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "update",
+		Summary:  "Update cnos binary",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: false,
+	}
+}
+
+func (c *UpdateCmd) Run(ctx context.Context, inv Invocation) error {
+	opts := binupdate.Options{
+		Version: c.Version,
+		Commit:  c.Commit,
+		Stdout:  inv.Stdout,
+		Stderr:  inv.Stderr,
+	}
+
+	for _, arg := range inv.Args {
+		switch arg {
+		case "--check":
+			opts.CheckOnly = true
+		default:
+			return fmt.Errorf("update: unknown argument %q (use --check)", arg)
+		}
+	}
+
+	return binupdate.Run(ctx, opts)
+}

--- a/go/internal/hubsetup/hubsetup.go
+++ b/go/internal/hubsetup/hubsetup.go
@@ -20,6 +20,7 @@ package hubsetup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -107,38 +108,16 @@ func ensureDefaultDeps(path, version string, stdout io.Writer) error {
 			{Name: "cnos.eng", Version: version},
 		},
 	}
-	data, err := marshalDeps(&m)
+	data, err := json.MarshalIndent(&m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("setup: marshal deps.json: %w", err)
 	}
+	data = append(data, '\n')
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("setup: write %s: %w", path, err)
 	}
 	fmt.Fprintf(stdout, "✓ Created .cn/deps.json (profile: engineer)\n")
 	return nil
-}
-
-// marshalDeps serializes a manifest to pretty JSON with a trailing
-// newline, matching the shape written by OCaml's cn_deps.ml.
-func marshalDeps(m *pkg.Manifest) ([]byte, error) {
-	// Build JSON manually so the field order is deterministic and
-	// matches the OCaml writer. encoding/json respects struct tag
-	// order for marshaling, but keeping the format stable protects
-	// diffs across runtimes.
-	var b strings.Builder
-	b.WriteString("{\n")
-	fmt.Fprintf(&b, "  %q: %q,\n", "schema", m.Schema)
-	fmt.Fprintf(&b, "  %q: %q,\n", "profile", m.Profile)
-	b.WriteString("  \"packages\": [\n")
-	for i, p := range m.Packages {
-		fmt.Fprintf(&b, "    { %q: %q, %q: %q }", "name", p.Name, "version", p.Version)
-		if i < len(m.Packages)-1 {
-			b.WriteString(",")
-		}
-		b.WriteString("\n")
-	}
-	b.WriteString("  ]\n}\n")
-	return []byte(b.String()), nil
 }
 
 // ensureGitignoreEntry adds ".cn/vendor/" to .gitignore if it is not

--- a/go/internal/hubsetup/hubsetup.go
+++ b/go/internal/hubsetup/hubsetup.go
@@ -1,0 +1,187 @@
+// Package hubsetup implements `cn setup` — make a hub wake-ready.
+//
+// Setup materializes the minimum state a hub needs before package
+// restore is meaningful:
+//
+//   - .cn/ and agent/ directories exist
+//   - .cn/deps.json is present (default profile if missing)
+//   - .gitignore excludes .cn/vendor/
+//
+// It does NOT run `cn deps restore`. The user (or a downstream
+// orchestrator) invokes restore explicitly — that keeps setup
+// scoped to "prepare the hub", with no network or package-index
+// dependency. This matches the kernel-minimal posture
+// (INVARIANTS.md T-002) and keeps the command testable without
+// package infrastructure.
+//
+// This package is cli/-boundary compliant per eng/go §2.18: all
+// logic lives here, and cli/cmd_setup.go is a thin wrapper.
+package hubsetup
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/usurobor/cnos/go/internal/pkg"
+)
+
+// Options carries the runtime context for a setup run.
+type Options struct {
+	// HubPath is the hub to configure (required). An empty string is
+	// an error even though cn setup is listed as needs_hub=false in
+	// the kernel manifest — the manifest makes setup "always available"
+	// but the operation itself still needs a hub to write into. The
+	// dispatch layer lets help print setup in the pre-hub command list;
+	// this function rejects the empty path cleanly.
+	HubPath string
+
+	// Version is the cnos binary version — used to populate the
+	// default deps.json when one does not already exist.
+	Version string
+
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run configures the hub at opts.HubPath.
+//
+// Behavior is idempotent:
+//   - existing deps.json is left untouched
+//   - existing .gitignore is amended only when the .cn/vendor/ line
+//     is not already present (exact substring match)
+//   - directories that already exist are not recreated
+func Run(ctx context.Context, opts Options) error {
+	_ = ctx // kept for symmetry with other domain Run funcs
+
+	if opts.HubPath == "" {
+		return fmt.Errorf("setup: hub path is empty — run this command from inside a hub")
+	}
+
+	fmt.Fprintf(opts.Stdout, "→ Setting up hub: %s\n", opts.HubPath)
+
+	// 1. Required directories.
+	for _, d := range []string{".cn", "agent"} {
+		full := filepath.Join(opts.HubPath, d)
+		if err := os.MkdirAll(full, 0755); err != nil {
+			return fmt.Errorf("setup: create %s: %w", d, err)
+		}
+	}
+
+	// 2. Default deps.json (only when missing).
+	depsPath := filepath.Join(opts.HubPath, ".cn", "deps.json")
+	if err := ensureDefaultDeps(depsPath, opts.Version, opts.Stdout); err != nil {
+		return err
+	}
+
+	// 3. .gitignore entry for .cn/vendor/.
+	if err := ensureGitignoreEntry(opts.HubPath, opts.Stdout); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.Stdout, "\n✓ Hub setup complete.\n")
+	fmt.Fprintf(opts.Stdout, "  Next: run 'cn deps restore' to install packages.\n")
+	return nil
+}
+
+// ensureDefaultDeps writes a default deps.json at path if none exists.
+// The default manifest pins cnos.core and cnos.eng to the given version
+// under the "engineer" profile. Matches
+// Cn_deps.default_manifest_for_profile in src/cmd/cn_deps.ml.
+func ensureDefaultDeps(path, version string, stdout io.Writer) error {
+	if _, err := os.Stat(path); err == nil {
+		// Present — preserve.
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("setup: stat %s: %w", path, err)
+	}
+
+	m := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: version},
+			{Name: "cnos.eng", Version: version},
+		},
+	}
+	data, err := marshalDeps(&m)
+	if err != nil {
+		return fmt.Errorf("setup: marshal deps.json: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("setup: write %s: %w", path, err)
+	}
+	fmt.Fprintf(stdout, "✓ Created .cn/deps.json (profile: engineer)\n")
+	return nil
+}
+
+// marshalDeps serializes a manifest to pretty JSON with a trailing
+// newline, matching the shape written by OCaml's cn_deps.ml.
+func marshalDeps(m *pkg.Manifest) ([]byte, error) {
+	// Build JSON manually so the field order is deterministic and
+	// matches the OCaml writer. encoding/json respects struct tag
+	// order for marshaling, but keeping the format stable protects
+	// diffs across runtimes.
+	var b strings.Builder
+	b.WriteString("{\n")
+	fmt.Fprintf(&b, "  %q: %q,\n", "schema", m.Schema)
+	fmt.Fprintf(&b, "  %q: %q,\n", "profile", m.Profile)
+	b.WriteString("  \"packages\": [\n")
+	for i, p := range m.Packages {
+		fmt.Fprintf(&b, "    { %q: %q, %q: %q }", "name", p.Name, "version", p.Version)
+		if i < len(m.Packages)-1 {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("  ]\n}\n")
+	return []byte(b.String()), nil
+}
+
+// ensureGitignoreEntry adds ".cn/vendor/" to .gitignore if it is not
+// already present. Creates .gitignore if it does not exist. Idempotent.
+func ensureGitignoreEntry(hubPath string, stdout io.Writer) error {
+	giPath := filepath.Join(hubPath, ".gitignore")
+	entry := ".cn/vendor/"
+
+	existing, err := os.ReadFile(giPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("setup: read .gitignore: %w", err)
+	}
+
+	// Already present — nothing to do.
+	if containsLine(existing, entry) {
+		return nil
+	}
+
+	var next []byte
+	switch {
+	case len(existing) == 0:
+		next = []byte(entry + "\n")
+	case existing[len(existing)-1] == '\n':
+		next = append(existing, []byte(entry+"\n")...)
+	default:
+		next = append(existing, []byte("\n"+entry+"\n")...)
+	}
+	if err := os.WriteFile(giPath, next, 0644); err != nil {
+		return fmt.Errorf("setup: write .gitignore: %w", err)
+	}
+	fmt.Fprintf(stdout, "✓ Added .cn/vendor/ to .gitignore\n")
+	return nil
+}
+
+// containsLine returns true if `data` contains `want` as a line,
+// ignoring leading/trailing whitespace and matching substring
+// occurrences that appear on their own. Prefix matches such as
+// ".cn/vendor/subdir" do not count.
+func containsLine(data []byte, want string) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/hubsetup/hubsetup_test.go
+++ b/go/internal/hubsetup/hubsetup_test.go
@@ -1,0 +1,255 @@
+package hubsetup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTempHub returns a tmp directory that is ready to be treated as a hub.
+// The caller decides which files pre-exist — only the top-level dir is
+// created so each test can assert whether Run creates the expected shape.
+func newTempHub(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+func TestRunEnsuresDirectories(t *testing.T) {
+	hub := newTempHub(t)
+
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+
+	for _, d := range []string{".cn", "agent"} {
+		info, err := os.Stat(filepath.Join(hub, d))
+		if err != nil {
+			t.Errorf("missing directory %s: %v", d, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s exists but is not a directory", d)
+		}
+	}
+}
+
+func TestRunWritesDefaultDeps(t *testing.T) {
+	hub := newTempHub(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}); err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+
+	depsPath := filepath.Join(hub, ".cn", "deps.json")
+	data, err := os.ReadFile(depsPath)
+	if err != nil {
+		t.Fatalf("read deps.json: %v", err)
+	}
+
+	var m struct {
+		Schema   string `json:"schema"`
+		Profile  string `json:"profile"`
+		Packages []struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse deps.json: %v\n%s", err, string(data))
+	}
+
+	if m.Schema != "cn.deps.v1" {
+		t.Errorf("schema = %q, want cn.deps.v1", m.Schema)
+	}
+	if m.Profile != "engineer" {
+		t.Errorf("profile = %q, want engineer", m.Profile)
+	}
+	wantPackages := map[string]bool{"cnos.core": false, "cnos.eng": false}
+	for _, p := range m.Packages {
+		if _, ok := wantPackages[p.Name]; !ok {
+			t.Errorf("unexpected package %q", p.Name)
+			continue
+		}
+		if p.Version != "3.50.0" {
+			t.Errorf("package %s version = %q, want 3.50.0", p.Name, p.Version)
+		}
+		wantPackages[p.Name] = true
+	}
+	for name, present := range wantPackages {
+		if !present {
+			t.Errorf("missing default package %q", name)
+		}
+	}
+}
+
+func TestRunPreservesExistingDeps(t *testing.T) {
+	hub := newTempHub(t)
+
+	// Pre-create a user-authored deps.json with a custom profile.
+	if err := os.MkdirAll(filepath.Join(hub, ".cn"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"schema":"cn.deps.v1","profile":"custom","packages":[{"name":"cnos.core","version":"9.9.9"}]}`
+	depsPath := filepath.Join(hub, ".cn", "deps.json")
+	if err := os.WriteFile(depsPath, []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}); err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(depsPath)
+	if err != nil {
+		t.Fatalf("read deps.json: %v", err)
+	}
+	if string(data) != existing {
+		t.Errorf("deps.json was overwritten\nhad:  %s\nwant: %s", string(data), existing)
+	}
+}
+
+func TestRunAddsGitignoreEntry(t *testing.T) {
+	hub := newTempHub(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}); err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(hub, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), ".cn/vendor/") {
+		t.Errorf(".gitignore missing .cn/vendor/ entry:\n%s", string(data))
+	}
+}
+
+func TestRunPreservesExistingGitignore(t *testing.T) {
+	hub := newTempHub(t)
+
+	// Pre-existing .gitignore with its own content.
+	original := "node_modules/\ndist/\n"
+	if err := os.WriteFile(filepath.Join(hub, ".gitignore"), []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}); err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(hub, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "node_modules/") {
+		t.Error(".gitignore lost prior entry: node_modules/")
+	}
+	if !strings.Contains(content, "dist/") {
+		t.Error(".gitignore lost prior entry: dist/")
+	}
+	if !strings.Contains(content, ".cn/vendor/") {
+		t.Error(".gitignore missing new entry: .cn/vendor/")
+	}
+}
+
+func TestRunGitignoreIdempotent(t *testing.T) {
+	hub := newTempHub(t)
+
+	// Second run should not duplicate the .cn/vendor/ line.
+	var stdout1, stderr1 bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout1,
+		Stderr:  &stderr1,
+	}); err != nil {
+		t.Fatalf("Run (first): %v", err)
+	}
+
+	var stdout2, stderr2 bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout2,
+		Stderr:  &stderr2,
+	}); err != nil {
+		t.Fatalf("Run (second): %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(hub, ".gitignore"))
+	count := strings.Count(string(data), ".cn/vendor/")
+	if count != 1 {
+		t.Errorf(".cn/vendor/ appeared %d time(s) in .gitignore, want 1:\n%s", count, string(data))
+	}
+}
+
+func TestRunMissingHubPath(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{
+		HubPath: "",
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+	if err == nil {
+		t.Fatal("expected error when HubPath is empty")
+	}
+	if !strings.Contains(err.Error(), "hub") {
+		t.Errorf("error should mention hub: %v", err)
+	}
+}
+
+func TestRunPrintsNextSteps(t *testing.T) {
+	hub := newTempHub(t)
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		HubPath: hub,
+		Version: "3.50.0",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "cn deps restore") {
+		t.Errorf("expected guidance to run 'cn deps restore':\n%s", out)
+	}
+}


### PR DESCRIPTION
**DRAFT — §2.5b check 8.** Opening draft so CI runs before
requesting review. Local verification complete:
`go build ./... && go vet ./... && go test -race ./...` clean.
63 Go tests pass (25 new).

---

Phase 3 Slice D of #212: the last two kernel commands. Closes
#212 when merged (AC5, AC6, AC7, AC8, AC9 in this PR; AC1–AC4
satisfied by Slices A/B/C).

## What shipped

`cn update` — binary update from GitHub Releases:

| Step | Behavior |
|---|---|
| fetch | `GET /repos/{repo}/releases/latest` with explicit Accept header |
| classify | version bump / same-version patch (#37) / up-to-date |
| `--check` | report only, no download, exit 0 |
| download | GET release asset → `<bin>.new`, writable-dir guard first |
| verify | SHA-256 against `checksums.txt` — missing entry is an **error**, not a silent install (eng/go §3.5) |
| install | `os.Rename` atomic replace; tmp cleanup on failure |

`cn setup` — hub bootstrap:

| Step | Behavior |
|---|---|
| dirs | ensures `.cn/` and `agent/` |
| deps | writes default `.cn/deps.json` (schema `cn.deps.v1`, profile `engineer`, `cnos.core` + `cnos.eng` at current version) **only if missing** |
| .gitignore | appends `.cn/vendor/` entry, idempotent (exact-line match), creates file if absent |
| guidance | prints `cn deps restore` next step |

## Shape

Per eng/go §2.18 (cli/ dispatch boundary), cli/ stays a thin
wrapper; all logic lives in domain packages:

```
go/internal/binupdate/   # update flow (493 LOC) + tests (408 LOC)
go/internal/hubsetup/    # setup flow (187 LOC) + tests (255 LOC)
go/internal/cli/cmd_update.go   # 46-line wrapper
go/internal/cli/cmd_setup.go    # 37-line wrapper
go/cmd/cn/main.go               # registers both (+ version/commit ldflag vars)
```

Both wrappers are well under the ~30-line domain-logic threshold
from INVARIANTS.md T-002. They translate `Invocation` → domain
`Options` and call `Run`.

## Scope

**In:** check → fetch → platform-detect → download → verify →
atomic install; `--check` flag; hub bootstrap (dirs + default
deps manifest + .gitignore).

**Out (deferred to Phase 5 feature parity):**
- re-exec into new binary (requires platform-specific `syscall.Exec`)
- package reconciliation after binary replace (requires
  `default_manifest_for_profile` in Go — not yet ported)
- auto-update cooldown + self-update background hook
- runtime.md + git auto-commit
- full interactive setup with restore invocation + templates

These are intentional non-goals per the issue (#212 "Non-goals"
block) and keep Slice D scoped to kernel-minimal behavior.

## Design-doc footnote (setup.needs_hub)

`setup` declares `NeedsHub=false` to match GO-KERNEL-COMMANDS.md
§2.8, so it appears in the pre-hub `cn help` list. The operation
itself still requires a hub path, and `hubsetup.Run` rejects an
empty `HubPath` cleanly with a clear error message. This preserves
the design-doc listing without hiding the operational requirement.

## ACs

- [x] **AC5** `cn update` checks for and applies binary updates (+ `--check`)
- [x] **AC6** `cn setup` runs initial hub configuration
- [x] **AC7** Both commands implement `Command` (Spec + Run with Invocation)
- [x] **AC8** 25 new tests — happy path + degraded/error paths
- [x] **AC9** `cn help` lists all 8 kernel commands when in a hub

## Tests

**63 Go tests total (25 new).** All pass under `-race`.

- **binupdate** (17 tests)
  - `TestIsNewerVersion` — 10 cases incl. `3.9.0` vs `3.10.0`, `dev`, empty
  - `TestPlatformBinaryName` — 7 cases: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, + 3 unsupported
  - `TestFetchLatestReleaseParsesTagAndCommit` — parses + 7-char SHA truncation
  - `TestFetchLatestReleaseIgnoresNonSHACommitish` — `main` branch name → empty commit
  - `TestFetchLatestReleaseHTTPError` — 429 rate limit
  - `TestFetchLatestReleaseMalformedJSON`
  - `TestFetchLatestReleaseMissingTag`
  - `TestDownloadBinary` — bytes + exec bit
  - `TestDownloadBinaryHTTPError` — partial file cleaned up
  - `TestVerifyChecksumMatch` / `Mismatch` / `MissingEntry`
  - `TestInstallBinaryAtomicReplace`
  - `TestRunCheckOnlyUpToDate` / `Available` / `SameVersionPatch` / `FetchError`
- **hubsetup** (8 tests)
  - `TestRunEnsuresDirectories`
  - `TestRunWritesDefaultDeps`
  - `TestRunPreservesExistingDeps`
  - `TestRunAddsGitignoreEntry`
  - `TestRunPreservesExistingGitignore`
  - `TestRunGitignoreIdempotent`
  - `TestRunMissingHubPath`
  - `TestRunPrintsNextSteps`

**Smoke tests:**
- `go build ./cmd/cn && ./cn help` → lists 5 pre-hub commands (help, init, setup, build, update)
- `cn help` inside a hub → lists all 8 kernel commands
- `cn setup` in a tempdir → wrote `.cn/`, `agent/`, `.cn/deps.json`, `.gitignore` with expected content
- `cn update --check` → reached real GitHub API, correctly reported "new version available: 3.49.0" (against `dev` build)

## Self-verification report

### Active skills

- **eng/go** — §2.17 Parse/Read purity (pure helpers
  `IsNewerVersion`, `platformBinaryName`, `parseVersion`,
  `isHexSHA`, `lookupChecksum`, `classify`; IO isolated in
  `FetchLatestRelease`, `downloadBinary`, `verifyChecksum`,
  `installBinary`); §2.18 dispatch boundary (cli wrappers ≤46
  lines); §2.11 stdlib-only (no new dependencies added); §3.5
  fallback discipline (missing checksum entry → error, not
  silent install); `%w` wrapping everywhere; defer-after-err-check
  for Close(); no package globals controlling behavior.
- **cdd** — tests-before-code in both domain packages (tests
  written and observed failing against the empty scaffold before
  implementation was written); primary branch artifact is the PR
  body + commit message per §2.5b check 3 for L5/L6 cycles.
- **testing** — table-driven where applicable (IsNewerVersion,
  platformBinaryName); httptest for HTTP surfaces so no network
  is needed in CI; happy + degraded paths for every network/IO
  operation.

### Project invariants (INVARIANTS.md)

| Constraint | Touched? | Status |
|---|---|---|
| INV-001 one package substrate | No (no new package format) | N/A |
| INV-003 distinct surfaces | Yes (new commands) | preserved — update/setup dispatched like every other Command |
| INV-004 kernel owns policy | Yes (update decides install) | preserved — no package-level override of update flow |
| T-002 kernel minimal | Yes (primary touch) | preserved — no new built-in accretion; update/setup are bootstrap commands already in the kernel manifest |
| T-003 Go kernel | Yes | preserved — pure Go, stdlib only, no CGo, no dynamic loading |
| T-004 source/artifact/installed explicit | No | N/A |
| P-001 two-agent minimum | Yes | reviewer TBD |

### Artifact order

Tests-before-code enforced in both packages. The test files were
written first, `go test ./internal/hubsetup/...` was run against
an empty scaffold (failed), then the implementation was written,
then tests passed. Same for binupdate. No inversion.

### cli/ line counts (eng/go §2.18)

- `cmd_setup.go` — 37 lines (wrapper only)
- `cmd_update.go` — 46 lines (wrapper + 5-line arg parse)

Both well under the ~30-line domain-logic threshold. All
substantive logic lives in `internal/hubsetup/` and
`internal/binupdate/`.

### Known debt (explicit, deferred)

- **No re-exec after binary update.** User is told to restart
  `cn` after a successful update. Phase 5 will need
  `syscall.Exec` + a CN_UPDATE_RUNNING guard to avoid recursion
  (cf. OCaml `cn_agent.re_exec`).
- **No package reconciliation after update.** Requires
  `default_manifest_for_profile` in Go which has not been
  ported. Would couple `binupdate` to `hubsetup`/restore — a
  Phase 5 concern.
- **No `--version` sanity check on the downloaded binary.**
  Checksum verification against `checksums.txt` is authoritative;
  running an unvalidated binary during the install step is not
  portable and cannot be tested without real binaries. OCaml's
  extra check is belt-and-suspenders.
- **`cn setup` does not invoke `deps restore` or write
  SOUL.md/USER.md templates.** Templates live inside `cnos.core`
  which is not guaranteed to be installed yet (chicken/egg). The
  user is told to run `cn deps restore` next.

### Build / vet / test / format

```
go build ./...    # clean
go vet ./...      # clean
go test ./...     # 9 packages, 63 tests, all pass
go test -race ./... # all pass
gofmt -l <new files> # clean (pre-existing non-gofmt files in internal/cli/, internal/pkg/, internal/restore/ not touched)
```

https://claude.ai/code/session_01PZrH3sTTTNrDURB7Gc8a6J