### PR TITLE
fix: cn status surfaces installed packages and command registry

### DIFF
--- a/src/go/cmd/cn/main.go
+++ b/src/go/cmd/cn/main.go
@@ -33,7 +33,8 @@ func main() {
 	reg.Register(&cli.InitCmd{})
 	reg.Register(&cli.SetupCmd{Version: version})
 	reg.Register(&cli.DepsCmd{})
-	reg.Register(&cli.StatusCmd{Version: version})
+	statusCmd := &cli.StatusCmd{Version: version, Registry: reg}
+	reg.Register(statusCmd)
 	doctorCmd := &cli.DoctorCmd{Version: version, Registry: reg}
 	reg.Register(doctorCmd)
 	reg.Register(&cli.BuildCmd{})

--- a/src/go/internal/cli/cmd_status.go
+++ b/src/go/internal/cli/cmd_status.go
@@ -6,9 +6,11 @@ import (
 	"github.com/usurobor/cnos/src/go/internal/hubstatus"
 )
 
-// StatusCmd implements the "status" command — shows hub info + installed packages.
+// StatusCmd implements the "status" command — shows hub info, installed
+// packages, and command registry. Thin wrapper per eng/go §2.18 (T-002).
 type StatusCmd struct {
-	Version string
+	Version  string
+	Registry *Registry // set by main.go for command registry display
 }
 
 func (c *StatusCmd) Spec() CommandSpec {
@@ -22,5 +24,29 @@ func (c *StatusCmd) Spec() CommandSpec {
 }
 
 func (c *StatusCmd) Run(_ context.Context, inv Invocation) error {
-	return hubstatus.Run(inv.HubPath, c.Version, inv.Stdout)
+	return hubstatus.Run(inv.HubPath, c.Version, registryToCommandInfo(c.Registry), inv.Stdout)
+}
+
+// registryToCommandInfo converts the cli Registry into the pure data
+// type hubstatus expects. This keeps hubstatus free of cli/ imports.
+func registryToCommandInfo(reg *Registry) []hubstatus.CommandInfo {
+	if reg == nil {
+		return nil
+	}
+	tierLabel := map[CommandTier]string{
+		TierKernel:    "kernel",
+		TierRepoLocal: "repo-local",
+		TierPackage:   "package",
+	}
+	var cmds []hubstatus.CommandInfo
+	for _, cmd := range reg.All() {
+		spec := cmd.Spec()
+		cmds = append(cmds, hubstatus.CommandInfo{
+			Name:    spec.Name,
+			Summary: spec.Summary,
+			Tier:    tierLabel[spec.Tier],
+			Package: spec.Package,
+		})
+	}
+	return cmds
 }

--- a/src/go/internal/hubstatus/hubstatus.go
+++ b/src/go/internal/hubstatus/hubstatus.go
@@ -1,6 +1,8 @@
 // Package hubstatus implements the cn status display logic.
 //
 // Extracted from cli/cmd_status.go per eng/go §2.18 (INVARIANTS.md T-002).
+// This package does not import cli/ — it accepts pure data types to
+// avoid import cycles (eng/go §2.17).
 package hubstatus
 
 import (
@@ -8,23 +10,62 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+
+	"github.com/usurobor/cnos/src/go/internal/pkg"
 )
 
-// Run displays hub info + installed packages with version drift detection.
-func Run(hubPath, version string, stdout io.Writer) error {
+// CommandInfo is the data hubstatus needs to display a command.
+// Populated by the cli layer from the Registry — no cli/ import needed.
+type CommandInfo struct {
+	Name    string
+	Summary string
+	Tier    string // "kernel", "repo-local", "package"
+	Package string // non-empty for package commands
+}
+
+// Run displays hub info, installed packages (from manifests), and
+// the command registry grouped by tier.
+//
+// Package metadata is read from cn.package.json inside each vendor
+// dir — not parsed from directory names (BUILD-AND-DIST.md: vendor
+// path is name/, no @version).
+//
+// Version drift compares each manifest's engines.cnos against the
+// running binary version.
+func Run(hubPath, version string, commands []CommandInfo, stdout io.Writer) error {
 	hubName := filepath.Base(hubPath)
 
 	fmt.Fprintf(stdout, "cn hub: %s\n\n", hubName)
-	fmt.Fprintf(stdout, "hub..................... ✓\n")
-	fmt.Fprintf(stdout, "name.................... ✓ %s\n", hubName)
-	fmt.Fprintf(stdout, "path.................... ✓ %s\n", hubPath)
+	fmt.Fprintf(stdout, "hub..................... %s\n", check)
+	fmt.Fprintf(stdout, "name.................... %s %s\n", check, hubName)
+	fmt.Fprintf(stdout, "path.................... %s %s\n", check, hubPath)
 
-	// List installed packages with version drift detection.
-	// Note: drift detection assumes all installed packages are first-party
-	// (version should match the binary version). This matches OCaml behavior
-	// in cn_system.ml::run_status. Third-party packages would need their
-	// own version authority — not yet supported.
+	if err := showPackages(hubPath, version, stdout); err != nil {
+		return err
+	}
+
+	showCommands(commands, stdout)
+	return nil
+}
+
+const (
+	check = "\u2713" // ✓
+	cross = "\u2717" // ✗
+)
+
+// installedPackage holds parsed manifest data for one installed package.
+type installedPackage struct {
+	name           string
+	version        string
+	enginesCnos    string
+	contentClasses []string
+}
+
+// showPackages lists installed packages with name, version, content
+// summary, and version drift detection.
+func showPackages(hubPath, version string, stdout io.Writer) error {
 	vendorDir := filepath.Join(hubPath, ".cn", "vendor", "packages")
 	entries, err := os.ReadDir(vendorDir)
 	if err != nil {
@@ -35,35 +76,97 @@ func Run(hubPath, version string, stdout io.Writer) error {
 		return fmt.Errorf("status: read vendor dir: %w", err)
 	}
 
-	hasDrift := false
+	var packages []installedPackage
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		name := entry.Name()
-		atIdx := strings.LastIndex(name, "@")
-		if atIdx < 0 {
+		dirName := entry.Name()
+		manifestPath := filepath.Join(vendorDir, dirName, "cn.package.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			// Skip dirs without a manifest — not a valid package.
 			continue
 		}
-		pkgName := name[:atIdx]
-		pkgVersion := name[atIdx+1:]
+		manifest, err := pkg.ParseFullManifestData(data)
+		if err != nil {
+			continue
+		}
+		packages = append(packages, installedPackage{
+			name:           manifest.Name,
+			version:        manifest.Version,
+			enginesCnos:    manifest.Engines.Cnos,
+			contentClasses: manifest.ContentClasses(),
+		})
+	}
 
-		if version != "" && pkgVersion != version {
+	if len(packages) == 0 {
+		fmt.Fprintf(stdout, "\nNo packages installed.\n")
+		return nil
+	}
+
+	// Sort by name for deterministic output (eng/go §2.13).
+	slices.SortFunc(packages, func(a, b installedPackage) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	fmt.Fprintf(stdout, "\nInstalled packages:\n")
+	hasDrift := false
+	for _, p := range packages {
+		content := ""
+		if len(p.contentClasses) > 0 {
+			content = " [" + strings.Join(p.contentClasses, ", ") + "]"
+		}
+
+		// Version drift: compare engines.cnos from manifest against
+		// the running binary version. If engines.cnos is set and does
+		// not match, flag drift.
+		if version != "" && p.enginesCnos != "" && p.enginesCnos != version {
 			hasDrift = true
-			fmt.Fprintf(stdout, "%s................. ✗ %s (expected %s)\n",
-				pkgName, pkgVersion, version)
+			fmt.Fprintf(stdout, "  %s %s %s (engines.cnos %s, running %s)%s\n",
+				cross, p.name, p.version, p.enginesCnos, version, content)
 		} else {
-			fmt.Fprintf(stdout, "%s................. ✓ %s\n",
-				pkgName, pkgVersion)
+			fmt.Fprintf(stdout, "  %s %s %s%s\n", check, p.name, p.version, content)
 		}
 	}
 
 	fmt.Fprintln(stdout)
 	if hasDrift {
-		fmt.Fprintf(stdout, "⚠ version_drift version=%s\n", version)
+		fmt.Fprintf(stdout, "%s version_drift version=%s\n", "\u26a0", version)
 	} else {
 		fmt.Fprintf(stdout, "ok version=%s\n", version)
 	}
 
 	return nil
+}
+
+// showCommands lists all registered commands grouped by tier.
+func showCommands(commands []CommandInfo, stdout io.Writer) {
+	if len(commands) == 0 {
+		return
+	}
+
+	// Group by tier. Tier strings are stable: "kernel", "repo-local", "package".
+	groups := map[string][]CommandInfo{}
+	for _, c := range commands {
+		groups[c.Tier] = append(groups[c.Tier], c)
+	}
+
+	tierOrder := []string{"kernel", "repo-local", "package"}
+
+	fmt.Fprintf(stdout, "\nCommands:\n")
+	for _, tier := range tierOrder {
+		items, ok := groups[tier]
+		if !ok || len(items) == 0 {
+			continue
+		}
+		fmt.Fprintf(stdout, "  %s:\n", tier)
+		for _, c := range items {
+			suffix := ""
+			if c.Package != "" {
+				suffix = fmt.Sprintf(" (%s)", c.Package)
+			}
+			fmt.Fprintf(stdout, "    %-16s %s%s\n", c.Name, c.Summary, suffix)
+		}
+	}
 }

--- a/src/go/internal/hubstatus/hubstatus_test.go
+++ b/src/go/internal/hubstatus/hubstatus_test.go
@@ -8,36 +8,101 @@ import (
 	"testing"
 )
 
+// writeManifest creates a cn.package.json in the vendor dir for the
+// given package name. Helper — keeps test setup concise.
+func writeManifest(t *testing.T, hub, name, manifest string) {
+	t.Helper()
+	dir := filepath.Join(hub, ".cn", "vendor", "packages", name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cn.package.json"), []byte(manifest), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunShowsPackages(t *testing.T) {
 	hub := t.TempDir()
-	for _, pkg := range []string{"cnos.core@3.48.0", "cnos.eng@3.48.0"} {
-		os.MkdirAll(filepath.Join(hub, ".cn", "vendor", "packages", pkg), 0755)
-	}
+	writeManifest(t, hub, "cnos.core", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.core",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"},
+		"skills": {"exposed": ["agent/cap"]},
+		"commands": {"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "Daily"}}
+	}`)
+	writeManifest(t, hub, "cnos.eng", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.eng",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"},
+		"skills": {"exposed": ["eng/go"]}
+	}`)
 
 	var stdout bytes.Buffer
-	if err := Run(hub, "3.48.0", &stdout); err != nil {
+	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
 		t.Fatalf("status: %v", err)
 	}
 
 	out := stdout.String()
 	if !strings.Contains(out, "cnos.core") {
-		t.Error("expected cnos.core")
+		t.Error("expected cnos.core in output")
 	}
-	if !strings.Contains(out, "✓ 3.48.0") {
-		t.Error("expected ✓ for matching version")
+	if !strings.Contains(out, "cnos.eng") {
+		t.Error("expected cnos.eng in output")
+	}
+	if !strings.Contains(out, "3.52.0") {
+		t.Error("expected version 3.52.0")
+	}
+	if !strings.Contains(out, "\u2713") {
+		t.Error("expected check mark for matching version")
+	}
+}
+
+func TestRunContentClasses(t *testing.T) {
+	hub := t.TempDir()
+	writeManifest(t, hub, "cnos.core", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.core",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"},
+		"skills": {"exposed": ["agent/cap"]},
+		"commands": {"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "Daily"}}
+	}`)
+
+	var stdout bytes.Buffer
+	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "[skills, commands]") {
+		t.Errorf("expected content classes [skills, commands] in output, got:\n%s", out)
 	}
 }
 
 func TestRunVersionDrift(t *testing.T) {
 	hub := t.TempDir()
-	os.MkdirAll(filepath.Join(hub, ".cn", "vendor", "packages", "cnos.core@3.42.0"), 0755)
+	writeManifest(t, hub, "cnos.core", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.core",
+		"version": "3.48.0",
+		"kind": "package",
+		"engines": {"cnos": "3.48.0"}
+	}`)
 
 	var stdout bytes.Buffer
-	Run(hub, "3.48.0", &stdout)
+	Run(hub, "3.52.0", nil, &stdout)
 
 	out := stdout.String()
-	if !strings.Contains(out, "✗ 3.42.0") {
-		t.Error("expected ✗ for mismatch")
+	if !strings.Contains(out, "\u2717") {
+		t.Error("expected cross mark for drift")
+	}
+	if !strings.Contains(out, "engines.cnos 3.48.0") {
+		t.Error("expected engines.cnos drift info")
 	}
 	if !strings.Contains(out, "version_drift") {
 		t.Error("expected version_drift warning")
@@ -48,11 +113,80 @@ func TestRunNoPackages(t *testing.T) {
 	hub := t.TempDir()
 
 	var stdout bytes.Buffer
-	if err := Run(hub, "3.48.0", &stdout); err != nil {
+	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
 		t.Fatalf("status: %v", err)
 	}
 
 	if !strings.Contains(stdout.String(), "No packages installed") {
 		t.Error("expected 'No packages installed'")
+	}
+}
+
+func TestRunCommandRegistry(t *testing.T) {
+	hub := t.TempDir()
+	// Create a minimal vendor dir so we get past the package section.
+	writeManifest(t, hub, "cnos.core", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.core",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"}
+	}`)
+
+	commands := []CommandInfo{
+		{Name: "help", Summary: "Show available commands", Tier: "kernel"},
+		{Name: "deploy", Summary: "Deploy to prod", Tier: "repo-local"},
+		{Name: "daily", Summary: "Daily reflection", Tier: "package", Package: "cnos.core"},
+	}
+
+	var stdout bytes.Buffer
+	if err := Run(hub, "3.52.0", commands, &stdout); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Commands:") {
+		t.Error("expected Commands: header")
+	}
+	if !strings.Contains(out, "kernel:") {
+		t.Error("expected kernel: tier group")
+	}
+	if !strings.Contains(out, "repo-local:") {
+		t.Error("expected repo-local: tier group")
+	}
+	if !strings.Contains(out, "package:") {
+		t.Error("expected package: tier group")
+	}
+	if !strings.Contains(out, "daily") {
+		t.Error("expected daily command listed")
+	}
+	if !strings.Contains(out, "(cnos.core)") {
+		t.Error("expected package attribution for daily command")
+	}
+}
+
+func TestRunSkipsDirsWithoutManifest(t *testing.T) {
+	hub := t.TempDir()
+	// Create a dir without cn.package.json — should be silently skipped.
+	os.MkdirAll(filepath.Join(hub, ".cn", "vendor", "packages", "junk"), 0755)
+	writeManifest(t, hub, "cnos.core", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.core",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"}
+	}`)
+
+	var stdout bytes.Buffer
+	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "junk") {
+		t.Error("junk dir without manifest should not appear")
+	}
+	if !strings.Contains(out, "cnos.core") {
+		t.Error("expected cnos.core in output")
 	}
 }

--- a/src/go/internal/pkg/pkg.go
+++ b/src/go/internal/pkg/pkg.go
@@ -104,14 +104,54 @@ type PackageCommandEntry struct {
 	Summary    string // brief description for help output
 }
 
+// EnginesJSON is the "engines" object in cn.package.json.
+// Currently only cnos compatibility is declared.
+type EnginesJSON struct {
+	Cnos string `json:"cnos"`
+}
+
+// SkillsJSON is the "skills" object in cn.package.json.
+type SkillsJSON struct {
+	Exposed  []string `json:"exposed"`
+	Internal []string `json:"internal"`
+}
+
 // FullPackageManifest is the extended shape of cn.package.json that
-// includes the commands object. Used by command discovery.
+// includes commands, engines, and content class objects. Used by
+// command discovery and status display.
 type FullPackageManifest struct {
-	Schema   string                          `json:"schema"`
-	Name     string                          `json:"name"`
-	Version  string                          `json:"version"`
-	Kind     string                          `json:"kind"`
-	Commands map[string]PackageCommandJSON   `json:"commands"`
+	Schema        string                        `json:"schema"`
+	Name          string                        `json:"name"`
+	Version       string                        `json:"version"`
+	Kind          string                        `json:"kind"`
+	Engines       EnginesJSON                   `json:"engines"`
+	Commands      map[string]PackageCommandJSON `json:"commands"`
+	Skills        *SkillsJSON                   `json:"skills"`
+	Orchestrators json.RawMessage               `json:"orchestrators"`
+	Extensions    json.RawMessage               `json:"extensions"`
+	Providers     json.RawMessage               `json:"providers"`
+}
+
+// ContentClasses returns the list of content classes present in this
+// package, in a stable order. Pure — no IO.
+func (m *FullPackageManifest) ContentClasses() []string {
+	var classes []string
+	if m.Skills != nil && (len(m.Skills.Exposed) > 0 || len(m.Skills.Internal) > 0) {
+		classes = append(classes, "skills")
+	}
+	if len(m.Commands) > 0 {
+		classes = append(classes, "commands")
+	}
+	if len(m.Orchestrators) > 0 && string(m.Orchestrators) != "null" {
+		classes = append(classes, "orchestrators")
+	}
+	if len(m.Extensions) > 0 && string(m.Extensions) != "null" {
+		classes = append(classes, "extensions")
+	}
+	if len(m.Providers) > 0 && string(m.Providers) != "null" {
+		classes = append(classes, "providers")
+	}
+	return classes
 }
 
 // PackageCommandJSON is the JSON shape of one command entry in


### PR DESCRIPTION
## Summary

- **Fix broken vendor path parsing** — `cn status` parsed vendor dirs as `name@version` but #229 changed to `name/`. Now reads `cn.package.json` manifests for package metadata instead of parsing directory names.
- **Show installed packages with content summary** — each package displays name, version, and content classes present (skills, commands, orchestrators, etc.)
- **Show command registry grouped by tier** — lists all registered commands (kernel / repo-local / package) with source attribution, reusing the existing `cli.Registry`
- **Fix version drift detection** — compares `engines.cnos` from manifest against running binary version, not directory name parsing

MVA Step 4 (#228), closes #233, satisfies #192 AC4.

## Key design decisions

- `hubstatus` accepts pure `CommandInfo` data type instead of importing `cli.Registry` directly — avoids import cycle, follows eng/go §2.17 (purity boundary)
- `cmd_status.go` stays a thin wrapper (~30 lines) with a `registryToCommandInfo()` converter — enforces T-002 (dispatch boundary)
- Package metadata read from manifests, not directory names — enforces T-004 (source/artifact/installed explicit)
- Output sorted by package name for deterministic display — eng/go §2.13

## Test plan

- [x] `TestRunShowsPackages` — packages listed from `name/` vendor dirs with manifests
- [x] `TestRunContentClasses` — content summary `[skills, commands]` shown
- [x] `TestRunVersionDrift` — drift detected via `engines.cnos` mismatch
- [x] `TestRunNoPackages` — graceful "No packages installed" when vendor dir missing
- [x] `TestRunCommandRegistry` — commands grouped by kernel/repo-local/package tiers
- [x] `TestRunSkipsDirsWithoutManifest` — dirs without `cn.package.json` silently skipped
- [x] `go build ./...`, `go test ./...`, `go vet ./...` all pass
- [x] End-to-end: `cn build` → manual vendor setup → `cn status` shows correct output

https://claude.ai/code/session_01KMDo4rawmKDKAZBaoCHoJ8