### PR TITLE
ci: run Tier 1 kata in release workflow before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,25 @@ jobs:
           cp src/go/cn dist/cn-${{ matrix.target }}
           chmod +x dist/cn-${{ matrix.target }}
 
+      - name: Configure git identity
+        # `cn doctor` (kata 04) checks git user.name / user.email.
+        # GitHub runners have no default identity — set one so the
+        # Tier 1 doctor kata sees a clean config.
+        run: |
+          git config --global user.name "release-ci"
+          git config --global user.email "release-ci@cnos.local"
+
+      - name: Run Tier 1 kata (shipped binary)
+        # Prove the packaged binary — the one being shipped — works
+        # end-to-end (help → init → status → doctor → build → install)
+        # on this platform before uploading. If any kata fails here,
+        # the matrix position fails, the `release` job's `needs: build`
+        # gate fails, and no artifacts are published.
+        run: |
+          cp dist/cn-${{ matrix.target }} cn
+          export PATH="$PWD:$PATH"
+          scripts/kata/run-all.sh
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Closes #246.

## Summary

Insert the Tier 1 kata suite into the release workflow's build matrix, between `Package binary` and `Upload artifact`. The binary being tested is the packaged binary (bit-identical to the uploaded artifact). If any kata fails on any of the 4 matrix platforms (linux-x64, linux-arm64, macos-x64, macos-arm64), that matrix job fails, the `release` job's `needs: build` gate blocks, and no artifacts are published.

The `ci` workflow already runs `kata-tier1` on PRs — but fresh compiles on release matrix runners were unproven until now (a platform-specific regression on e.g. macos-arm64 could ship). This closes that gap.

## CDD Trace

| Step | Evidence |
|------|----------|
| **Gap** | Release matrix builds binaries for 4 platforms and publishes without running any kata (#246). Fresh compiles on different OS/arch are unproven at ship time. |
| **Mode** | MCA — all infrastructure (Tier 1 kata, `run-all.sh`, CI pattern in `ci.yml`) exists. Pure wiring. |
| **Cycle level** | L5 — local correctness; follows the established pattern from `kata-tier1` in `ci.yml`. No boundary change. |
| **Active skills** | `eng/go` (CI/build structure), `cdd` |
| **Invariants touched** | T-003 (Go sole language / all CI+release workflows use Go exclusively) — **preserved**: kata runs the Go binary only; no new deps, no language additions. |
| **Tests** | The kata **is** the test. Locally simulated the exact release-workflow step sequence on linux-x64 (checkout → `go build -o cn ./cmd/cn` → package → `cp dist/cn-linux-x64 cn; export PATH=...; scripts/kata/run-all.sh`) and all 6 kata pass on the shipped binary. |
| **Round-trip** | `cn build` inside kata 05 writes only `dist/packages/`; the packaged binary at `dist/cn-${target}` is untouched and uploaded cleanly. |

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | +19 lines: two steps inserted into the `build` matrix — `Configure git identity` (required by `cn doctor` per kata 04) and `Run Tier 1 kata (shipped binary)`. |

## Placement rationale (AC3)

```
Build binary → Test → Package binary → [Configure git identity] → [Run Tier 1 kata] → Upload artifact
```

The kata runs on `cp dist/cn-${matrix.target} cn` — byte-identical to the uploaded artifact. AC3 ("the binary being tested is the binary being shipped") is satisfied structurally, not by parallel build.

## AC checklist

- [x] **AC1** — Release workflow runs `scripts/kata/run-all.sh` against the freshly-built binary on each platform before the publish step. *Evidence: new "Run Tier 1 kata (shipped binary)" step executes on every matrix position in `build`.*
- [x] **AC2** — If any kata fails on any platform, the release is blocked; no artifacts published. *Evidence: kata failure → step fails → matrix job fails → `release.needs: build` gate fails → publish never runs. The 4 platforms are matrix siblings; any sibling failure fails the aggregate.*
- [x] **AC3** — Kata run after binary build, before artifact upload. Tested binary is the shipped binary. *Evidence: step placement between `Package binary` and `Upload artifact`; `cp dist/cn-${{ matrix.target }} cn` puts the packaged binary on PATH for the kata.*

## Self-coherence (§2.5b)

1. Branch rebased onto current `main` — ✓ (branch tip is 1 commit ahead of `origin/main`).
2. Self-coherence — this PR body carries the CDD Trace (L5 narrative, matches #239/#234/#231 convention).
3. CDD Trace in PR body — ✓ above.
4. Tests reference ACs — each AC maps to step placement / matrix wiring; see AC checklist above.
5. Known debt — none.
6. Schema/shape audit — no schema/fixture changes in this diff.
7. Workspace-global library-name uniqueness — no new libraries.
8. CI green on head commit before marking ready-for-review — draft until the `go` + `kata-tier1` jobs pass on this PR's head.

## Test plan

- [x] Local simulation: run the release-workflow step sequence (build → package → kata) on linux-x64 with a freshly-built `cn`; all 6 kata pass end-to-end on the packaged binary.
- [ ] CI `go` + `kata-tier1` green on head commit (gating ready-for-review).
- [ ] On next release-tag push, observe the `build` matrix run the new kata step on all 4 platforms before any artifact upload, and the `release` job block if any platform fails.

## Known debt

None.
