### PR TITLE
feat: git-style subcommand dispatch (cn <noun> <verb>)

### DIFF
--- a/src/go/cmd/cn/main.go
+++ b/src/go/cmd/cn/main.go
@@ -63,24 +63,41 @@ func main() {
 		os.Exit(0)
 	}
 
-	cmdName := os.Args[1]
-	args := os.Args[2:]
+	// Resolve the command — supports noun-verb form (cn kata run),
+	// flat form (cn kata-run), and noun-group listing (cn kata).
+	// See docs/alpha/DESIGN-CONSTRAINTS.md §3.1.
+	res := cli.ResolveCommand(reg, os.Args[1:])
 
-	cmd, ok := reg.Lookup(cmdName)
-	if !ok {
-		fmt.Fprintf(os.Stderr, "✗ Unknown command: %s\n\n", cmdName)
+	// Group case: args[0] is a noun prefix with no matching verb.
+	if res.Group != "" {
+		unknownVerb := len(res.Remaining) > 0 && !strings.HasPrefix(res.Remaining[0], "-")
+		if unknownVerb {
+			fmt.Fprintf(os.Stderr, "✗ Unknown subcommand: %s %s\n\n", res.Group, res.Remaining[0])
+			cli.PrintGroup(os.Stderr, reg, res.Group)
+			os.Exit(1)
+		}
+		cli.PrintGroup(os.Stdout, reg, res.Group)
+		os.Exit(0)
+	}
+
+	// No command, no group — unknown.
+	if res.Command == nil {
+		fmt.Fprintf(os.Stderr, "✗ Unknown command: %s\n\n", os.Args[1])
 		fmt.Fprintf(os.Stderr, "Run 'cn help' to see available commands.\n")
 		os.Exit(1)
 	}
 
+	cmd := res.Command
+	args := res.Remaining
+
 	// Check hub requirement.
 	spec := cmd.Spec()
 	if spec.NeedsHub && hubPath == "" {
-		fmt.Fprintf(os.Stderr, "✗ Command '%s' requires a hub, but no hub found.\n\n", cmdName)
+		fmt.Fprintf(os.Stderr, "✗ Command '%s' requires a hub, but no hub found.\n\n", spec.Name)
 		fmt.Fprintf(os.Stderr, "Fix by running:\n")
 		fmt.Fprintf(os.Stderr, "  1) cn init    (to create a new hub)\n")
 		fmt.Fprintf(os.Stderr, "  2) cd <hub>   (to enter an existing hub)\n\n")
-		fmt.Fprintf(os.Stderr, "Then rerun: cn %s %s\n", cmdName, strings.Join(args, " "))
+		fmt.Fprintf(os.Stderr, "Then rerun: cn %s\n", strings.Join(os.Args[1:], " "))
 		os.Exit(1)
 	}
 

--- a/src/go/internal/cli/cmd_help.go
+++ b/src/go/internal/cli/cmd_help.go
@@ -22,6 +22,15 @@ func (c *HelpCmd) Spec() CommandSpec {
 }
 
 func (c *HelpCmd) Run(_ context.Context, inv Invocation) error {
+	// `cn help <noun>` — show the subcommand listing for a noun group.
+	// Falls through to the full listing when <noun> is not a group, so
+	// `cn help <unknown>` remains informative rather than erroring.
+	if len(inv.Args) > 0 {
+		if PrintGroup(inv.Stdout, c.Registry, inv.Args[0]) {
+			return nil
+		}
+	}
+
 	hasHub := inv.HubPath != ""
 
 	// Kernel commands are always part of the binary and always listed —

--- a/src/go/internal/cli/dispatch.go
+++ b/src/go/internal/cli/dispatch.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Resolution is the outcome of ResolveCommand.
+//
+// Exactly one of Command or Group is non-empty; both are empty when no
+// command matched and args[0] is not a known noun prefix.
+type Resolution struct {
+	// Command is the resolved command, or nil if no command matched.
+	Command Command
+
+	// Remaining is the args to pass to the command after the command
+	// name. When Group is set, it holds the args after the noun.
+	Remaining []string
+
+	// Group is set when no command matched but args[0] is a noun
+	// prefix of one or more "<noun>-<verb>" commands. The caller
+	// should list the group's members.
+	Group string
+}
+
+// ResolveCommand returns the command to dispatch for the given argv
+// (without the program name).
+//
+// Lookup order — see docs/alpha/DESIGN-CONSTRAINTS.md §3.1:
+//
+//  1. Noun-verb form: args[0]+"-"+args[1] as a registry key
+//     (e.g., "kata run" → "kata-run").
+//  2. Flat form: args[0] as a registry key
+//     (e.g., "kata-run", "doctor"). Backward-compat for the
+//     hyphenated form.
+//  3. Group: args[0] matches "<noun>-*" in the registry with no
+//     matching verb. Caller lists the group.
+//
+// The user-facing surface is noun-verb. The flat form is kept as an
+// undocumented fallback so existing scripts do not break.
+func ResolveCommand(reg *Registry, args []string) Resolution {
+	if len(args) == 0 {
+		return Resolution{}
+	}
+
+	// 1. Noun-verb form.
+	if len(args) >= 2 {
+		if cmd, ok := reg.Lookup(args[0] + "-" + args[1]); ok {
+			return Resolution{Command: cmd, Remaining: args[2:]}
+		}
+	}
+
+	// 2. Flat form.
+	if cmd, ok := reg.Lookup(args[0]); ok {
+		return Resolution{Command: cmd, Remaining: args[1:]}
+	}
+
+	// 3. Group prefix.
+	if len(GroupMembers(reg, args[0])) > 0 {
+		return Resolution{Group: args[0], Remaining: args[1:]}
+	}
+
+	return Resolution{}
+}
+
+// GroupMembers returns commands whose name starts with prefix+"-".
+// Results are returned in registry order so help output is deterministic.
+func GroupMembers(reg *Registry, prefix string) []Command {
+	pfx := prefix + "-"
+	var cmds []Command
+	for _, c := range reg.All() {
+		if strings.HasPrefix(c.Spec().Name, pfx) {
+			cmds = append(cmds, c)
+		}
+	}
+	return cmds
+}
+
+// PrintGroup writes a help listing for a noun prefix to w.
+//
+// The listing uses the user-facing space-separated form
+// ("kata run") rather than the internal hyphenated key ("kata-run").
+// Returns false when the prefix has no members.
+func PrintGroup(w io.Writer, reg *Registry, prefix string) bool {
+	members := GroupMembers(reg, prefix)
+	if len(members) == 0 {
+		return false
+	}
+
+	pfx := prefix + "-"
+
+	// Compute the widest verb for column alignment.
+	maxVerb := 0
+	for _, c := range members {
+		verb := strings.TrimPrefix(c.Spec().Name, pfx)
+		if len(verb) > maxVerb {
+			maxVerb = len(verb)
+		}
+	}
+
+	fmt.Fprintf(w, "Usage: cn %s <subcommand>\n\n", prefix)
+	fmt.Fprintf(w, "Subcommands:\n")
+	for _, c := range members {
+		spec := c.Spec()
+		verb := strings.TrimPrefix(spec.Name, pfx)
+		fmt.Fprintf(w, "  %s %-*s  %s\n", prefix, maxVerb, verb, spec.Summary)
+	}
+	return true
+}

--- a/src/go/internal/cli/dispatch_test.go
+++ b/src/go/internal/cli/dispatch_test.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// newTestRegistry builds a registry populated with a representative mix
+// of flat kernel commands and a "kata" noun group.
+func newTestRegistry() *Registry {
+	reg := NewRegistry()
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "help", Summary: "Show available commands", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "doctor", Summary: "Run diagnostic checks", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "deps", Summary: "Manage package dependencies", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "kata-run", Summary: "Run a kata", Source: SourcePackage, Tier: TierPackage, Package: "cnos.kata"}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "kata-list", Summary: "List katas", Source: SourcePackage, Tier: TierPackage, Package: "cnos.kata"}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "kata-judge", Summary: "Judge a kata bundle", Source: SourcePackage, Tier: TierPackage, Package: "cnos.kata"}})
+	return reg
+}
+
+func TestResolveCommandNounVerb(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"kata", "run", "--verbose", "M0-gap"})
+
+	if res.Command == nil {
+		t.Fatal("expected kata-run to resolve, got nil")
+	}
+	if got := res.Command.Spec().Name; got != "kata-run" {
+		t.Errorf("Command.Name = %q, want %q", got, "kata-run")
+	}
+	if !reflect.DeepEqual(res.Remaining, []string{"--verbose", "M0-gap"}) {
+		t.Errorf("Remaining = %v, want [--verbose M0-gap]", res.Remaining)
+	}
+	if res.Group != "" {
+		t.Errorf("Group = %q, want empty", res.Group)
+	}
+}
+
+func TestResolveCommandFlatBackwardCompat(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"kata-run", "--verbose"})
+
+	if res.Command == nil {
+		t.Fatal("expected kata-run to resolve from flat form")
+	}
+	if got := res.Command.Spec().Name; got != "kata-run" {
+		t.Errorf("Command.Name = %q, want %q", got, "kata-run")
+	}
+	if !reflect.DeepEqual(res.Remaining, []string{"--verbose"}) {
+		t.Errorf("Remaining = %v, want [--verbose]", res.Remaining)
+	}
+}
+
+func TestResolveCommandFlatKernelCommand(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"doctor"})
+
+	if res.Command == nil {
+		t.Fatal("expected doctor to resolve")
+	}
+	if got := res.Command.Spec().Name; got != "doctor" {
+		t.Errorf("Command.Name = %q, want %q", got, "doctor")
+	}
+	if len(res.Remaining) != 0 {
+		t.Errorf("Remaining = %v, want empty", res.Remaining)
+	}
+}
+
+func TestResolveCommandDepsSubcommandPreserved(t *testing.T) {
+	// `cn deps lock` should fall back to the flat `deps` command with
+	// ["lock"] as args, because `deps-lock` is not a separate registry
+	// entry. This preserves DepsCmd's internal subcommand dispatch.
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"deps", "lock"})
+
+	if res.Command == nil {
+		t.Fatal("expected deps to resolve")
+	}
+	if got := res.Command.Spec().Name; got != "deps" {
+		t.Errorf("Command.Name = %q, want %q", got, "deps")
+	}
+	if !reflect.DeepEqual(res.Remaining, []string{"lock"}) {
+		t.Errorf("Remaining = %v, want [lock]", res.Remaining)
+	}
+}
+
+func TestResolveCommandGroupNoVerb(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"kata"})
+
+	if res.Command != nil {
+		t.Errorf("Command = %v, want nil (group case)", res.Command)
+	}
+	if res.Group != "kata" {
+		t.Errorf("Group = %q, want %q", res.Group, "kata")
+	}
+	if len(res.Remaining) != 0 {
+		t.Errorf("Remaining = %v, want empty", res.Remaining)
+	}
+}
+
+func TestResolveCommandGroupUnknownVerb(t *testing.T) {
+	// `cn kata bogus` — not a known verb; kata-* exists.
+	// The resolver reports the group and the caller decides what to do
+	// with the unknown verb (we keep it in Remaining for the caller).
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"kata", "bogus"})
+
+	if res.Command != nil {
+		t.Errorf("Command = %v, want nil", res.Command)
+	}
+	if res.Group != "kata" {
+		t.Errorf("Group = %q, want %q", res.Group, "kata")
+	}
+	if !reflect.DeepEqual(res.Remaining, []string{"bogus"}) {
+		t.Errorf("Remaining = %v, want [bogus]", res.Remaining)
+	}
+}
+
+func TestResolveCommandGroupHelpFlag(t *testing.T) {
+	// `cn kata --help` — --help is not a verb, falls through to group.
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"kata", "--help"})
+
+	if res.Group != "kata" {
+		t.Errorf("Group = %q, want %q", res.Group, "kata")
+	}
+	if !reflect.DeepEqual(res.Remaining, []string{"--help"}) {
+		t.Errorf("Remaining = %v, want [--help]", res.Remaining)
+	}
+}
+
+func TestResolveCommandUnknown(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, []string{"bogus"})
+
+	if res.Command != nil {
+		t.Errorf("Command = %v, want nil", res.Command)
+	}
+	if res.Group != "" {
+		t.Errorf("Group = %q, want empty", res.Group)
+	}
+}
+
+func TestResolveCommandEmpty(t *testing.T) {
+	reg := newTestRegistry()
+
+	res := ResolveCommand(reg, nil)
+
+	if res.Command != nil || res.Group != "" {
+		t.Errorf("empty args should give empty Resolution, got %+v", res)
+	}
+}
+
+func TestGroupMembersOrder(t *testing.T) {
+	reg := newTestRegistry()
+
+	members := GroupMembers(reg, "kata")
+
+	if len(members) != 3 {
+		t.Fatalf("len(members) = %d, want 3", len(members))
+	}
+	want := []string{"kata-run", "kata-list", "kata-judge"}
+	for i, m := range members {
+		if m.Spec().Name != want[i] {
+			t.Errorf("members[%d].Name = %q, want %q", i, m.Spec().Name, want[i])
+		}
+	}
+}
+
+func TestGroupMembersEmpty(t *testing.T) {
+	reg := newTestRegistry()
+
+	if got := GroupMembers(reg, "bogus"); len(got) != 0 {
+		t.Errorf("GroupMembers(bogus) = %v, want empty", got)
+	}
+}
+
+func TestGroupMembersExactNameNotMember(t *testing.T) {
+	// A flat command named "deps" should not be returned as a member of
+	// the "deps" group — only "deps-<verb>" commands are.
+	reg := newTestRegistry()
+
+	if got := GroupMembers(reg, "deps"); len(got) != 0 {
+		t.Errorf("GroupMembers(deps) = %v, want empty (deps is flat, not a group)", got)
+	}
+}
+
+func TestPrintGroup(t *testing.T) {
+	reg := newTestRegistry()
+
+	var buf bytes.Buffer
+	ok := PrintGroup(&buf, reg, "kata")
+
+	if !ok {
+		t.Fatal("PrintGroup returned false for a known group")
+	}
+	out := buf.String()
+	// User-facing form uses "kata run", not "kata-run".
+	for _, want := range []string{"kata run", "kata list", "kata judge", "Run a kata", "List katas", "Judge a kata bundle"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, out)
+		}
+	}
+	// Internal hyphenated keys must not leak to the user-facing listing.
+	if strings.Contains(out, "kata-run") {
+		t.Errorf("output leaks internal hyphenated key kata-run:\n%s", out)
+	}
+}
+
+func TestPrintGroupUnknownPrefix(t *testing.T) {
+	reg := newTestRegistry()
+
+	var buf bytes.Buffer
+	ok := PrintGroup(&buf, reg, "bogus")
+
+	if ok {
+		t.Error("PrintGroup should return false for unknown prefix")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("PrintGroup wrote %q for unknown prefix, want nothing", buf.String())
+	}
+}

--- a/src/go/internal/cli/registry_test.go
+++ b/src/go/internal/cli/registry_test.go
@@ -139,6 +139,66 @@ func TestHelpCmdNoHub(t *testing.T) {
 	}
 }
 
+func TestHelpCmdGroupListing(t *testing.T) {
+	// `cn help kata` — HelpCmd must dispatch to the group listing
+	// instead of the full kernel listing.
+	reg := NewRegistry()
+	help := &HelpCmd{Registry: reg}
+	reg.Register(help)
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "kata-run", Summary: "Run a kata", Source: SourcePackage, Tier: TierPackage}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "kata-list", Summary: "List katas", Source: SourcePackage, Tier: TierPackage}})
+
+	var stdout bytes.Buffer
+	inv := Invocation{
+		HubPath: "/some/hub",
+		Args:    []string{"kata"},
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	if err := help.Run(context.Background(), inv); err != nil {
+		t.Fatalf("help.Run: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "kata run") {
+		t.Errorf("expected 'kata run' in group listing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "kata list") {
+		t.Errorf("expected 'kata list' in group listing, got:\n%s", out)
+	}
+	if strings.Contains(out, "Kernel commands:") {
+		t.Errorf("group listing should not include the full kernel listing:\n%s", out)
+	}
+}
+
+func TestHelpCmdUnknownGroupFallsThrough(t *testing.T) {
+	// `cn help bogus` — unknown noun falls through to the full listing
+	// rather than erroring.
+	reg := NewRegistry()
+	help := &HelpCmd{Registry: reg}
+	reg.Register(help)
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "deps", Summary: "Manage package dependencies", Source: SourceKernel}})
+
+	var stdout bytes.Buffer
+	inv := Invocation{
+		HubPath: "/some/hub",
+		Args:    []string{"bogus"},
+		Stdout:  &stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	if err := help.Run(context.Background(), inv); err != nil {
+		t.Fatalf("help.Run: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Kernel commands:") {
+		t.Errorf("expected full listing fallback, got:\n%s", out)
+	}
+	if !strings.Contains(out, "deps") {
+		t.Errorf("expected 'deps' in fallback full listing, got:\n%s", out)
+	}
+}
+
 func TestHelpCmdTieredOutput(t *testing.T) {
 	reg := NewRegistry()
 	help := &HelpCmd{Registry: reg}


### PR DESCRIPTION
## Gap

cnos commands are flat-hyphenated (`cn kata-run`, `cn cdd-verify`). Standard CLI convention (git, docker, gh, kubectl) is `<noun> <verb>`. DESIGN-CONSTRAINTS §3.1 already names this the convention; this PR implements it.

Closes #254.

## Mode

MCA (mechanize the existing design constraint in dispatch).

## Tier 3 skills

- `eng/go` (§2.18 dispatch boundary — `cli/` owns dispatch, domain packages own logic)
- `eng/ux-cli` (group listing format, error messages)

## What changed

- `src/go/internal/cli/dispatch.go` (new) — `ResolveCommand`, `GroupMembers`, `PrintGroup`.
- `src/go/internal/cli/dispatch_test.go` (new) — 14 tests covering noun-verb, flat fallback, group, help-flag, unknown verb/command, empty args, deps preservation, user-facing formatting.
- `src/go/cmd/cn/main.go` — dispatch uses `ResolveCommand`; on group, list subcommands (stdout on help, stderr + exit 1 on unknown verb).
- `src/go/internal/cli/cmd_help.go` — `cn help <noun>` prints group listing; unknown noun falls through to full listing.
- `src/go/internal/cli/registry_test.go` — add two HelpCmd tests (group listing, unknown-group fallthrough).

## Lookup order

1. Noun-verb: `args[0]+"-"+args[1]` in registry → dispatch with `args[2:]`.
2. Flat: `args[0]` in registry → dispatch with `args[1:]` (backward-compat).
3. Group: `args[0]-*` exists in registry → list members.
4. Unknown → error.

Flat form is an undocumented fallback so existing scripts (`cn kata-run`) still work. User-facing surface is space-separated; registry keys remain hyphenated (AC5).

`DepsCmd` is preserved: `deps-lock` is not a separate registry entry, so `cn deps lock` takes the flat path (rule 2) and `DepsCmd.Run` handles its internal subcommand.

## Acceptance criteria

- [x] **AC1:** `cn <noun> <verb>` dispatches to `<noun>-<verb>` — `TestResolveCommandNounVerb` + integration test `cn kata run M0-gap`.
- [x] **AC2:** `cn <noun>` (no verb) shows available subcommands — `TestResolveCommandGroupNoVerb` + `TestPrintGroup` + integration test.
- [x] **AC3:** `cn help <noun>` shows grouped subcommand help — `TestHelpCmdGroupListing` + integration test `cn help kata`.
- [x] **AC4:** Flat names still work — `TestResolveCommandFlatBackwardCompat` + integration test `cn kata-run M0-gap`.
- [x] **AC5:** No `cn.package.json` schema changes; internal key stays hyphenated — diff touches only 5 Go files; `PrintGroup` verifies no hyphenated key leaks to the user-facing listing.

## Self-coherence

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  .../internal/cli        (23 tests including 14 new)
ok  .../internal/... (all other packages)
```

Integration-tested against a synthetic hub vendoring `cnos.kata`: noun-verb dispatch, flat backward-compat, `cn kata` listing, `cn help kata`, `cn kata --help`, `cn kata bogus` (error + listing + exit 1), `cn bogus` (unknown command), `cn deps` (internal subcommand preserved), `cn` no-args (full help).

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | — | Issue #254 + DESIGN-CONSTRAINTS §3.1 already converged |
| 1 Select | — | — | #254 (user-facing CLI coherence with git convention) |
| 4 Gap | this PR body | — | Dispatch flat-only; convention says noun-verb |
| 5 Mode | this PR body | cdd, eng/go, eng/ux-cli | MCA; L6 (dispatch behavior + tests + docs align) |
| 6 Artifacts | diff | eng/go, eng/ux-cli | Code + tests + integration-verified |
| 7 Self-coherence | this PR body | cdd | `go build/vet/test` clean; 10 integration scenarios pass |
| 7a Pre-review | this PR body | cdd | Branch on head of main; CI pending |
