### PR TITLE
fix: converge ContentClasses across cn build --check and cn status (#253)

### DIFF
--- a/docs/alpha/package-system/PACKAGE-SYSTEM.md
+++ b/docs/alpha/package-system/PACKAGE-SYSTEM.md
@@ -43,9 +43,10 @@ a package's source directory at `src/packages/<name>/<class>/`.
 | templates | named files | `src/packages/<name>/templates/` | Identity/config scaffolding for new hubs |
 | commands | directory trees | `src/packages/<name>/commands/` | Operator-facing CLI commands |
 | orchestrators | directory trees | `src/packages/<name>/orchestrators/` | Mechanical workflows (`cn.orchestrator.v1`) |
+| katas | directory trees | `src/packages/<name>/katas/` | Executable verification scenarios bundled with the artefact they prove |
 | (metadata) | implicit | `src/packages/<name>/` | `cn.package.json` — package identity, version, engine constraint |
 
-All seven content classes are co-located with their package manifest.
+All eight content classes are co-located with their package manifest.
 `cn build` assembles each package from `src/packages/<name>/` into
 a tarball in `dist/packages/`. `cn deps restore` installs from dist
 into `.cn/vendor/packages/<name>/` on a hub. Content is authored
@@ -189,8 +190,11 @@ co-located with the manifest, so no `sources` map is needed.
 
 `cn build` discovers content classes by scanning for known directory
 names (`doctrine/`, `mindsets/`, `skills/`, `templates/`, `commands/`,
-`orchestrators/`, `extensions/`) inside each package's source directory.
-A package includes only the classes it has directories for.
+`orchestrators/`, `extensions/`, `katas/`) inside each package's
+source directory. A package includes only the classes it has
+directories for. The canonical list is defined once in
+`src/go/internal/pkg/pkg.go` (`pkg.ContentClasses`) and shared by
+`cn build --check` and `cn status` via `pkgbuild.FindContentClasses`.
 
 ---
 
@@ -206,7 +210,7 @@ extensible model.
 - **Semantics**: Different classes have different copy modes (file vs tree vs wildcard). These are not interchangeable.
 - **Readability**: Each class is a known directory name. No configuration needed.
 - **Debugging**: A mismatch in one class is easy to identify.
-- **Current scale**: 7 classes. The explicit model is not a maintenance burden.
+- **Current scale**: 8 classes. The explicit model is not a maintenance burden.
 
 **When to reconsider:**
 
@@ -223,8 +227,8 @@ Templates became a content class (rather than being special-cased) because:
 
 ### 4.3 Why the set is closed (for now)
 
-The current 6 content classes cover all shipped cognitive assets plus
-identity templates. The set is intentionally closed:
+The current 8 content classes cover all shipped cognitive assets plus
+identity templates and bundled verification katas. The set is intentionally closed:
 
 - New classes should be added only when an existing asset type cannot
   be served by any current class
@@ -267,6 +271,8 @@ identity templates. The set is intentionally closed:
 | v3.24.0 | Templates added as 5th content class (#119) |
 | v3.37.0 | Commands migrated from built-in to package content class |
 | v3.51.0 | Content co-located with manifests in `src/packages/`; `sources` field removed |
+| v3.55.0 | Katas added as 8th content class (kata framework split; `cnos.kata`, `cnos.cdd.kata`) |
+| #253 | Single source of truth in `pkg.ContentClasses`; `cn status` and `cn build --check` agree on membership via filesystem presence |
 
 ---
 

--- a/docs/alpha/package-system/PACKAGE-SYSTEM.md
+++ b/docs/alpha/package-system/PACKAGE-SYSTEM.md
@@ -74,7 +74,7 @@ The build system uses two copy strategies:
 - **Individual file copy**: Used by doctrine (when named), mindsets, and templates.
   Each declared entry is a single file name relative to the package's class directory.
 
-- **Directory tree copy**: Used by skills, extensions, commands, and orchestrators.
+- **Directory tree copy**: Used by skills, extensions, commands, orchestrators, and katas.
   Each declared entry is a directory path. The entire subtree is copied recursively.
 
 Doctrine has a special case: `"*"` copies all `.md` files (wildcard mode).

--- a/src/go/internal/hubstatus/hubstatus.go
+++ b/src/go/internal/hubstatus/hubstatus.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/pkgbuild"
 )
 
 // CommandInfo is the data hubstatus needs to display a command.
@@ -82,7 +83,8 @@ func showPackages(hubPath, version string, stdout io.Writer) error {
 			continue
 		}
 		dirName := entry.Name()
-		manifestPath := filepath.Join(vendorDir, dirName, "cn.package.json")
+		pkgDir := filepath.Join(vendorDir, dirName)
+		manifestPath := filepath.Join(pkgDir, "cn.package.json")
 		data, err := os.ReadFile(manifestPath)
 		if err != nil {
 			// Skip dirs without a manifest — not a valid package.
@@ -92,11 +94,14 @@ func showPackages(hubPath, version string, stdout io.Writer) error {
 		if err != nil {
 			continue
 		}
+		// Content classes are discovered from filesystem presence, not
+		// manifest JSON fields (PACKAGE-SYSTEM.md §3). This is the same
+		// authority used by `cn build --check` via pkgbuild.FindContentClasses.
 		packages = append(packages, installedPackage{
 			name:           manifest.Name,
 			version:        manifest.Version,
 			enginesCnos:    manifest.Engines.Cnos,
-			contentClasses: manifest.ContentClasses(),
+			contentClasses: pkgbuild.FindContentClasses(pkgDir),
 		})
 	}
 

--- a/src/go/internal/hubstatus/hubstatus_test.go
+++ b/src/go/internal/hubstatus/hubstatus_test.go
@@ -21,6 +21,21 @@ func writeManifest(t *testing.T, hub, name, manifest string) {
 	}
 }
 
+// writeContentDir creates a non-empty content-class directory inside an
+// installed package dir. Used by tests that exercise the filesystem-based
+// content-class discovery path (pkgbuild.FindContentClasses).
+func writeContentDir(t *testing.T, hub, pkgName, class string) {
+	t.Helper()
+	dir := filepath.Join(hub, ".cn", "vendor", "packages", pkgName, class)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A single marker file satisfies the "non-empty" check.
+	if err := os.WriteFile(filepath.Join(dir, ".keep"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunShowsPackages(t *testing.T) {
 	hub := t.TempDir()
 	writeManifest(t, hub, "cnos.core", `{
@@ -68,10 +83,13 @@ func TestRunContentClasses(t *testing.T) {
 		"name": "cnos.core",
 		"version": "3.52.0",
 		"kind": "package",
-		"engines": {"cnos": "3.52.0"},
-		"skills": {"exposed": ["agent/cap"]},
-		"commands": {"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "Daily"}}
+		"engines": {"cnos": "3.52.0"}
 	}`)
+	// Content classes are discovered from the package directory tree,
+	// not from manifest JSON fields. Presence is the single authority
+	// (PACKAGE-SYSTEM.md §3).
+	writeContentDir(t, hub, "cnos.core", "skills")
+	writeContentDir(t, hub, "cnos.core", "commands")
 
 	var stdout bytes.Buffer
 	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
@@ -81,6 +99,39 @@ func TestRunContentClasses(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "[skills, commands]") {
 		t.Errorf("expected content classes [skills, commands] in output, got:\n%s", out)
+	}
+}
+
+// TestRunContentClassesAllEight verifies that cn status surfaces every
+// content class enumerated in pkg.ContentClasses when the installed
+// package contains all of them. This is the cn status side of the
+// convergence proved by TestFindContentClassesAll in pkgbuild.
+func TestRunContentClassesAllEight(t *testing.T) {
+	hub := t.TempDir()
+	writeManifest(t, hub, "cnos.full", `{
+		"schema": "cn.package.v1",
+		"name": "cnos.full",
+		"version": "3.52.0",
+		"kind": "package",
+		"engines": {"cnos": "3.52.0"}
+	}`)
+	for _, class := range []string{
+		"doctrine", "mindsets", "skills", "extensions",
+		"templates", "commands", "orchestrators", "katas",
+	} {
+		writeContentDir(t, hub, "cnos.full", class)
+	}
+
+	var stdout bytes.Buffer
+	if err := Run(hub, "3.52.0", nil, &stdout); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	// Expect the canonical order from pkg.ContentClasses.
+	out := stdout.String()
+	want := "[doctrine, mindsets, skills, extensions, templates, commands, orchestrators, katas]"
+	if !strings.Contains(out, want) {
+		t.Errorf("expected content classes %s in output, got:\n%s", want, out)
 	}
 }
 

--- a/src/go/internal/pkg/pkg.go
+++ b/src/go/internal/pkg/pkg.go
@@ -110,48 +110,38 @@ type EnginesJSON struct {
 	Cnos string `json:"cnos"`
 }
 
-// SkillsJSON is the "skills" object in cn.package.json.
-type SkillsJSON struct {
-	Exposed  []string `json:"exposed"`
-	Internal []string `json:"internal"`
+// ContentClasses is the canonical, ordered list of package content
+// class directory names. This is the single source of truth shared
+// by `cn build --check` (filesystem discovery) and `cn status`
+// (installed-package display), per docs/alpha/package-system/PACKAGE-SYSTEM.md
+// §1.1.
+//
+// Order follows the canonical §1.1 table. Filesystem presence — not
+// manifest JSON fields — determines which classes a package contains
+// (PACKAGE-SYSTEM.md §3: "Content classes are discovered by directory
+// presence"). `providers` is intentionally absent: per
+// POLYGLOT-PACKAGES-AND-PROVIDERS.md, providers are a runtime
+// capability surface, not a package content class.
+var ContentClasses = []string{
+	"doctrine", "mindsets", "skills", "extensions",
+	"templates", "commands", "orchestrators", "katas",
 }
 
 // FullPackageManifest is the extended shape of cn.package.json that
-// includes commands, engines, and content class objects. Used by
-// command discovery and status display.
+// includes commands and engines. Used by command discovery and
+// status display.
+//
+// Content-class membership is NOT declared here: it is discovered
+// from filesystem presence (see ContentClasses above). The manifest
+// only carries the metadata that is not derivable from the directory
+// layout itself — currently `commands` metadata and `engines.cnos`.
 type FullPackageManifest struct {
-	Schema        string                        `json:"schema"`
-	Name          string                        `json:"name"`
-	Version       string                        `json:"version"`
-	Kind          string                        `json:"kind"`
-	Engines       EnginesJSON                   `json:"engines"`
-	Commands      map[string]PackageCommandJSON `json:"commands"`
-	Skills        *SkillsJSON                   `json:"skills"`
-	Orchestrators json.RawMessage               `json:"orchestrators"`
-	Extensions    json.RawMessage               `json:"extensions"`
-	Providers     json.RawMessage               `json:"providers"`
-}
-
-// ContentClasses returns the list of content classes present in this
-// package, in a stable order. Pure — no IO.
-func (m *FullPackageManifest) ContentClasses() []string {
-	var classes []string
-	if m.Skills != nil && (len(m.Skills.Exposed) > 0 || len(m.Skills.Internal) > 0) {
-		classes = append(classes, "skills")
-	}
-	if len(m.Commands) > 0 {
-		classes = append(classes, "commands")
-	}
-	if len(m.Orchestrators) > 0 && string(m.Orchestrators) != "null" {
-		classes = append(classes, "orchestrators")
-	}
-	if len(m.Extensions) > 0 && string(m.Extensions) != "null" {
-		classes = append(classes, "extensions")
-	}
-	if len(m.Providers) > 0 && string(m.Providers) != "null" {
-		classes = append(classes, "providers")
-	}
-	return classes
+	Schema   string                        `json:"schema"`
+	Name     string                        `json:"name"`
+	Version  string                        `json:"version"`
+	Kind     string                        `json:"kind"`
+	Engines  EnginesJSON                   `json:"engines"`
+	Commands map[string]PackageCommandJSON `json:"commands"`
 }
 
 // PackageCommandJSON is the JSON shape of one command entry in

--- a/src/go/internal/pkgbuild/build.go
+++ b/src/go/internal/pkgbuild/build.go
@@ -25,15 +25,34 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/usurobor/cnos/src/go/internal/pkg"
+	pkgtypes "github.com/usurobor/cnos/src/go/internal/pkg"
 )
 
-// ContentClasses lists the content classes that a package may contain.
-// `cn build --check` treats a package as valid if at least one of these
-// directories is present and non-empty.
-var ContentClasses = []string{
-	"doctrine", "mindsets", "skills", "extensions",
-	"templates", "orchestrators", "commands", "katas",
+// FindContentClasses returns the subset of pkgtypes.ContentClasses
+// that are present as non-empty directories inside pkgDir. This is
+// the shared filesystem predicate used by `cn build --check` (validating
+// sources under src/packages/) and `cn status` (inspecting installed
+// packages under .cn/vendor/packages/). Presence is the single
+// authority; manifest JSON fields are not consulted.
+//
+// Order follows pkgtypes.ContentClasses. An error walking an entry
+// is treated as absence — the caller gets a conservative "not present"
+// rather than a partial failure.
+func FindContentClasses(pkgDir string) []string {
+	var present []string
+	for _, class := range pkgtypes.ContentClasses {
+		classDir := filepath.Join(pkgDir, class)
+		info, err := os.Stat(classDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		entries, err := os.ReadDir(classDir)
+		if err != nil || len(entries) == 0 {
+			continue
+		}
+		present = append(present, class)
+	}
+	return present
 }
 
 // PackageManifest is the parsed cn.package.json.
@@ -331,7 +350,7 @@ func CheckOne(pkg DiscoveredPackage) CheckResult {
 	}
 
 	hasContent := false
-	for _, class := range ContentClasses {
+	for _, class := range pkgtypes.ContentClasses {
 		classDir := filepath.Join(pkg.SrcDir, class)
 		if info, err := os.Stat(classDir); err == nil && info.IsDir() {
 			hasContent = true
@@ -351,15 +370,15 @@ func CheckOne(pkg DiscoveredPackage) CheckResult {
 // --- Lockfile generation ---
 
 // GenerateLockfileData produces a cn.lock.v2 lockfile from build results.
-// Uses canonical pkg.Lockfile/pkg.LockedDep types — single schema definition.
-// Pure — no IO.
+// Uses canonical pkgtypes.Lockfile/pkgtypes.LockedDep types — single
+// schema definition. Pure — no IO.
 func GenerateLockfileData(results []BuildResult) ([]byte, error) {
-	lf := pkg.Lockfile{Schema: "cn.lock.v2"}
+	lf := pkgtypes.Lockfile{Schema: "cn.lock.v2"}
 	for _, r := range results {
 		if r.Err != nil {
 			continue
 		}
-		lf.Packages = append(lf.Packages, pkg.LockedDep{
+		lf.Packages = append(lf.Packages, pkgtypes.LockedDep{
 			Name:    r.Name,
 			Version: r.Version,
 			SHA256:  r.SHA256,

--- a/src/go/internal/pkgbuild/build_test.go
+++ b/src/go/internal/pkgbuild/build_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	pkgtypes "github.com/usurobor/cnos/src/go/internal/pkg"
 )
 
 func TestBuildOneProducesTarball(t *testing.T) {
@@ -221,6 +223,81 @@ func TestGenerateLockfile(t *testing.T) {
 	}
 	if lf.Packages[0].Name != "test.pkg" {
 		t.Errorf("package name = %q, want %q", lf.Packages[0].Name, "test.pkg")
+	}
+}
+
+// --- FindContentClasses ---
+
+// TestFindContentClassesEmpty: absent and empty directories count as
+// not-present. This is the conservative behaviour `cn build --check`
+// relied on (an empty class dir is not a content class).
+func TestFindContentClassesEmpty(t *testing.T) {
+	pkgDir := t.TempDir()
+	if got := FindContentClasses(pkgDir); len(got) != 0 {
+		t.Errorf("expected no classes, got %v", got)
+	}
+
+	// Empty class dir is present on disk but should still be absent.
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got := FindContentClasses(pkgDir); len(got) != 0 {
+		t.Errorf("empty skills/ should not count, got %v", got)
+	}
+}
+
+// TestFindContentClassesAll: every class enumerated in
+// pkgtypes.ContentClasses is surfaced when its directory is non-empty,
+// and the returned order follows the canonical list. This is the
+// single-source-of-truth check for #253.
+func TestFindContentClassesAll(t *testing.T) {
+	pkgDir := t.TempDir()
+	// Create every canonical class directory with a marker file.
+	for _, class := range pkgtypes.ContentClasses {
+		classDir := filepath.Join(pkgDir, class)
+		if err := os.MkdirAll(classDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(classDir, ".keep"), []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := FindContentClasses(pkgDir)
+	if len(got) != len(pkgtypes.ContentClasses) {
+		t.Fatalf("got %d classes, want %d (%v)", len(got), len(pkgtypes.ContentClasses), got)
+	}
+	for i, class := range pkgtypes.ContentClasses {
+		if got[i] != class {
+			t.Errorf("position %d: got %q, want %q", i, got[i], class)
+		}
+	}
+}
+
+// TestFindContentClassesSubset: only non-empty canonical directories
+// are returned; unknown directories alongside them are ignored.
+func TestFindContentClassesSubset(t *testing.T) {
+	pkgDir := t.TempDir()
+	// Two canonical classes, one ignored unknown directory.
+	for _, class := range []string{"skills", "katas", "not-a-class"} {
+		classDir := filepath.Join(pkgDir, class)
+		if err := os.MkdirAll(classDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(classDir, ".keep"), []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := FindContentClasses(pkgDir)
+	want := []string{"skills", "katas"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, class := range want {
+		if got[i] != class {
+			t.Errorf("position %d: got %q, want %q", i, got[i], class)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #253.

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | — | Issue #253 triaged by γ in 3.55.0/3.56.0 assessments; divergence between `pkgbuild.ContentClasses` (8) and `FullPackageManifest.ContentClasses()` (5); flagged by β during #251/#252 cycle |
| 1 Select | issue #253 | cdd | Assessment commitment (§3.3): #253 committed as next MCA in 3.56.0 assessment |
| 4 Gap | this PR body | cdd | Two content-class surfaces disagree → `cn status` and `cn build --check` report different truths about the same package |
| 5 Mode | this PR body | cdd, eng/go | MCA, L6, bugfix-convergence; active: cdd/review, eng/go, eng/testing |
| 6 Artifacts | code + tests + doctrine | eng/go, eng/testing | `pkg.ContentClasses` canonical list + `pkgbuild.FindContentClasses` shared predicate + PACKAGE-SYSTEM.md §1.1 synced |
| 7 Self-coherence | this PR body | cdd | See below |
| 7a Pre-review | this PR body | cdd | Rebased on main (0 behind), local `go build`/`go test`/`go vet` green, `cn build --check` green on all 5 real packages |
| 8 Review | PR #this | review | Pending |
| 9 Gate | — | — | Pending |
| 10 Release | — | — | Pending |

## Gap (step 4)

**What:** `pkgbuild.ContentClasses` (filesystem discovery) and `pkg.FullPackageManifest.ContentClasses()` (JSON heuristic in `cn status`) disagreed on what counts as a content class. Filesystem listed 8 (doctrine, mindsets, skills, extensions, templates, orchestrators, commands, katas). Manifest listed 5 (skills, commands, orchestrators, extensions, providers). The two sets intersect imperfectly, so the same installed package could be reported differently by the two surfaces.

**Why it matters:** Status-display and build-check are the two operator-facing truth surfaces on package content. When they disagree the operator has no single answer to "what does this package contain?" — and canonical doctrine (`docs/alpha/package-system/PACKAGE-SYSTEM.md §1.1`) does not resolve the ambiguity either.

**What fails if skipped:** Every time a new content class is added or an old one is reshaped, the drift compounds silently. The 3.55.0 cycle already shipped `katas` as "the 8th content class" in `pkgbuild` without updating `FullPackageManifest` or canonical doctrine — that drift is this issue.

## Mode + Active Skills (step 5)

- **Mode:** MCA
- **Work shape:** bugfix-convergence (single-source-of-truth establishment)
- **Level:** L6 — eliminates a class of cross-surface drift; future content-class additions touch exactly one list
- **Active skills:** `cdd`, `cdd/review`, `eng/go`, `eng/testing`
- **Dominant risk:** two parallel lists silently drift as new classes arrive

## Changes

### Added

- `pkg.ContentClasses` — canonical exported list, order per PACKAGE-SYSTEM.md §1.1, 8 entries: doctrine, mindsets, skills, extensions, templates, commands, orchestrators, katas (`src/go/internal/pkg/pkg.go`).
- `pkgbuild.FindContentClasses(pkgDir string) []string` — shared filesystem predicate (`src/go/internal/pkgbuild/build.go`).
- `TestFindContentClassesEmpty`, `TestFindContentClassesAll`, `TestFindContentClassesSubset` in `pkgbuild/build_test.go`.
- `TestRunContentClassesAllEight` in `hubstatus/hubstatus_test.go` — exercises all 8 classes in canonical order end-to-end through `cn status`.

### Changed

- `pkgbuild.CheckOne` now walks `pkgtypes.ContentClasses` instead of a local duplicate list.
- `hubstatus.Run` now calls `pkgbuild.FindContentClasses(pkgDir)` against the installed package dir, replacing the JSON-field heuristic on `FullPackageManifest`.
- `docs/alpha/package-system/PACKAGE-SYSTEM.md §1.1`: `katas` added as 8th content class; "seven" → "eight"; §4.1 "7 classes" → "8 classes"; §4.3 "6 content classes" → "8 content classes"; §3 discovery paragraph names `pkg.ContentClasses` and `pkgbuild.FindContentClasses` as the implementation; §6 history gains `v3.55.0` (katas) and `#253` (convergence) rows.
- `TestRunContentClasses`: updated to create actual content-class directories on disk (presence is now the single authority); retained as the pre-existing two-class smoke test.

### Removed

- `pkgbuild.ContentClasses` (local duplicate list) — callers use `pkgtypes.ContentClasses`.
- `(m *FullPackageManifest) ContentClasses() []string` method and its supporting fields (`Skills`, `Orchestrators`, `Extensions`, `Providers`) plus the now-orphaned `SkillsJSON` type. The JSON-field heuristic was the wrong authority per PACKAGE-SYSTEM.md §3 ("Content classes are discovered by directory presence"). `providers` was never a content class — per `POLYGLOT-PACKAGES-AND-PROVIDERS.md` it is a runtime capability surface, orthogonal to the content-class model.

### Not in scope

- **OCaml legacy surface** (`src/ocaml/cmd/cn_build.ml` still lists 7 `source_decl` fields with no `katas`). The OCaml `cn build` was superseded by the Go kernel and its `sources` field was removed from the schema in v3.51.0. Converging the OCaml legacy is separate work, and `cn build --check` now runs through the Go kernel end-to-end in CI.
- **`PACKAGE-AUTHORING.md §216-229`** talks about shipping katas as commands; it is not inconsistent with §1.1 adding `katas` (a package can do either — `cnos.kata` ships the runner commands, `cnos.cdd.kata` ships the content as `katas/`). No edit needed.
- **Frozen `docs/gamma/cdd/` snapshots** — frozen per CDD §5.6.

## Acceptance Criteria

- [x] **AC1**: One authoritative list of content classes. `pkg.ContentClasses` is exported from the pure types package and referenced by name from PACKAGE-SYSTEM.md §3. `pkgbuild` imports it; `hubstatus` gets content classes only via `pkgbuild.FindContentClasses` which iterates `pkg.ContentClasses`. No second list exists.
- [x] **AC2**: `cn status` and `cn build --check` agree on content class membership. Both derive from filesystem presence via the same helper. Proven by `TestFindContentClassesAll` (pkgbuild side) and `TestRunContentClassesAllEight` (hubstatus side) — both exercise every class in `pkg.ContentClasses` and assert the same canonical order.
- [ ] CI green

## Self-coherence (step 7)

| Claim | Evidence |
|-------|----------|
| Single canonical list | `grep -n "ContentClasses = \[\]string" src/go/internal/pkg/pkg.go` → one match. `grep -rn "pkgbuild.ContentClasses" src/go` → no matches. |
| No JSON-field heuristic survives | `grep -rn "\.ContentClasses()" src/go` → no matches. `grep -rn "\bproviders\b" src/go/internal` → only the doc comment in `pkg.go` explaining why `providers` is excluded. |
| Doctrine synced | `docs/alpha/package-system/PACKAGE-SYSTEM.md §1.1` row count = 8; "eight content classes"; §4.1 "8 classes"; §4.3 "8 content classes"; §3 discovery paragraph names the canonical list. |
| Real packages validate | `cn build --check` against the actual `src/packages/` tree reports all 5 packages valid; cnos.cdd.kata (katas-only) still validates. |
| Test coverage | `go test ./...` all-green; new tests exercise every canonical class in order on both surfaces. |
| Invariant T-005 (finite content classes) preserved | Set grew from 7 declared in doctrine to 8; still finite, still canonical, still in §1.1. |

## Known Debt

- **OCaml `cn_build.ml`** still carries the 7-field `source_decl` shape; it is no longer the live `cn build` path (Go kernel owns it), but a future cleanup should either drop the OCaml build surface or mechanically sync it.
- **PACKAGE-AUTHORING.md** uses the phrase "katas as commands" in one spot — consistent with the `katas` class but not cross-linked to §1.1. Cosmetic; not filed.
