### PR TITLE
fix(deps): cn deps lock honors deps.json pins (#250)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,32 @@ jobs:
       - name: Set up CI test hub (cnos.core + cnos.kata + cnos.cdd.kata)
         run: |
           export PATH="$PWD:$PATH"
+          # Extract real versions from package source — the only authority
+          # for what cn build just produced. Pre-#250 the lockfile dumped
+          # the full index, so a stale/wrong manifest still "worked"; now
+          # cn deps lock honors deps.json strictly, so the manifest must
+          # name versions that actually exist in the index.
+          version_of() {
+            grep -m1 '"version"' "src/packages/$1/cn.package.json" \
+              | sed -E 's/.*"version":[[:space:]]*"([^"]+)".*/\1/'
+          }
+          CORE_VER=$(version_of cnos.core)
+          KATA_VER=$(version_of cnos.kata)
+          CDDKATA_VER=$(version_of cnos.cdd.kata)
           mkdir -p ci-tier2
           cd ci-tier2
           cn init ci-hub >/dev/null
           cd cn-ci-hub
           cn setup >/dev/null
-          cat > .cn/deps.json <<'JSON'
+          cat > .cn/deps.json <<JSON
           {
             "schema": "cn.deps.v1",
             "profile": "engineer",
-            "packages": {
-              "cnos.core": "3.54.0",
-              "cnos.kata": "0.2.0",
-              "cnos.cdd.kata": "0.3.0"
-            }
+            "packages": [
+              {"name": "cnos.core", "version": "$CORE_VER"},
+              {"name": "cnos.kata", "version": "$KATA_VER"},
+              {"name": "cnos.cdd.kata", "version": "$CDDKATA_VER"}
+            ]
           }
           JSON
           cn deps lock

--- a/scripts/kata/06-install.sh
+++ b/scripts/kata/06-install.sh
@@ -40,6 +40,30 @@ cd cn-kata-hub
 
 cn setup >/dev/null 2>&1 || { fail "cn setup failed (precondition)"; kata_summary; }
 
+# `cn setup` writes a default deps.json pinning cnos.core/cnos.eng to
+# the binary version. In CI the binary is built without -ldflags, so
+# the version is "dev" — not a real key in the index. Overwrite with
+# a manifest pinned to the actually-built version of cnos.core (read
+# from the package source, the single authority for package versions).
+# This keeps the kata focused on lock/restore rather than version
+# negotiation between binary build and package source.
+CORE_VER=$(grep -m1 '"version"' "$REPO_ROOT/src/packages/cnos.core/cn.package.json" \
+  | sed -E 's/.*"version":[[:space:]]*"([^"]+)".*/\1/')
+if [ -z "$CORE_VER" ]; then
+  fail "could not extract cnos.core version from src/packages/cnos.core/cn.package.json"
+  kata_summary
+fi
+cat > .cn/deps.json <<JSON
+{
+  "schema": "cn.deps.v1",
+  "profile": "engineer",
+  "packages": [
+    {"name": "cnos.core", "version": "$CORE_VER"}
+  ]
+}
+JSON
+info "deps.json pinned to cnos.core@$CORE_VER"
+
 info "running: cn deps lock"
 if cn deps lock >/dev/null 2>&1; then
   pass "cn deps lock exits 0"
@@ -65,16 +89,22 @@ fi
 
 # Count installed packages with a cn.package.json manifest.
 INSTALLED=0
+INSTALLED_NAMES=""
 if [ -d ".cn/vendor/packages" ]; then
   for d in .cn/vendor/packages/*/; do
-    [ -f "${d}cn.package.json" ] && INSTALLED=$((INSTALLED + 1))
+    if [ -f "${d}cn.package.json" ]; then
+      INSTALLED=$((INSTALLED + 1))
+      INSTALLED_NAMES="$INSTALLED_NAMES $(basename "$d")"
+    fi
   done
 fi
 
-if [ "$INSTALLED" -ge 1 ]; then
-  pass "$INSTALLED package(s) installed under .cn/vendor/packages/ with cn.package.json"
+# Per #250: lock+restore must install only what deps.json pinned.
+# We pinned exactly cnos.core, so exactly one package must be installed.
+if [ "$INSTALLED" -eq 1 ] && [ -f ".cn/vendor/packages/cnos.core/cn.package.json" ]; then
+  pass "exactly cnos.core installed (deps.json pin honored)"
 else
-  fail "no packages installed under .cn/vendor/packages/"
+  fail "expected exactly cnos.core installed, got $INSTALLED package(s):$INSTALLED_NAMES"
 fi
 
 echo ""

--- a/src/go/internal/pkg/pkg.go
+++ b/src/go/internal/pkg/pkg.go
@@ -62,6 +62,16 @@ type PackageIndex struct {
 	Packages map[string]map[string]IndexEntry `json:"packages"`
 }
 
+// ParseManifest parses a deps.json manifest from raw JSON bytes.
+// Pure — no IO. The IO wrapper lives in internal/restore/restore.go.
+func ParseManifest(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	return &m, nil
+}
+
 // ParseLockfile parses a lockfile from raw JSON bytes.
 func ParseLockfile(data []byte) (*Lockfile, error) {
 	var lf Lockfile

--- a/src/go/internal/restore/restore.go
+++ b/src/go/internal/restore/restore.go
@@ -57,6 +57,15 @@ func ReadLockfile(path string) (*pkg.Lockfile, error) {
 	return pkg.ParseLockfile(data)
 }
 
+// ReadManifest reads and parses a deps.json manifest from disk.
+func ReadManifest(path string) (*pkg.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	return pkg.ParseManifest(data)
+}
+
 // ReadPackageIndex reads and parses a package index from disk.
 func ReadPackageIndex(path string) (*pkg.PackageIndex, error) {
 	data, err := os.ReadFile(path)
@@ -376,12 +385,31 @@ type LockResult struct {
 	Count    int
 }
 
-// GenerateLockFromIndex reads the package index and generates a lockfile
-// at <hubPath>/.cn/deps.lock.json. This is the domain logic for
-// `cn deps lock` — CLI wiring calls this, keeping cmd_deps.go thin.
-// Uses canonical pkg.Lockfile/pkg.LockedDep types. Output is sorted
-// by name then version for deterministic lockfile content.
+// GenerateLockFromIndex reads the hub's .cn/deps.json and produces a
+// lockfile pinning exactly the packages the manifest declares, resolving
+// each (name, version) pin against the package index. Writes the result
+// to <hubPath>/.cn/deps.lock.json.
+//
+// This is the domain logic for `cn deps lock` — CLI wiring calls this,
+// keeping cmd_deps.go thin. Uses canonical pkg.Lockfile/pkg.LockedDep
+// types. Output is sorted by name then version for deterministic content.
+//
+// Errors:
+//   - .cn/deps.json missing or unparseable → cannot lock without a manifest
+//   - package index missing or unparseable → cannot resolve pins
+//   - any pinned (name, version) not present in the index → reported in
+//     a single error listing every missing pin
+//
+// Today's resolution semantics are exact-match: the version string in
+// deps.json must equal a key under idx.Packages[name]. Semver range
+// resolution is a separate concern (issue #250 out-of-scope).
 func GenerateLockFromIndex(hubPath, indexPath string) (*LockResult, error) {
+	manifestPath := filepath.Join(hubPath, ".cn", "deps.json")
+	m, err := ReadManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read deps.json: %w", err)
+	}
+
 	idx, err := ReadPackageIndex(indexPath)
 	if err != nil {
 		return nil, fmt.Errorf("read index: %w", err)
@@ -393,17 +421,26 @@ func GenerateLockFromIndex(hubPath, indexPath string) (*LockResult, error) {
 	}
 
 	lf := pkg.Lockfile{Schema: "cn.lock.v2"}
-	for name, versions := range idx.Packages {
-		for version, entry := range versions {
-			lf.Packages = append(lf.Packages, pkg.LockedDep{
-				Name:    name,
-				Version: version,
-				SHA256:  entry.SHA256,
-			})
+	var missing []string
+	for _, dep := range m.Packages {
+		entry := idx.Lookup(dep.Name, dep.Version)
+		if entry == nil {
+			missing = append(missing, fmt.Sprintf("%s@%s", dep.Name, dep.Version))
+			continue
 		}
+		lf.Packages = append(lf.Packages, pkg.LockedDep{
+			Name:    dep.Name,
+			Version: dep.Version,
+			SHA256:  entry.SHA256,
+		})
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("packages pinned in deps.json not in index: %s",
+			strings.Join(missing, ", "))
 	}
 
-	// Sort for deterministic output — map iteration order is random.
+	// Sort for deterministic output — manifest order is operator-controlled
+	// and lockfile content must be reproducible regardless.
 	sort.Slice(lf.Packages, func(i, j int) bool {
 		if lf.Packages[i].Name != lf.Packages[j].Name {
 			return lf.Packages[i].Name < lf.Packages[j].Name

--- a/src/go/internal/restore/restore_test.go
+++ b/src/go/internal/restore/restore_test.go
@@ -437,6 +437,289 @@ func setupTestPackages(t *testing.T, repoRoot string) {
 		map[string]string{"name": "beta.pkg", "version": "0.5.0"})
 }
 
+// --- GenerateLockFromIndex tests (issue #250) ---
+
+// TestGenerateLockFromIndex_FiltersByManifest covers AC1 + AC4:
+// a single pin in deps.json against a multi-package, multi-version
+// index produces a lockfile containing only that pin. This is the
+// reproducer from issue #250 — the bug was that lock dumped the
+// entire index regardless of deps.json.
+func TestGenerateLockFromIndex_FiltersByManifest(t *testing.T) {
+	hub := t.TempDir()
+
+	// Index has 3 packages × 2 versions each. Bug-mode lock would
+	// produce 6 entries; correct lock produces 1.
+	idxDir := filepath.Join(hub, "dist", "packages")
+	os.MkdirAll(idxDir, 0755)
+	indexPath := filepath.Join(idxDir, "index.json")
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {
+				"1.0.0":  {URL: "cnos.core-1.0.0.tar.gz", SHA256: "core-100"},
+				"3.54.0": {URL: "cnos.core-3.54.0.tar.gz", SHA256: "core-3540"},
+			},
+			"cnos.eng": {
+				"1.0.0":  {URL: "cnos.eng-1.0.0.tar.gz", SHA256: "eng-100"},
+				"3.54.0": {URL: "cnos.eng-3.54.0.tar.gz", SHA256: "eng-3540"},
+			},
+			"cnos.cdd": {
+				"0.1.0": {URL: "cnos.cdd-0.1.0.tar.gz", SHA256: "cdd-010"},
+				"0.2.0": {URL: "cnos.cdd-0.2.0.tar.gz", SHA256: "cdd-020"},
+			},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	// Manifest pins exactly one package.
+	manifest := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: "3.54.0"},
+		},
+	}
+	writeJSON(t, filepath.Join(hub, ".cn", "deps.json"), manifest)
+
+	res, err := GenerateLockFromIndex(hub, indexPath)
+	if err != nil {
+		t.Fatalf("GenerateLockFromIndex: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only the pinned package)", res.Count)
+	}
+
+	lf, err := ReadLockfile(filepath.Join(hub, ".cn", "deps.lock.json"))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if len(lf.Packages) != 1 {
+		t.Fatalf("lockfile len = %d, want 1\nlockfile: %+v", len(lf.Packages), lf.Packages)
+	}
+	got := lf.Packages[0]
+	if got.Name != "cnos.core" || got.Version != "3.54.0" || got.SHA256 != "core-3540" {
+		t.Errorf("locked dep = %+v, want {cnos.core 3.54.0 core-3540}", got)
+	}
+}
+
+// TestGenerateLockFromIndex_NameAppearsAtMostOnce covers AC2: when the
+// index carries multiple versions of a pinned package, the lockfile
+// records exactly the version pinned in deps.json — not every version
+// available in the index.
+func TestGenerateLockFromIndex_NameAppearsAtMostOnce(t *testing.T) {
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {
+				"1.0.0":  {URL: "u1", SHA256: "s1"},
+				"2.0.0":  {URL: "u2", SHA256: "s2"},
+				"3.54.0": {URL: "u3", SHA256: "s3"},
+			},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	manifest := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: "3.54.0"},
+		},
+	}
+	writeJSON(t, filepath.Join(hub, ".cn", "deps.json"), manifest)
+
+	if _, err := GenerateLockFromIndex(hub, indexPath); err != nil {
+		t.Fatalf("GenerateLockFromIndex: %v", err)
+	}
+
+	lf, err := ReadLockfile(filepath.Join(hub, ".cn", "deps.lock.json"))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	seen := map[string]int{}
+	for _, d := range lf.Packages {
+		seen[d.Name]++
+	}
+	for name, n := range seen {
+		if n != 1 {
+			t.Errorf("name %q appears %d times in lockfile, want 1", name, n)
+		}
+	}
+	if lf.Packages[0].Version != "3.54.0" {
+		t.Errorf("locked version = %q, want %q (the pinned one)",
+			lf.Packages[0].Version, "3.54.0")
+	}
+}
+
+// TestGenerateLockFromIndex_RestoreInstallsOnlyPinned covers AC3:
+// restore against a lockfile produced by GenerateLockFromIndex installs
+// only the packages that were pinned in deps.json — even when other
+// packages exist in the index.
+func TestGenerateLockFromIndex_RestoreInstallsOnlyPinned(t *testing.T) {
+	manifest := `{"name": "cnos.core", "version": "1.0.0"}`
+	tarData, tarSHA := makeTarGz(t, map[string]string{
+		"cn.package.json": manifest,
+	})
+
+	// Stage two tarballs in dist (only one will be referenced by the
+	// pinned manifest entry, but both are reachable via the index).
+	hub := t.TempDir()
+	distDir := filepath.Join(hub, "dist", "packages")
+	os.MkdirAll(distDir, 0755)
+	os.WriteFile(filepath.Join(distDir, "cnos.core-1.0.0.tar.gz"), tarData, 0644)
+	// A second package present in the index — restore must NOT install it.
+	otherTar, otherSHA := makeTarGz(t, map[string]string{
+		"cn.package.json": `{"name": "cnos.eng", "version": "1.0.0"}`,
+	})
+	os.WriteFile(filepath.Join(distDir, "cnos.eng-1.0.0.tar.gz"), otherTar, 0644)
+
+	indexPath := filepath.Join(distDir, "index.json")
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.0.0": {URL: "cnos.core-1.0.0.tar.gz", SHA256: tarSHA}},
+			"cnos.eng":  {"1.0.0": {URL: "cnos.eng-1.0.0.tar.gz", SHA256: otherSHA}},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	// Pin only cnos.core in deps.json.
+	depsManifest := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: "1.0.0"},
+		},
+	}
+	writeJSON(t, filepath.Join(hub, ".cn", "deps.json"), depsManifest)
+
+	if _, err := GenerateLockFromIndex(hub, indexPath); err != nil {
+		t.Fatalf("GenerateLockFromIndex: %v", err)
+	}
+
+	results, err := Restore(context.Background(), hub, indexPath)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if HasErrors(results) {
+		for _, r := range Errors(results) {
+			t.Errorf("  %s@%s: %v", r.Name, r.Version, r.Err)
+		}
+		t.Fatal("restore had errors")
+	}
+
+	if _, err := os.Stat(pkg.VendorPath(hub, "cnos.core")); err != nil {
+		t.Errorf("cnos.core should be installed: %v", err)
+	}
+	if _, err := os.Stat(pkg.VendorPath(hub, "cnos.eng")); !os.IsNotExist(err) {
+		t.Errorf("cnos.eng should NOT be installed (not pinned in deps.json), got err=%v", err)
+	}
+}
+
+// TestGenerateLockFromIndex_MissingManifest verifies that lock cannot
+// proceed without a manifest — the lockfile is meaningless without
+// declared intent.
+func TestGenerateLockFromIndex_MissingManifest(t *testing.T) {
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+	idx := pkg.PackageIndex{Schema: "cn.package-index.v1", Packages: map[string]map[string]pkg.IndexEntry{}}
+	writeJSON(t, indexPath, idx)
+
+	_, err := GenerateLockFromIndex(hub, indexPath)
+	if err == nil {
+		t.Fatal("expected error for missing deps.json")
+	}
+	if !strings.Contains(err.Error(), "deps.json") {
+		t.Errorf("error should mention deps.json, got: %v", err)
+	}
+}
+
+// TestGenerateLockFromIndex_PinNotInIndex verifies that a pin without
+// a matching index entry surfaces an explicit error rather than silently
+// dropping the package or installing the wrong version.
+func TestGenerateLockFromIndex_PinNotInIndex(t *testing.T) {
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.0.0": {URL: "u", SHA256: "s"}},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	manifest := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: "9.9.9"},
+		},
+	}
+	writeJSON(t, filepath.Join(hub, ".cn", "deps.json"), manifest)
+
+	_, err := GenerateLockFromIndex(hub, indexPath)
+	if err == nil {
+		t.Fatal("expected error for pin not in index")
+	}
+	if !strings.Contains(err.Error(), "cnos.core@9.9.9") {
+		t.Errorf("error should name the missing pin, got: %v", err)
+	}
+}
+
+// TestGenerateLockFromIndex_DefaultProfile verifies the default deps.json
+// produced by `cn setup` (cnos.core + cnos.eng pinned to the binary
+// version) round-trips through lock to a two-entry lockfile.
+func TestGenerateLockFromIndex_DefaultProfile(t *testing.T) {
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.0.0": {URL: "core.tgz", SHA256: "core-sha"}},
+			"cnos.eng":  {"1.0.0": {URL: "eng.tgz", SHA256: "eng-sha"}},
+			// Extra package that must NOT leak into the lockfile.
+			"cnos.cdd": {"0.1.0": {URL: "cdd.tgz", SHA256: "cdd-sha"}},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	manifest := pkg.Manifest{
+		Schema:  "cn.deps.v1",
+		Profile: "engineer",
+		Packages: []pkg.ManifestDep{
+			{Name: "cnos.core", Version: "1.0.0"},
+			{Name: "cnos.eng", Version: "1.0.0"},
+		},
+	}
+	writeJSON(t, filepath.Join(hub, ".cn", "deps.json"), manifest)
+
+	res, err := GenerateLockFromIndex(hub, indexPath)
+	if err != nil {
+		t.Fatalf("GenerateLockFromIndex: %v", err)
+	}
+	if res.Count != 2 {
+		t.Errorf("Count = %d, want 2", res.Count)
+	}
+
+	lf, _ := ReadLockfile(filepath.Join(hub, ".cn", "deps.lock.json"))
+	// Sorted alphabetically: cnos.core before cnos.eng.
+	if len(lf.Packages) != 2 ||
+		lf.Packages[0].Name != "cnos.core" ||
+		lf.Packages[1].Name != "cnos.eng" {
+		t.Errorf("lockfile = %+v, want [cnos.core, cnos.eng]", lf.Packages)
+	}
+	for _, d := range lf.Packages {
+		if d.Name == "cnos.cdd" {
+			t.Error("cnos.cdd leaked into lockfile from index")
+		}
+	}
+}
+
 // --- helpers ---
 
 func writeJSON(t *testing.T, path string, v any) {

--- a/src/packages/cnos.kata/katas/R3-doctor-broken/run.sh
+++ b/src/packages/cnos.kata/katas/R3-doctor-broken/run.sh
@@ -44,7 +44,11 @@ cn init r3-hub >/dev/null 2>&1 || { fail "cn init failed"; kata_summary; }
 cd cn-r3-hub
 cn setup >/dev/null 2>&1 || { fail "cn setup failed"; kata_summary; }
 
-write_deps_json "cnos.core:3.54.0"
+CORE_VER="$(pkg_version_from_source cnos.core "$REPO_DIST")" || {
+  fail "could not read cnos.core version from src/packages/cnos.core/cn.package.json"
+  kata_summary
+}
+write_deps_json "cnos.core:$CORE_VER"
 
 if cn deps lock >/dev/null 2>&1 && cn deps restore >/dev/null 2>&1; then
   pass "cnos.core installed (precondition)"

--- a/src/packages/cnos.kata/katas/R4-self-describe/run.sh
+++ b/src/packages/cnos.kata/katas/R4-self-describe/run.sh
@@ -29,7 +29,11 @@ cn init r4-hub >/dev/null 2>&1 || { fail "cn init failed"; kata_summary; }
 cd cn-r4-hub
 cn setup >/dev/null 2>&1 || { fail "cn setup failed"; kata_summary; }
 
-write_deps_json "cnos.core:3.54.0"
+CORE_VER="$(pkg_version_from_source cnos.core "$REPO_DIST")" || {
+  fail "could not read cnos.core version from src/packages/cnos.core/cn.package.json"
+  kata_summary
+}
+write_deps_json "cnos.core:$CORE_VER"
 
 if cn deps lock >/dev/null 2>&1 && cn deps restore >/dev/null 2>&1; then
   pass "cnos.core installed (precondition)"

--- a/src/packages/cnos.kata/lib.sh
+++ b/src/packages/cnos.kata/lib.sh
@@ -58,23 +58,52 @@ find_repo_dist() {
 
 # write_deps_json writes a minimal deps.json into $PWD/.cn/deps.json.
 # Caller must be inside a hub (post-`cn init`). Takes "pkg:version" args.
+#
+# Schema is cn.deps.v1: `packages` is an ARRAY of {name, version}
+# objects (see src/go/internal/pkg/pkg.go and src/ocaml/lib/cn_package.ml).
+# Pre-#250 the lockfile dumped the entire index regardless of manifest
+# content, so a malformed (object-shaped) packages field still produced
+# an installable lockfile. Now `cn deps lock` honors the manifest, so
+# the JSON shape must match the parser.
 write_deps_json() {
   local out=".cn/deps.json"
   {
     echo '{'
     echo '  "schema": "cn.deps.v1",'
     echo '  "profile": "engineer",'
-    echo '  "packages": {'
+    echo '  "packages": ['
     local first=1
     for spec in "$@"; do
       local name="${spec%%:*}"
       local ver="${spec##*:}"
       if [ "$first" -eq 1 ]; then first=0; else echo '    ,'; fi
-      echo "    \"$name\": \"$ver\""
+      echo "    {\"name\": \"$name\", \"version\": \"$ver\"}"
     done
-    echo '  }'
+    echo '  ]'
     echo '}'
   } > "$out"
+}
+
+# pkg_version_from_source echoes the version declared in a package's
+# source manifest. Args: <pkg_name> <repo_dist_path>. The repo source
+# lives one directory above $REPO_DIST. Returns non-zero with no output
+# if the manifest cannot be read or the version field is absent.
+#
+# Used by katas that need to pin to "whatever version cn build just
+# produced" — hardcoded versions go stale and break silently when the
+# parent repo bumps src/packages/<pkg>/cn.package.json.
+pkg_version_from_source() {
+  local pkg="$1"
+  local dist="$2"
+  local repo_root
+  repo_root="$(dirname "$dist")"
+  local manifest="$repo_root/src/packages/$pkg/cn.package.json"
+  [ -f "$manifest" ] || return 1
+  local ver
+  ver=$(grep -m1 '"version"' "$manifest" \
+    | sed -E 's/.*"version":[[:space:]]*"([^"]+)".*/\1/')
+  [ -n "$ver" ] || return 1
+  echo "$ver"
 }
 
 # kata_summary prints a one-line pass/fail summary and exits non-zero


### PR DESCRIPTION
## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | cdd | Issue #250 dispatched by γ; α reads it as the selected gap |
| 1 Select | — | cdd | Selected gap: `cn deps lock` writes every name×version from index, ignoring `.cn/deps.json` |
| 4 Gap | this PR body | cdd | `GenerateLockFromIndex` iterates the entire package index instead of the manifest — pins have no effect, restore over-vendors |
| 5 Mode | this PR body | cdd, eng/go | MCA bugfix; L5 (local correctness restored) |
| 6 Artifacts | code + tests + CI | eng/go | `ParseManifest` (pure) + `ReadManifest` (IO) added; `GenerateLockFromIndex` rewritten to read `.cn/deps.json` and resolve each pin against the index; kata-tier1 + ci.yml tier2 setup updated to use real versions and array-format manifest (exposed by fix) |
| 7 Self-coherence | this PR body | eng/go | All ACs mapped to tests; `go build ./...` + `go test ./...` + `go test -race ./...` green; six new tests fail on the buggy code, pass on the fix; full local Tier 1 kata suite green; Tier 2 hub setup simulation installs exactly the three pinned packages |
| 7a Pre-review | this PR body | cdd | Branch on tip of `origin/main`; CI re-running on `dc5b985`; PR draft-until-green |
| 8 Review | PR #this | review | Pending |
| 9 Gate | — | release | Pending |
| 10 Release | — | release | Pending |

## Gap (step 4)

**What:** `GenerateLockFromIndex` (`src/go/internal/restore/restore.go`) iterates `idx.Packages` and writes every (name, version) pair into `.cn/deps.lock.json`. It never reads `.cn/deps.json`, so the manifest's pins have no effect and `cn deps restore` installs every package present in the index.

**Why it matters:** `.cn/deps.json` is supposed to be the single source of truth for what a hub uses. The pin is silently dropped — `deps.json` pins `cnos.core@3.54.0` but the lockfile records every `cnos.core@*` plus every other package in the index. Hubs vendor packages they never declared. Tier 2 CI noise from #237/PR #248 was masking this — and the bug was masking two latent test-infrastructure errors of its own (see "Changes / CI harness" below).

**What fails if skipped:** Any hub that pins a strict subset of available packages over-vendors. Version pins are not enforced — last writer wins inside `restoreOne` when the lockfile carries multiple versions of the same name.

## Mode + Active Skills (step 5)

- **Mode:** MCA
- **Work shape:** bugfix (kernel/runtime Go) + CI harness alignment
- **Level:** L5 — local correctness; the bug is a missing read of `deps.json`, fix is in one function. The CI alignment is mechanical follow-on (test infrastructure was relying on bug behavior).
- **Active skills:** `cdd`, `eng/go` (purity boundary §2.17, error rule §2.5, schema discipline §2.12, determinism §2.13)
- **Dominant risk:** silent over-install hides which packages a hub actually depends on; fix must be explicit (error on missing manifest, error on unresolved pin) rather than re-introduce a different silent fallback

## Changes

### Added

- `pkg.ParseManifest([]byte) (*Manifest, error)` — pure parser (no IO), mirrors existing `ParseLockfile` / `ParsePackageIndex` shape.
- `restore.ReadManifest(path) (*pkg.Manifest, error)` — IO wrapper that calls `ParseManifest`. Mirrors the `Parse*`/`Read*` split required by eng/go §2.17.
- Six tests in `restore_test.go` targeting AC1–AC4 of #250.

### Changed

- `restore.GenerateLockFromIndex` now reads `.cn/deps.json` first and resolves each pinned `(name, version)` against the index by exact match. Output stays sorted by name then version for deterministic content. Godoc updated to spell out the new contract and the error cases.
- **CI harness** (`scripts/kata/06-install.sh`, `.github/workflows/ci.yml` Tier 2 setup) — both relied on the bug. The fix exposed two errors that were masked:
  - Tier 1 `cn setup` pins `deps.json` to the binary version, which is `"dev"` in CI builds without `-ldflags`. Pre-fix, lock dumped 5 packages from the index; post-fix, lock errors on `cnos.core@dev`. Now overwrites the post-setup `deps.json` with a manifest pinned to the actual `cnos.core` version (read from `src/packages/cnos.core/cn.package.json`) and tightens the post-condition to "exactly `cnos.core` installed" — mechanically protects against over-vendoring regression.
  - Tier 2 used object-syntax `{"name":"version"}` which the parser doesn't accept (schema is an array of `{name, version}`), and pinned `cnos.core@3.54.0` while src is at `3.56.1`. Both masked. Switched to array syntax, versions derived from `src/packages/*/cn.package.json`.

### Removed

- The "iterate the entire index" code path. There is no policy under which producing a lockfile of the whole index is correct — it was the bug.

### Not in scope

- Semver range resolution (`*`, `^`, `~`) — issue #250 explicitly defers this. A pin of `*` will now error as "not in index" because `*` is not a real version key, matching the OCaml `lockfile_for_manifest` behavior.
- Transitive dependency resolution — package manifests don't yet declare a `dependencies` field. When that lands, `GenerateLockFromIndex` will need to walk the dependency graph; today it only emits what `deps.json` declares.
- Schema evolution — `cn.deps.v1` and `cn.lock.v2` are unchanged.
- Changing `cn setup`'s default-version policy — the binary-version-pin is preserved; the kata works around it explicitly. Whether `cn setup` should resolve against the local index is a separate design question.

## Acceptance Criteria

- [x] **AC1** `cn deps lock` produces a lockfile containing exactly the packages in `.cn/deps.json` (transitive deps not yet specified). Covered by `TestGenerateLockFromIndex_FiltersByManifest`.
- [x] **AC2** Each `name` appears at most once in `deps.lock.json`; the version is the one pinned in `deps.json`. Covered by `TestGenerateLockFromIndex_NameAppearsAtMostOnce`.
- [x] **AC3** `cn deps restore` against the AC1/AC2 lockfile installs only those packages. Covered by `TestGenerateLockFromIndex_RestoreInstallsOnlyPinned` and now also by tightened Tier 1 kata 06-install ("exactly cnos.core installed").
- [x] **AC4** Test covers a single-pin lockfile against a multi-package index — fails on the buggy code, passes on the fix. Verified by reverting the fix locally: all six new tests fail with the exact symptoms from the issue (lockfile len 6 instead of 1, `cnos.core` appears 3 times, `cnos.eng` installed when not pinned, etc.).
- [ ] CI green
- [ ] Deployed and validated (release cycle, β-owned)

## Known Debt

- `cn setup` still pins `deps.json` to the binary version. In any environment where the binary version doesn't appear in the local package index (development checkouts, CI without `-ldflags`), `cn deps lock` immediately after `cn setup` will now error explicitly. The Tier 1 kata works around this; operators in similar setups will need to either build the binary with `-X main.version=<version>` or hand-edit `deps.json`. A separate change to make `cn setup` resolve against the local index is a candidate for a follow-up issue.
- The OCaml side (`src/ocaml/cmd/cn_deps.ml`) already does this correctly via `lockfile_for_manifest`. The Go and OCaml runtimes are now coherent on lockfile generation.
