### PR TITLE
fix: normalize cnos.cdd package after triadic rewrite

### DIFF
--- a/.github/ISSUE_TEMPLATE/cdd-issue.md
+++ b/.github/ISSUE_TEMPLATE/cdd-issue.md
@@ -29,7 +29,7 @@ labels: ''
 ## Skills and Constraints
 
 - **Tier 3 skills:** <!-- only issue-specific skills, not Tier 1 or Tier 2 -->
-- **Active invariants:** <!-- linked governing constraints in plain language -->
+- **Active design constraints:** <!-- linked governing constraints (invariants, transition, process) in plain language -->
 
 ## Acceptance Criteria
 

--- a/src/packages/cnos.cdd/skills/cdd/CDD.md
+++ b/src/packages/cnos.cdd/skills/cdd/CDD.md
@@ -3,7 +3,7 @@
 **Version:** 3.15.0
 **Status:** Draft
 **Date:** 2026-03-25
-**Placement:** γ document (`docs/gamma/cdd/`)
+**Placement:** `src/packages/cnos.cdd/skills/cdd/`
 **Audience:** Contributors, reviewers, maintainers, release operators
 **Scope:** Canonical algorithm spec for how cnos selects, executes, measures, and closes substantial development cycles
 
@@ -78,9 +78,9 @@ These are operational roles. They are not a claim that every cycle always uses t
 
 | Role | Function | Steps owned | Responsibility | Identity constraint |
 |------|----------|-------------|----------------|---------------------|
-| **α (Implementer)** | Produce | 0–7a | Code, tests, fixes, self-coherence, pre-review readiness, PR | Must be separate from β |
+| **γ (Coordinator)** | Orchestrate | 0–1 + cycle-wide | Observe, select, issue creation, dispatch prompts to α and β, unblocking when stuck, cross-agent context, compliance verification | Must hold full cycle context |
+| **α (Implementer)** | Produce | 2–7a | Branch, bootstrap, gap, mode, artifacts (tests/code/docs), self-coherence, pre-review readiness, PR | Must be separate from β |
 | **β (Reviewer + Releaser)** | Judge and integrate | 8–13 | Review (RC/A decision), merge, tag, deploy, post-release assessment, close the cycle | Must be separate from α |
-| **γ (Coordinator)** | Orchestrate | cycle-wide | Issue creation, dispatch prompts to α and β, unblocking when stuck, cross-agent context, compliance verification | Must hold full cycle context |
 
 #### Triadic rule
 
@@ -443,7 +443,7 @@ The Tier 3 skill set must be stated alongside mode. Example:
 
 ```text
 Mode: MCA
-Tier 3 skills: go, ux-cli
+Tier 3 skills: eng/<language>, eng/ux-cli
 ```
 
 When in doubt about mode, apply CAP: if the answer is already in the system, cite it (MCA) — don't reinvent it (MCI). If two paths close the same gap, take the lighter one unless the heavier one buys durability the lighter one cannot.
@@ -521,7 +521,7 @@ CDD is artifact-driven. For substantial changes, each lifecycle step must leave 
 
 **Primary branch artifact:** the PR body (`.github/PULL_REQUEST_TEMPLATE.md`) for L5/L6 changes, or the design artifact (design/SKILL.md §3.1) for larger changes.
 
-**Role key (§1.4):** *α (implementer)* = steps 0–7a, *β (reviewer + releaser)* = steps 8–13 (review RC/A decision, merge, deploy, assess), *γ (coordinator)* = cycle-wide (issue creation, dispatch, unblocking). Delegated implementer is α-side. Merge is part of step 9 (gate + merge).
+**Role key (§1.4):** *γ (coordinator)* = steps 0–1 (observe, select, issue creation, dispatch, unblocking) + cycle-wide coordination, *α (implementer)* = steps 2–7a (branch, bootstrap, gap, mode, artifacts, self-coherence, pre-review), *β (reviewer + releaser)* = steps 8–13 (review RC/A decision, merge, deploy, assess). Delegated implementer is α-side. Merge is part of step 9 (gate + merge).
 
 **Producer key:** *agent* = judgment required, *mechanical* = automatable by cnos (#94), *reviewer* = produced by the review process.
 

--- a/src/packages/cnos.cdd/skills/cdd/design/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/design/SKILL.md
@@ -105,12 +105,12 @@ Identify what governs before proposing what changes.
   - What reads, renders, or acts on the artifact you're changing?
   - ❌ Update CDD skill, forget post-release template consumes the new metrics
   - ✅ "CDD §11.11 defines metrics → post-release template must render them → review skill must tag findings by type"
-  - ✅ "Adding a new FSM state → check: protocol .mli, doctor checks, status output, packed context renderer, tests"
+  - ✅ "Adding a new FSM state → check: protocol interface, doctor checks, status output, packed context renderer, tests"
 
 4.2. **Enumerate upstream producers**
   - What produces the inputs your design depends on?
   - ❌ "Tests will use the version" (which version? from where?)
-  - ✅ "VERSION file → build generates cn_version.ml → cn_lib.ml reads it → tests derive from Cn_lib.version"
+  - ✅ "VERSION file → build generates version module → core library reads it → tests derive from the exported version constant"
 
 4.3. **Enumerate copies and embeddings**
   - Where does the same information appear in multiple places?
@@ -120,7 +120,7 @@ Identify what governs before proposing what changes.
 4.4. **Name authority relationships**
   - If two artifacts carry the same information, which governs?
   - ❌ Both skill and canonical doc have the rule, unclear which wins
-  - ✅ "Skill is executable summary. Canonical doc governs on disagreement. New §1.5 exists only in skill — authority explicitly narrowed until canonical catches up."
+  - ✅ "CDD.md is the normative source for the lifecycle algorithm. Role skills (alpha/, beta/, gamma/) expand execution detail for their role. Each fact lives in exactly one place — skills do not restate canonical rules, they add role-local detail that CDD.md does not cover."
 
 4.5. **Trace rule changes through all embeddings**
   - When you add a rule, find every artifact that embeds, templates, or implements that rule
@@ -248,7 +248,7 @@ List every file that needs to change, grouped by action.
 
 9.1. **Create / Generate / Edit / Delete**
   - ❌ "Update the relevant files" (which ones?)
-  - ✅ "Create: `VERSION`. Generate: `src/lib/cn_version.ml`. Edit: `cn_lib.ml`, `cn.json`, 3 package manifests, `cn_deps.ml`, `cn_system.ml`, `cn_runtime_contract.ml`, 3 test files."
+  - ✅ "Create: `VERSION`. Generate: version module. Edit: core library, package manifest, dependency config, system config, runtime contract, 3 test files."
 
 9.2. **Name the specific change per file**
   - ❌ "Edit cn_deps.ml"

--- a/src/packages/cnos.cdd/skills/cdd/gamma/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/gamma/SKILL.md
@@ -43,7 +43,7 @@ It expands those steps into executable checks, evidence, and gates.
 
 ## Step map
 
-- Step 1 → observe + select (`§2.1–§2.2`)
+- Step 1a → observe and build candidates (`§2.1`), Step 1b → select and size (`§2.2`)
 - Step 2 → issue pack + issue-quality gate (`§2.3–§2.4`)
 - Steps 3–5 → dispatch + unblocking (`§2.5`)
 - Steps 6–7 → deferred release mechanics (`§2.6`)
@@ -92,7 +92,7 @@ Close-out converts cycle findings into immediate fixes or committed next work.
 
 ## 2. Unfold
 
-### 2.1. Step 1 — Observe and build candidates
+### 2.1. Step 1a — Observe and build candidates
 
 Before selecting work, read the observation surfaces required by `CDD.md`:
 1. CHANGELOG TSC table
@@ -113,7 +113,7 @@ Do not select from memory or preference alone.
 - ❌ "I remember issue #143 felt important"
 - ✅ "Candidate table shows #143 is selected under CDD §3.x for a named reason"
 
-### 2.2. Step 1 — Select by `CDD.md`, then size the intervention
+### 2.2. Step 1b — Select by `CDD.md`, then size the intervention
 
 Apply `CDD.md` §3 in order.
 Do **not** restate or reorder the rule list here.

--- a/src/packages/cnos.cdd/skills/cdd/gamma/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/gamma/SKILL.md
@@ -141,7 +141,7 @@ A dispatchable γ issue is:
 - **plus** dependency notes when sequencing or blockers are real
 
 γ does not restate Tier 1 or Tier 2 skills in the issue.
-γ does name Tier 3 skills, active invariants, related artifacts, non-goals, and priority exactly as `issue/SKILL.md` requires.
+γ does name Tier 3 skills, active design constraints, related artifacts, non-goals, and priority exactly as `issue/SKILL.md` requires.
 
 If the issue cannot be written to that level, the work is not ready for α dispatch.
 
@@ -156,7 +156,7 @@ Before dispatch, verify:
 - every noun in ACs and work items is in scope
 - non-goals exist when the issue is substantial
 - Tier 3 skills are named explicitly
-- active invariants are linked and stated plainly
+- active design constraints are linked and stated plainly
 - related artifacts are linked or explicitly absent
 - priority is stated
 - work-shape is stated
@@ -378,7 +378,7 @@ Rewrite it into a dispatchable γ issue pack.
 - numbered ACs
 - non-goals
 - Tier 3 skills
-- active invariants
+- active design constraints
 - related artifacts
 - priority
 - work-shape note

--- a/src/packages/cnos.cdd/skills/cdd/issue/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/issue/SKILL.md
@@ -107,11 +107,11 @@ Failure mode: issue requires back-and-forth to clarify scope, acceptance, or pri
   - ❌ List all CDD and general eng skills — those are always loaded, listing them is noise
   - ✅ "Tier 3 skills: `eng/<language>` (relevant boundary rules), `eng/ux-cli` (output formatting)"
 
-2.4.2. **Name the active invariants**
-  - Link to `docs/alpha/DESIGN-CONSTRAINTS.md` entries that govern the work
+2.4.2. **Name the active design constraints**
+  - Link to `docs/alpha/DESIGN-CONSTRAINTS.md` entries that govern the work — including invariants, transition constraints, and process constraints
   - State the key rule in plain text so the implementer doesn't have to load the doc to know the constraint exists
   - ❌ "Follow project conventions"
-  - ✅ "`docs/alpha/DESIGN-CONSTRAINTS.md` §5.2: cli/ owns dispatch, domain packages own logic — no cmd_*.go file may exceed 30 lines of domain logic"
+  - ✅ "`docs/alpha/DESIGN-CONSTRAINTS.md` §5.2: cli/ owns dispatch, domain packages own logic — no CLI entry point may contain domain logic beyond dispatch"
 
 ### 2.5. Related artifacts
 

--- a/src/packages/cnos.cdd/skills/cdd/plan/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/plan/SKILL.md
@@ -41,7 +41,7 @@ Failure mode: plan restates the design instead of operationalizing it. Or: steps
 1.3. **Name the failure mode**
   - Plan fails via **duplication** (restating the design) or **ambiguity** (steps without acceptance criteria). A plan that just reorganizes the design into numbered steps adds no information.
   - ❌ "Step 1: Fix restore. Step 2: Fix third-party." (no criteria, no files, no order rationale)
-  - ✅ "Step 1: Full package restore. AC: profiles and extensions present in installed root. Files: `src/go/internal/deps/restore.go`, `src/go/internal/deps/restore_test.go`. Depends on: nothing. Unblocks: Step 4 (doctor)."
+  - ✅ "Step 1: Full package restore. AC: profiles and extensions present in installed root. Files: `src/lib/deps/restore.{src,test}`. Depends on: nothing. Unblocks: Step 4 (doctor)."
 
 ---
 
@@ -76,7 +76,7 @@ Failure mode: plan restates the design instead of operationalizing it. Or: steps
 2.2.3. **Each step names files changed**
   - Reviewer can scope the diff before reading it
   - ❌ "Various files"
-  - ✅ "`src/go/internal/deps/restore.go`, `src/go/internal/deps/restore_test.go`"
+  - ✅ "`src/lib/deps/restore.{src,test}`"
   - ✅ "`src/packages/cnos.cdd/skills/cdd/CDD.md`, `src/packages/cnos.cdd/skills/cdd/SKILL.md`"
 
 2.2.4. **Order minimizes rework**
@@ -126,7 +126,7 @@ Failure mode: plan restates the design instead of operationalizing it. Or: steps
 3.2. **Every step has AC + files**
   - No step without acceptance criteria. No step without named files.
   - ❌ "Step 5: Clarify metadata source-of-truth"
-  - ✅ "Step 5: Clarify metadata source-of-truth. AC: one explicit rule exists, build/check/doctor enforce it. Files: `src/go/internal/pkgbuild/`, docs."
+  - ✅ "Step 5: Clarify metadata source-of-truth. AC: one explicit rule exists, build/check/doctor enforce it. Files: `src/lib/pkgbuild/`, docs."
 
 3.3. **Order is explicit, not implicit**
   - State why step N comes before step N+1


### PR DESCRIPTION
## Summary

Normalization pass on the cnos.cdd package after the triadic restructure. Fixes five findings from β review.

## Findings addressed

| # | Sev | Fix |
|---|-----|-----|
| F1 | D | Placement metadata → `src/packages/cnos.cdd/skills/cdd/`; role key + §1.4 table now assign steps 0–1 to γ, 2–7a to α |
| F2 | C | Replaced `.mli`, `cn_version.ml`, `Cn_lib.version`, `cmd_*.go`, `src/go/internal/` with language-agnostic equivalents across 4 skill files |
| F3 | C | design/SKILL.md §2.3 4.4 now teaches single-source + loader-skill model instead of duplicated-authority |
| F4 | B | Issue template + issue skill: "Active invariants" → "Active design constraints" (captures transition/process constraints) |
| F5 | B | gamma/SKILL.md: Step 1 / Step 1 → Step 1a / Step 1b |

## Verification

```
git grep -n 'cmd_.*\.go' src/packages/cnos.cdd/       # clean
git grep -n 'src/go/internal/' src/packages/cnos.cdd/  # clean
git grep -n '\.mli' src/packages/cnos.cdd/             # clean
git grep -n 'cn_version\.ml' src/packages/cnos.cdd/    # clean
git grep -n 'Cn_lib\.version' src/packages/cnos.cdd/   # clean
git grep -n 'Active invariants' src/packages/cnos.cdd/ # only review/SKILL.md L289 (correct usage)
git grep -n 'src/agent/' src/packages/cnos.cdd/        # clean
git grep -n 'INVARIANTS.md' src/packages/cnos.cdd/     # clean
```

Closes no issue (normalization pass, not issue-tracked).