### PR TITLE
α #230: distribution chain honesty — version-skip + release-bootstrap smoke

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,89 @@
+name: Release Smoke
+
+# Issue #230 AC4: smoke runs on tagged releases (not every PR). The
+# release-published trigger fires after the Release workflow uploads
+# all assets, so the smoke pulls the just-shipped binary + index +
+# tarballs from the GitHub release URL exactly the way an operator
+# would.
+#
+# A failure here flags a release with a broken bootstrap chain — the
+# kind of encoding leak (packages/index.json migration, dev-stamped
+# binary, missing tarball) that previously slipped through silently.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to smoke-test (default: latest)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+          - os: macos-latest
+            target: macos-x64
+          - os: macos-14
+            target: macos-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve target tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run release bootstrap smoke
+        # AC3 + AC5: the script exits 0 (ok), 1 (chain broken), or
+        # 2 (skipped — offline / no release). We propagate 1 as a job
+        # failure and treat 2 as a non-failing skip so transient API
+        # outages do not red-flag a healthy release.
+        run: |
+          set +e
+          scripts/smoke/90-release-bootstrap.sh "${{ steps.tag.outputs.tag }}"
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "::notice::release-smoke ok on ${{ matrix.target }}" ;;
+            2) echo "::warning::release-smoke skipped on ${{ matrix.target }} (rc=2)" ;;
+            *) echo "::error::release-smoke FAILED on ${{ matrix.target }} (rc=$rc)"; exit "$rc" ;;
+          esac
+
+  notify:
+    needs: bootstrap
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Telegram notification
+        env:
+          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
+          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
+        run: |
+          if [ -z "$TG_BOT_TOKEN" ] || [ -z "$TG_CHAT_ID" ]; then exit 0; fi
+          STATUS="${{ needs.bootstrap.result }}"
+          ICON="✅"; [ "$STATUS" != "success" ] && ICON="❌"
+          TAG="${{ github.event.release.tag_name || github.event.inputs.tag || 'latest' }}"
+          MSG="$ICON Release smoke $STATUS: ${{ github.repository }}@${TAG}"
+          curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TG_CHAT_ID}" -d text="${MSG}" -d disable_notification=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,16 @@ jobs:
           cache-dependency-path: src/go/go.sum
 
       - name: Build binary
+        # Stamp the release tag into the binary so `cn setup` writes a
+        # default deps.json pinning packages to the matching version
+        # (issue #230 AC3 — release-bootstrap smoke). Without -ldflags
+        # the binary's compile-time `version` stays "dev", which `cn
+        # setup` then writes into deps.json, breaking `cn deps lock`
+        # against the released package index.
         working-directory: src/go
-        run: go build -o cn ./cmd/cn
+        run: |
+          go build -ldflags "-X main.version=${{ github.ref_name }}" \
+            -o cn ./cmd/cn
 
       - name: Test
         working-directory: src/go

--- a/scripts/smoke/90-release-bootstrap.sh
+++ b/scripts/smoke/90-release-bootstrap.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# 90-release-bootstrap.sh — Prove a freshly released cn binary can
+# bootstrap a hub from production endpoints.
+#
+# Issue #230 AC3–AC5: the encoding-leak chain (lockfile → vendor →
+# released binary) was last caught by accident (packages/index.json
+# migration leak in the v3.x era). This smoke is the named test that
+# would have caught it.
+#
+# Steps:
+#   1. detect host platform (linux-x64 | linux-arm64 | macos-x64 | macos-arm64)
+#   2. resolve release tag (arg, latest from gh, or latest from GitHub API)
+#   3. download cn-<platform>, packages/index.json, every referenced tarball,
+#      and checksums.txt from the GitHub release
+#   4. verify tarball SHA-256 against checksums.txt
+#   5. cn init scratch-hub  → cn setup  → cn deps lock → cn deps restore
+#   6. assert each pinned package is present under .cn/vendor/packages/<name>/
+#      with a cn.package.json whose version matches the lockfile pin
+#
+# Usage:
+#   scripts/smoke/90-release-bootstrap.sh              # latest release
+#   scripts/smoke/90-release-bootstrap.sh 3.58.0       # specific tag
+#
+# Exit:
+#   0 — bootstrap chain works end-to-end against the released artifacts
+#   1 — failure (chain is broken: missing asset, sha mismatch, install error)
+#   2 — skipped (offline, no curl, or no release available — not a failure)
+#
+# Conventions: eng/tool/SKILL.md (set -euo pipefail, NO_COLOR support,
+# prereq checks, idempotent within its own temp dir, machine-readable
+# trailing summary line).
+
+set -euo pipefail
+
+REPO="usurobor/cnos"
+TAG="${1:-}"
+
+# --- color (NO_COLOR support) ---
+if [[ -n "${NO_COLOR:-}" ]] || [[ ! -t 1 ]]; then
+  RED="" GREEN="" YELLOW="" BLUE="" RESET=""
+else
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'; RESET='\033[0m'
+fi
+
+info()  { printf "%b→%b %s\n"  "$BLUE"   "$RESET" "$*"; }
+pass()  { printf "%b✓%b %s\n"  "$GREEN"  "$RESET" "$*"; }
+warn()  { printf "%b!%b %s\n"  "$YELLOW" "$RESET" "$*" >&2; }
+fail()  { printf "%b✗%b %s\n"  "$RED"    "$RESET" "$*" >&2; }
+skip()  { printf "%b○%b %s\n"  "$YELLOW" "$RESET" "$*" >&2; }
+
+# --- prereqs ---
+need() {
+  command -v "$1" >/dev/null 2>&1 || { fail "missing prereq: $1"; exit 1; }
+}
+need curl
+need tar
+need shasum 2>/dev/null || need sha256sum
+SHA_TOOL="$(command -v shasum >/dev/null 2>&1 && echo 'shasum -a 256' || echo 'sha256sum')"
+
+# jq is preferred but optional — we have a sed fallback for the index.
+HAVE_JQ=0
+command -v jq >/dev/null 2>&1 && HAVE_JQ=1
+
+# --- platform detection ---
+detect_platform() {
+  local os arch
+  case "$(uname -s)" in
+    Linux)  os="linux"  ;;
+    Darwin) os="macos"  ;;
+    *)      fail "unsupported OS: $(uname -s)"; exit 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64)   arch="x64"   ;;
+    arm64|aarch64)  arch="arm64" ;;
+    *)              fail "unsupported arch: $(uname -m)"; exit 1 ;;
+  esac
+  echo "${os}-${arch}"
+}
+PLATFORM="$(detect_platform)"
+info "platform: $PLATFORM"
+
+# --- network probe (AC5: graceful offline skip) ---
+if ! curl -fsS --max-time 5 -o /dev/null https://api.github.com/zen 2>/dev/null; then
+  skip "no network reachability to api.github.com — skipping (AC5)"
+  echo "RESULT: skipped (offline)"
+  exit 2
+fi
+
+# --- resolve tag ---
+api() { curl -fsS --max-time 30 -H "Accept: application/vnd.github+json" "$@"; }
+
+if [[ -z "$TAG" ]]; then
+  info "resolving latest release tag from GitHub API"
+  if [[ "$HAVE_JQ" -eq 1 ]]; then
+    TAG="$(api "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)"
+  else
+    # Fallback: grep the tag_name line. Conservative — bare alphanumerics + dots/dashes.
+    TAG="$(api "https://api.github.com/repos/${REPO}/releases/latest" \
+      | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+  fi
+fi
+if [[ -z "$TAG" || "$TAG" == "null" ]]; then
+  skip "no release available on $REPO (empty tag_name) — skipping"
+  echo "RESULT: skipped (no-release)"
+  exit 2
+fi
+info "release tag: $TAG"
+
+DL="https://github.com/${REPO}/releases/download/${TAG}"
+
+# --- workspace ---
+WORKDIR="$(mktemp -d -t cn-bootstrap-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+info "workspace: $WORKDIR"
+
+# --- download cn binary ---
+BIN="$WORKDIR/cn"
+info "downloading cn-$PLATFORM"
+if ! curl -fsSL --max-time 120 -o "$BIN" "${DL}/cn-${PLATFORM}"; then
+  fail "could not download cn-${PLATFORM} from ${DL}"
+  exit 1
+fi
+chmod +x "$BIN"
+
+# Sanity: binary runs and reports a version.
+if ! BIN_VERSION_OUT="$("$BIN" status 2>&1 || true)"; then
+  : # status fails outside a hub — that is fine; we just want it to execute.
+fi
+pass "binary cn-$PLATFORM downloaded and executable"
+
+# --- download index + tarballs into a dist/packages/ tree ---
+# restore.FindIndexPath walks up from the hub looking for
+# dist/packages/index.json. Lay the assets out so the hub at
+# $WORKDIR/scratch/cn-scratch-hub/ resolves the index at
+# $WORKDIR/dist/packages/index.json with relative tarball URLs
+# adjacent.
+PKG_DIR="$WORKDIR/dist/packages"
+mkdir -p "$PKG_DIR"
+
+info "downloading packages/index.json"
+if ! curl -fsSL --max-time 60 -o "$PKG_DIR/index.json" "${DL}/index.json"; then
+  fail "could not download index.json from ${DL}"
+  exit 1
+fi
+
+info "downloading checksums.txt"
+if ! curl -fsSL --max-time 60 -o "$PKG_DIR/checksums.txt" "${DL}/checksums.txt"; then
+  warn "checksums.txt missing — continuing without external sha verification"
+fi
+
+# Enumerate (name,version,filename) triples from the index. The release
+# pipeline writes URLs as bare filenames (cn build's relative form), so
+# we treat .url as the filename to fetch from the same release.
+list_index_entries() {
+  if [[ "$HAVE_JQ" -eq 1 ]]; then
+    jq -r '
+      .packages
+      | to_entries[]
+      | .key as $name
+      | .value | to_entries[]
+      | "\($name)\t\(.key)\t\(.value.url)\t\(.value.sha256)"
+    ' "$PKG_DIR/index.json"
+  else
+    # jq-free fallback: parse the canonical structure with python3 if
+    # available; otherwise warn and bail.
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - "$PKG_DIR/index.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    idx = json.load(f)
+for name, vers in (idx.get("packages") or {}).items():
+    for v, e in vers.items():
+        print(f"{name}\t{v}\t{e.get('url','')}\t{e.get('sha256','')}")
+PY
+    else
+      fail "neither jq nor python3 available to parse index.json"
+      exit 1
+    fi
+  fi
+}
+
+ENTRIES="$(list_index_entries)"
+if [[ -z "$ENTRIES" ]]; then
+  fail "index.json has no package entries — release is empty?"
+  exit 1
+fi
+
+# Download each tarball and verify SHA-256 against the index entry.
+N_PKGS=0
+while IFS=$'\t' read -r name ver url sha; do
+  [[ -z "$name" ]] && continue
+  N_PKGS=$((N_PKGS + 1))
+  fname="$url"
+  # If the index ever moves to absolute URLs, take the basename.
+  case "$fname" in
+    http://*|https://*) fname="$(basename "$fname")" ;;
+  esac
+  dest="$PKG_DIR/$fname"
+  if [[ ! -f "$dest" ]]; then
+    info "downloading $fname"
+    if ! curl -fsSL --max-time 180 -o "$dest" "${DL}/${fname}"; then
+      fail "could not download $fname"
+      exit 1
+    fi
+  fi
+  actual="$($SHA_TOOL "$dest" | awk '{print $1}')"
+  if [[ "$actual" != "$sha" ]]; then
+    fail "sha256 mismatch for $name@$ver: index=$sha got=$actual"
+    exit 1
+  fi
+done <<< "$ENTRIES"
+pass "downloaded + verified $N_PKGS tarball(s)"
+
+# --- bootstrap chain ---
+SCRATCH="$WORKDIR/scratch"
+mkdir -p "$SCRATCH"
+cd "$SCRATCH"
+
+info "cn init scratch-hub"
+if ! "$BIN" init scratch-hub >/dev/null; then
+  fail "cn init failed"; exit 1
+fi
+HUB="$SCRATCH/cn-scratch-hub"
+[[ -d "$HUB" ]] || { fail "cn init did not create cn-scratch-hub"; exit 1; }
+cd "$HUB"
+
+info "cn setup"
+if ! "$BIN" setup >/dev/null; then
+  fail "cn setup failed"; exit 1
+fi
+
+# AC3 strict reading: the chain `init + setup + deps restore` must work
+# against the production package source. `cn setup` writes a default
+# deps.json pinning cnos.core/cnos.eng to the binary's compiled-in
+# version. Verify each pinned (name, version) is present in the index
+# we downloaded — if not, the released binary cannot self-bootstrap and
+# the smoke must fail honestly.
+DEPS_JSON="$HUB/.cn/deps.json"
+[[ -f "$DEPS_JSON" ]] || { fail ".cn/deps.json not written by cn setup"; exit 1; }
+
+index_has() {
+  # index_has <name> <version> → exit 0 iff index.json packages[name][version] exists.
+  local n="$1" v="$2"
+  if [[ "$HAVE_JQ" -eq 1 ]]; then
+    jq -e --arg n "$n" --arg v "$v" \
+      '(.packages // {}) | (.[$n] // {}) | has($v)' \
+      "$PKG_DIR/index.json" >/dev/null 2>&1
+  else
+    python3 - "$PKG_DIR/index.json" "$n" "$v" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+pkgs = d.get("packages") or {}
+sys.exit(0 if sys.argv[2] in pkgs and sys.argv[3] in pkgs[sys.argv[2]] else 1)
+PY
+  fi
+}
+
+verify_default_deps_resolvable() {
+  local missing=""
+  while IFS=$'\t' read -r name ver; do
+    [[ -z "$name" ]] && continue
+    if ! index_has "$name" "$ver"; then
+      missing="${missing}${missing:+, }${name}@${ver}"
+    fi
+  done < <(default_deps_pins)
+  if [[ -n "$missing" ]]; then
+    fail "cn setup pinned packages not in released index: $missing"
+    fail "  → released binary's compiled version disagrees with released package set"
+    exit 1
+  fi
+}
+
+default_deps_pins() {
+  if [[ "$HAVE_JQ" -eq 1 ]]; then
+    jq -r '.packages[] | "\(.name)\t\(.version)"' "$DEPS_JSON"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 - "$DEPS_JSON" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+for p in d.get("packages", []):
+    print(f"{p.get('name','')}\t{p.get('version','')}")
+PY
+  else
+    fail "neither jq nor python3 available to parse deps.json"; exit 1
+  fi
+}
+
+verify_default_deps_resolvable
+pass "cn setup default deps resolvable in released index"
+
+info "cn deps lock"
+if ! "$BIN" deps lock >/dev/null; then
+  fail "cn deps lock failed"; exit 1
+fi
+
+info "cn deps restore"
+if ! "$BIN" deps restore >/dev/null; then
+  fail "cn deps restore failed"; exit 1
+fi
+
+# --- verify installation ---
+ok=0; bad=""
+while IFS=$'\t' read -r name ver; do
+  [[ -z "$name" ]] && continue
+  pkg_dir="$HUB/.cn/vendor/packages/$name"
+  m="$pkg_dir/cn.package.json"
+  if [[ ! -f "$m" ]]; then
+    bad="${bad}${bad:+, }${name}(no manifest)"
+    continue
+  fi
+  installed_ver=""
+  if [[ "$HAVE_JQ" -eq 1 ]]; then
+    installed_ver="$(jq -r .version "$m")"
+  else
+    installed_ver="$(grep -m1 '"version"' "$m" | sed -E 's/.*"version":[[:space:]]*"([^"]+)".*/\1/')"
+  fi
+  if [[ "$installed_ver" != "$ver" ]]; then
+    bad="${bad}${bad:+, }${name}(installed=${installed_ver}, want=${ver})"
+    continue
+  fi
+  ok=$((ok + 1))
+done < <(default_deps_pins)
+
+if [[ -n "$bad" ]]; then
+  fail "vendor verification failed: $bad"
+  echo "RESULT: failed"
+  exit 1
+fi
+
+pass "vendor verified: $ok package(s) match deps.json pins"
+echo "RESULT: ok ($TAG / $PLATFORM, $ok package(s) verified)"

--- a/scripts/smoke/90-release-bootstrap.sh
+++ b/scripts/smoke/90-release-bootstrap.sh
@@ -9,10 +9,11 @@
 #
 # Steps:
 #   1. detect host platform (linux-x64 | linux-arm64 | macos-x64 | macos-arm64)
-#   2. resolve release tag (arg, latest from gh, or latest from GitHub API)
-#   3. download cn-<platform>, packages/index.json, every referenced tarball,
-#      and checksums.txt from the GitHub release
-#   4. verify tarball SHA-256 against checksums.txt
+#   2. resolve release tag (arg or latest from GitHub API)
+#   3. download cn-<platform>, packages/index.json, and every referenced
+#      tarball from the GitHub release
+#   4. verify each tarball's SHA-256 against the index.json entry — the
+#      same authority `cn deps restore` itself trusts at runtime
 #   5. cn init scratch-hub  → cn setup  → cn deps lock → cn deps restore
 #   6. assert each pinned package is present under .cn/vendor/packages/<name>/
 #      with a cn.package.json whose version matches the lockfile pin
@@ -123,10 +124,11 @@ if ! curl -fsSL --max-time 120 -o "$BIN" "${DL}/cn-${PLATFORM}"; then
 fi
 chmod +x "$BIN"
 
-# Sanity: binary runs and reports a version.
-if ! BIN_VERSION_OUT="$("$BIN" status 2>&1 || true)"; then
-  : # status fails outside a hub — that is fine; we just want it to execute.
-fi
+# Sanity: the binary executes. `cn status` exits non-zero outside a
+# hub, which is expected; the `|| true` swallows the rc and the line
+# only fails if the binary cannot be invoked at all (missing loader,
+# wrong arch, exec bit lost in transit).
+"$BIN" status >/dev/null 2>&1 || true
 pass "binary cn-$PLATFORM downloaded and executable"
 
 # --- download index + tarballs into a dist/packages/ tree ---
@@ -143,11 +145,11 @@ if ! curl -fsSL --max-time 60 -o "$PKG_DIR/index.json" "${DL}/index.json"; then
   fail "could not download index.json from ${DL}"
   exit 1
 fi
-
-info "downloading checksums.txt"
-if ! curl -fsSL --max-time 60 -o "$PKG_DIR/checksums.txt" "${DL}/checksums.txt"; then
-  warn "checksums.txt missing — continuing without external sha verification"
-fi
+# index.json is the integrity authority for tarball SHA-256 — it is what
+# `cn deps restore` itself trusts at runtime. The release also publishes
+# a checksums.txt covering the cn binary assets (release.yml `Generate
+# binary checksums`); that file is not the tarball authority and is not
+# fetched here, keeping the smoke aligned with one source of truth.
 
 # Enumerate (name,version,filename) triples from the index. The release
 # pipeline writes URLs as bare filenames (cn build's relative form), so

--- a/src/go/internal/doctor/doctor.go
+++ b/src/go/internal/doctor/doctor.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/usurobor/cnos/src/go/internal/activation"
+	"github.com/usurobor/cnos/src/go/internal/pkg"
 )
 
 // Status classifies a CheckResult.
@@ -272,10 +273,11 @@ func checkPackages(hubPath, _ string) CheckResult {
 			stale = append(stale, fmt.Sprintf("%s (no manifest)", dep.Name))
 			continue
 		}
-		var pm struct {
-			Version string `json:"version"`
-		}
-		if err := json.Unmarshal(manifestData, &pm); err != nil {
+		// Reuse the pure parser introduced for restoreOne (issue #230 F1):
+		// one parser per fact ("installed package version") — eng/go §2.17
+		// + design §3.2.
+		pm, err := pkg.ParseInstalledManifestData(manifestData)
+		if err != nil {
 			stale = append(stale, fmt.Sprintf("%s (unparseable manifest)", dep.Name))
 			continue
 		}

--- a/src/go/internal/doctor/doctor.go
+++ b/src/go/internal/doctor/doctor.go
@@ -246,7 +246,8 @@ func checkPackages(hubPath, _ string) CheckResult {
 	}
 	var lf struct {
 		Packages []struct {
-			Name string `json:"name"`
+			Name    string `json:"name"`
+			Version string `json:"version"`
 		} `json:"packages"`
 	}
 	if err := json.Unmarshal(lockData, &lf); err != nil {
@@ -254,15 +255,43 @@ func checkPackages(hubPath, _ string) CheckResult {
 			Value: fmt.Sprintf("%d installed (lockfile parse error)", total)}
 	}
 	missing := 0
+	// stale tracks installed packages whose vendor cn.package.json
+	// version disagrees with the lockfile pin (issue #230 AC6 — make
+	// the runtime surface the same lie that drove the silent skip).
+	var stale []string
 	for _, dep := range lf.Packages {
 		pkgDir := filepath.Join(vendorDir, dep.Name)
 		if _, err := os.Stat(pkgDir); err != nil {
 			missing++
+			continue
+		}
+		manifestData, err := os.ReadFile(filepath.Join(pkgDir, "cn.package.json"))
+		if err != nil {
+			// Vendor dir present but cn.package.json missing — the
+			// install is structurally broken; flag it as stale.
+			stale = append(stale, fmt.Sprintf("%s (no manifest)", dep.Name))
+			continue
+		}
+		var pm struct {
+			Version string `json:"version"`
+		}
+		if err := json.Unmarshal(manifestData, &pm); err != nil {
+			stale = append(stale, fmt.Sprintf("%s (unparseable manifest)", dep.Name))
+			continue
+		}
+		if pm.Version != dep.Version {
+			stale = append(stale, fmt.Sprintf("%s (installed %s, locked %s)",
+				dep.Name, pm.Version, dep.Version))
 		}
 	}
 	if missing > 0 {
 		return CheckResult{Name: "packages", Status: StatusFail,
 			Value: fmt.Sprintf("%d installed, %d missing from lockfile (run 'cn deps restore')", total, missing)}
+	}
+	if len(stale) > 0 {
+		return CheckResult{Name: "packages", Status: StatusFail,
+			Value: fmt.Sprintf("%d installed, stale: %s (run 'cn deps restore')",
+				total, strings.Join(stale, ", "))}
 	}
 	return CheckResult{Name: "packages", Status: StatusPass,
 		Value: fmt.Sprintf("%d installed, all present", total)}

--- a/src/go/internal/doctor/doctor_test.go
+++ b/src/go/internal/doctor/doctor_test.go
@@ -97,6 +97,35 @@ func TestRunAllPackageVersionDrift(t *testing.T) {
 	}
 }
 
+// TestRunAllPackageManifestUnparseable covers the third stale-state
+// branch (issue #230 F3): cn.package.json is present but contains
+// invalid JSON. Doctor must flag it stale with the "unparseable
+// manifest" diagnostic — same severity as missing/drift.
+func TestRunAllPackageManifestUnparseable(t *testing.T) {
+	hub := makeTestHub(t)
+	pkgDir := filepath.Join(hub, ".cn", "vendor", "packages", "cnos.core")
+	os.MkdirAll(pkgDir, 0755)
+	// Garbage JSON body.
+	os.WriteFile(filepath.Join(pkgDir, "cn.package.json"),
+		[]byte(`{not valid json`), 0644)
+	lockfile := `{"schema":"cn.lock.v2","packages":[{"name":"cnos.core","version":"1.0.0","sha256":"aaa"}]}`
+	os.WriteFile(filepath.Join(hub, ".cn", "deps.lock.json"), []byte(lockfile), 0644)
+
+	checks := RunAll(context.Background(), hub, "3.48.0", nil)
+
+	found := false
+	for _, ch := range checks {
+		if ch.Name == "packages" && ch.Status == StatusFail &&
+			strings.Contains(ch.Value, "unparseable manifest") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected StatusFail with 'unparseable manifest' diagnostic, got: %+v",
+			packagesCheck(checks))
+	}
+}
+
 // TestRunAllPackageManifestMissing covers the half-state case: vendor
 // dir present but cn.package.json absent (a partial install or manual
 // mkdir). Doctor must flag it stale and direct the operator to restore.

--- a/src/go/internal/doctor/doctor_test.go
+++ b/src/go/internal/doctor/doctor_test.go
@@ -65,6 +65,74 @@ func TestRunAllPackageMissing(t *testing.T) {
 	}
 }
 
+// TestRunAllPackageVersionDrift covers issue #230 AC6: when the
+// installed cn.package.json version disagrees with the lockfile pin,
+// doctor must surface it (StatusFail). Pre-fix the runtime surface
+// agreed with the silent-skip lie — installed packages were reported
+// as healthy regardless of the lockfile bump.
+func TestRunAllPackageVersionDrift(t *testing.T) {
+	hub := makeTestHub(t)
+	pkgDir := filepath.Join(hub, ".cn", "vendor", "packages", "cnos.core")
+	os.MkdirAll(pkgDir, 0755)
+	// Installed v1, lockfile pins v2.
+	os.WriteFile(filepath.Join(pkgDir, "cn.package.json"),
+		[]byte(`{"name":"cnos.core","version":"1.0.0"}`), 0644)
+	lockfile := `{"schema":"cn.lock.v2","packages":[{"name":"cnos.core","version":"2.0.0","sha256":"aaa"}]}`
+	os.WriteFile(filepath.Join(hub, ".cn", "deps.lock.json"), []byte(lockfile), 0644)
+
+	checks := RunAll(context.Background(), hub, "3.48.0", nil)
+
+	found := false
+	for _, ch := range checks {
+		if ch.Name == "packages" && ch.Status == StatusFail &&
+			strings.Contains(ch.Value, "stale") &&
+			strings.Contains(ch.Value, "1.0.0") &&
+			strings.Contains(ch.Value, "2.0.0") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected StatusFail with stale-vendor diagnostic naming both versions, got: %+v",
+			packagesCheck(checks))
+	}
+}
+
+// TestRunAllPackageManifestMissing covers the half-state case: vendor
+// dir present but cn.package.json absent (a partial install or manual
+// mkdir). Doctor must flag it stale and direct the operator to restore.
+func TestRunAllPackageManifestMissing(t *testing.T) {
+	hub := makeTestHub(t)
+	pkgDir := filepath.Join(hub, ".cn", "vendor", "packages", "cnos.core")
+	os.MkdirAll(pkgDir, 0755) // empty — no cn.package.json
+	lockfile := `{"schema":"cn.lock.v2","packages":[{"name":"cnos.core","version":"1.0.0","sha256":"aaa"}]}`
+	os.WriteFile(filepath.Join(hub, ".cn", "deps.lock.json"), []byte(lockfile), 0644)
+
+	checks := RunAll(context.Background(), hub, "3.48.0", nil)
+
+	found := false
+	for _, ch := range checks {
+		if ch.Name == "packages" && ch.Status == StatusFail &&
+			strings.Contains(ch.Value, "no manifest") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected StatusFail with 'no manifest' diagnostic, got: %+v",
+			packagesCheck(checks))
+	}
+}
+
+// packagesCheck is a small helper to surface only the packages check
+// in test failure messages.
+func packagesCheck(checks []CheckResult) CheckResult {
+	for _, ch := range checks {
+		if ch.Name == "packages" {
+			return ch
+		}
+	}
+	return CheckResult{Name: "packages", Status: StatusInfo, Value: "<not present in results>"}
+}
+
 func TestRunAllRuntimeContract(t *testing.T) {
 	hub := makeTestHub(t)
 	contract := map[string]any{

--- a/src/go/internal/pkg/pkg.go
+++ b/src/go/internal/pkg/pkg.go
@@ -215,10 +215,27 @@ func IsFirstParty(name string) bool {
 
 // --- Package manifest validation ---
 
-// PackageManifest is the minimal shape of cn.package.json that we
-// validate after extraction. Only the name field is checked.
+// PackageManifest is the minimal shape of cn.package.json read after
+// extraction or for installed-state inspection. Only name+version are
+// captured; the full manifest shape is FullPackageManifest.
 type PackageManifest struct {
-	Name string `json:"name"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ParseInstalledManifestData parses raw cn.package.json bytes into a
+// PackageManifest. Returns an error only if the JSON is malformed;
+// missing name or version fields are returned as empty strings so the
+// caller can decide whether the absence is fatal in its context.
+//
+// Used by restore + doctor to compare the installed version against
+// the lockfile version (issue #230 — silent v1→v2 skip).
+func ParseInstalledManifestData(data []byte) (PackageManifest, error) {
+	var m PackageManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return m, fmt.Errorf("invalid cn.package.json: %w", err)
+	}
+	return m, nil
 }
 
 // ValidatePackageManifestData checks that raw cn.package.json bytes
@@ -226,9 +243,9 @@ type PackageManifest struct {
 // is responsible for reading the file from disk (IO lives in
 // internal/restore/, not here).
 func ValidatePackageManifestData(data []byte, expectedName string) error {
-	var m PackageManifest
-	if err := json.Unmarshal(data, &m); err != nil {
-		return fmt.Errorf("invalid cn.package.json: %w", err)
+	m, err := ParseInstalledManifestData(data)
+	if err != nil {
+		return err
 	}
 	if m.Name == "" {
 		return fmt.Errorf("cn.package.json missing 'name' field")

--- a/src/go/internal/restore/restore.go
+++ b/src/go/internal/restore/restore.go
@@ -86,6 +86,21 @@ func ValidatePackageManifest(pkgDir, expectedName string) error {
 	return pkg.ValidatePackageManifestData(data, expectedName)
 }
 
+// ReadInstalledManifest reads cn.package.json from pkgDir and returns
+// the parsed (name, version) pair. The wrapper around the pure parser
+// in pkg/. Returns an error if the file is missing or malformed.
+//
+// Used by restoreOne (version-aware skip — issue #230) and by doctor
+// (stale-vendor detection).
+func ReadInstalledManifest(pkgDir string) (pkg.PackageManifest, error) {
+	path := filepath.Join(pkgDir, "cn.package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pkg.PackageManifest{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return pkg.ParseInstalledManifestData(data)
+}
+
 // Result records the outcome of restoring one package.
 type Result struct {
 	Name    string
@@ -136,17 +151,44 @@ func restoreOne(ctx context.Context, hubPath string, idx *pkg.PackageIndex, dep 
 
 	pkgDir := pkg.VendorPath(hubPath, dep.Name)
 
-	// Already installed — skip.
-	// NOTE: With version-less VendorPath, this check does not detect
-	// version upgrades (v1 installed, lockfile updated to v2 → directory
-	// exists from v1, skip fires). Version upgrade requires comparing
-	// the installed cn.package.json version against the lockfile version,
-	// or comparing SHA-256 of installed state. Tracked in #230.
+	// Skip-or-reinstall decision (issue #230).
+	//
+	// VendorPath is version-less by design (BUILD-AND-DIST.md keeps the
+	// active runtime simple). The installed version lives inside the
+	// extracted cn.package.json. To detect a lockfile-driven version
+	// bump we read the installed manifest and compare its version to
+	// the lockfile pin:
+	//
+	//   - same version  → skip (no work)
+	//   - drift / unreadable / missing manifest → reinstall
+	//
+	// Reinstall path: remove the stale tree first so leftover files
+	// from the prior version cannot survive the new extraction. The
+	// degraded-path log makes the reinstall visible to the operator
+	// (DESIGN-CONSTRAINTS §6.3).
 	if _, err := os.Stat(pkgDir); err == nil {
-		slog.DebugContext(ctx, "package already installed, skipping",
-			slog.String("package", dep.Name),
-			slog.String("version", dep.Version))
-		return r
+		installed, readErr := ReadInstalledManifest(pkgDir)
+		switch {
+		case readErr == nil && installed.Version == dep.Version:
+			slog.DebugContext(ctx, "package already installed, skipping",
+				slog.String("package", dep.Name),
+				slog.String("version", dep.Version))
+			return r
+		case readErr != nil:
+			slog.WarnContext(ctx, "vendor manifest unreadable, reinstalling",
+				slog.String("package", dep.Name),
+				slog.String("expected_version", dep.Version),
+				slog.String("error", readErr.Error()))
+		default:
+			slog.WarnContext(ctx, "vendor version drift, reinstalling",
+				slog.String("package", dep.Name),
+				slog.String("installed_version", installed.Version),
+				slog.String("lockfile_version", dep.Version))
+		}
+		if err := os.RemoveAll(pkgDir); err != nil {
+			r.Err = fmt.Errorf("remove stale vendor %s: %w", pkgDir, err)
+			return r
+		}
 	}
 
 	// Lookup in index.

--- a/src/go/internal/restore/restore_test.go
+++ b/src/go/internal/restore/restore_test.go
@@ -170,14 +170,16 @@ func TestRestoreAlreadyInstalled(t *testing.T) {
 	hub := t.TempDir()
 	indexPath := filepath.Join(hub, "index.json")
 
-	// Create an empty index (won't be needed — package already installed).
+	// Create an empty index (won't be needed — package already installed
+	// at the same version as the lockfile).
 	idx := pkg.PackageIndex{Schema: "cn.package-index.v1", Packages: map[string]map[string]pkg.IndexEntry{}}
 	writeJSON(t, indexPath, idx)
 
-	// Pre-install the package.
+	// Pre-install the package at the version the lockfile pins.
 	pkgDir := pkg.VendorPath(hub, "cnos.core")
 	os.MkdirAll(pkgDir, 0755)
-	writeJSON(t, filepath.Join(pkgDir, "cn.package.json"), map[string]any{"name": "cnos.core"})
+	writeJSON(t, filepath.Join(pkgDir, "cn.package.json"),
+		map[string]any{"name": "cnos.core", "version": "3.42.0"})
 
 	lockPath := filepath.Join(hub, ".cn", "deps.lock.json")
 	os.MkdirAll(filepath.Dir(lockPath), 0755)
@@ -194,7 +196,147 @@ func TestRestoreAlreadyInstalled(t *testing.T) {
 		t.Fatalf("Restore: %v", err)
 	}
 	if HasErrors(results) {
-		t.Fatal("expected no errors for already-installed package")
+		t.Fatal("expected no errors for already-installed package at matching version")
+	}
+}
+
+// TestRestoreVersionDriftReinstalls is the AC1+AC2 test for issue #230:
+// install v1, bump the lockfile to v2, run restore — the vendor tree
+// must be reinstalled with the v2 manifest. Pre-fix this case silently
+// kept v1 because the version-less VendorPath already existed.
+func TestRestoreVersionDriftReinstalls(t *testing.T) {
+	// Build a v2 tarball with a v2 cn.package.json.
+	v2Manifest := `{"name": "cnos.core", "version": "2.0.0"}`
+	v2Tar, v2SHA := makeTarGz(t, map[string]string{
+		"cn.package.json":   v2Manifest,
+		"doctrine/SOUL.md":  "# v2 Soul\n",
+		"v2-only-marker":    "marker\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(v2Tar)
+	}))
+	defer srv.Close()
+
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {
+				"2.0.0": {URL: srv.URL + "/cnos.core-2.0.0.tar.gz", SHA256: v2SHA},
+			},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	// Pre-install v1 with a stale-only marker file that proves the
+	// reinstall actually wiped the tree (rather than overwriting on top).
+	pkgDir := pkg.VendorPath(hub, "cnos.core")
+	os.MkdirAll(pkgDir, 0755)
+	writeJSON(t, filepath.Join(pkgDir, "cn.package.json"),
+		map[string]any{"name": "cnos.core", "version": "1.0.0"})
+	os.WriteFile(filepath.Join(pkgDir, "v1-only-marker"), []byte("v1\n"), 0644)
+
+	// Lockfile pins v2.
+	lockPath := filepath.Join(hub, ".cn", "deps.lock.json")
+	os.MkdirAll(filepath.Dir(lockPath), 0755)
+	lf := pkg.Lockfile{
+		Schema: "cn.lock.v2",
+		Packages: []pkg.LockedDep{
+			{Name: "cnos.core", Version: "2.0.0", SHA256: v2SHA},
+		},
+	}
+	writeJSON(t, lockPath, lf)
+
+	results, err := Restore(context.Background(), hub, indexPath)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if HasErrors(results) {
+		for _, r := range Errors(results) {
+			t.Errorf("  %s@%s: %v", r.Name, r.Version, r.Err)
+		}
+		t.Fatal("restore had errors")
+	}
+
+	// Vendor manifest must now be v2.
+	installed, err := ReadInstalledManifest(pkgDir)
+	if err != nil {
+		t.Fatalf("read installed manifest: %v", err)
+	}
+	if installed.Version != "2.0.0" {
+		t.Errorf("installed version = %q, want %q (vendor was not reinstalled)",
+			installed.Version, "2.0.0")
+	}
+	// v2-only file must be present.
+	if _, err := os.Stat(filepath.Join(pkgDir, "v2-only-marker")); err != nil {
+		t.Errorf("v2-only-marker missing — extraction did not happen: %v", err)
+	}
+	// v1-only file must be gone — reinstall must wipe the prior tree,
+	// not overlay on top of it.
+	if _, err := os.Stat(filepath.Join(pkgDir, "v1-only-marker")); !os.IsNotExist(err) {
+		t.Errorf("v1-only-marker still present — stale files leaked into v2 install (err=%v)", err)
+	}
+}
+
+// TestRestoreUnreadableManifestReinstalls covers the degraded-path
+// branch of the version-aware skip: when cn.package.json is missing
+// or unparseable, restore treats the install as untrusted and rebuilds
+// it. Pre-fix this case also silently skipped.
+func TestRestoreUnreadableManifestReinstalls(t *testing.T) {
+	manifest := `{"name": "cnos.core", "version": "1.0.0"}`
+	tarData, tarSHA := makeTarGz(t, map[string]string{
+		"cn.package.json": manifest,
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(tarData)
+	}))
+	defer srv.Close()
+
+	hub := t.TempDir()
+	indexPath := filepath.Join(hub, "index.json")
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.0.0": {URL: srv.URL + "/c.tgz", SHA256: tarSHA}},
+		},
+	}
+	writeJSON(t, indexPath, idx)
+
+	// Pre-create an empty vendor dir with no cn.package.json — the kind
+	// of half-state a crashed extraction or manual mkdir leaves behind.
+	pkgDir := pkg.VendorPath(hub, "cnos.core")
+	os.MkdirAll(pkgDir, 0755)
+
+	lockPath := filepath.Join(hub, ".cn", "deps.lock.json")
+	os.MkdirAll(filepath.Dir(lockPath), 0755)
+	lf := pkg.Lockfile{
+		Schema: "cn.lock.v2",
+		Packages: []pkg.LockedDep{
+			{Name: "cnos.core", Version: "1.0.0", SHA256: tarSHA},
+		},
+	}
+	writeJSON(t, lockPath, lf)
+
+	results, err := Restore(context.Background(), hub, indexPath)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if HasErrors(results) {
+		for _, r := range Errors(results) {
+			t.Errorf("  %s@%s: %v", r.Name, r.Version, r.Err)
+		}
+		t.Fatal("restore had errors")
+	}
+	// Manifest must now exist and parse with the lockfile-pinned version.
+	installed, err := ReadInstalledManifest(pkgDir)
+	if err != nil {
+		t.Fatalf("read installed manifest: %v", err)
+	}
+	if installed.Version != "1.0.0" {
+		t.Errorf("installed version = %q, want %q", installed.Version, "1.0.0")
 	}
 }
 


### PR DESCRIPTION
Closes #230. Subsumes #238.

## Gap

Two adjacent gaps make the install authority chain (lockfile → vendor → released binary) silently lie:

1. `restoreOne` skipped reinstall whenever the version-less `VendorPath` already existed — a lockfile bump from `cnos.core@1.0.0` → `2.0.0` was silently ignored, stale v1 stayed installed.
2. There was no automated check that a freshly released `cn` binary could bootstrap a fresh hub from production endpoints.

## Mode

- **Mode:** MCA (in-system patch + new gate)
- **Work shape:** runtime / platform + tooling
- **Level:** L6 — system-safe execution: the lying chain becomes a failing chain.
- **Active skills:** `eng/go`, `eng/test`, `eng/tool`

Design / Plan — **not required** (justified in original PR description; surgical changes within constraints already named by the issue).

## Round 2 — β findings F1–F4 addressed

Round 1 review (comment above) requested changes on four anchors. Round 2 (`93ea1d6`) addresses all four on-branch:

| # | Sev | Finding | Fix in `93ea1d6` |
|---|---|---|---|
| F1 | C | doctor parses `cn.package.json` inline; should reuse `pkg.ParseInstalledManifestData` | `doctor.go` imports `pkg`, replaces the anonymous-struct unmarshal with the pure parser. One parser per fact. |
| F2 | B | smoke header lies about checksums authority; `checksums.txt` download is irrelevant | Header rewritten to name `index.json` sha256 (the runtime authority). `checksums.txt` download removed; comment explains it is the binary-asset file from `release.yml`. |
| F3 | B | `(unparseable manifest)` branch lacks a test | Added `TestRunAllPackageManifestUnparseable` — writes garbage JSON, asserts StatusFail with the right diagnostic. |
| F4 | A | smoke captures `BIN_VERSION_OUT` then never reads it; dead `if !` branch | Replaced with `"$BIN" status >/dev/null 2>&1 || true` — same intent, no dead code. |

β notes (non-findings) accepted as-is:
- Branch name non-canonical — deferred by design scope (cannot rename without losing PR continuity); flagged for γ.
- Stale doc paths in `eng/go/SKILL.md` and `pkg.go:134` — pre-existing on main, out of #230 scope.

## What changed (round 1 baseline + round 2)

| Area | File | Change |
|---|---|---|
| pure type | `src/go/internal/pkg/pkg.go` | `PackageManifest` gains `Version`; new pure parser `ParseInstalledManifestData`; `ValidatePackageManifestData` reuses it. |
| restore | `src/go/internal/restore/restore.go` | New IO wrapper `ReadInstalledManifest`. `restoreOne` reads installed manifest when vendor dir exists: same version → skip; drift / unreadable / no manifest → `slog.WarnContext` + `RemoveAll` + reinstall. |
| restore tests | `src/go/internal/restore/restore_test.go` | `TestRestoreVersionDriftReinstalls` (AC1+AC2; v1-only marker absent after reinstall — anti-overlay assertion). `TestRestoreUnreadableManifestReinstalls`. |
| doctor | `src/go/internal/doctor/doctor.go` | `checkPackages` reads each installed `cn.package.json` via `pkg.ParseInstalledManifestData` (round 2 F1) and compares to lockfile pin; reports StatusFail with stale list (drift / no manifest / unparseable). |
| doctor tests | `src/go/internal/doctor/doctor_test.go` | `TestRunAllPackageVersionDrift` + `TestRunAllPackageManifestMissing` + `TestRunAllPackageManifestUnparseable` (round 2 F3). |
| smoke | `scripts/smoke/90-release-bootstrap.sh` | Detect platform; resolve tag; offline probe → exit 2; download `cn-<platform>` + `index.json` + tarballs; verify each tarball's SHA-256 against `index.json` (the integrity authority `cn deps restore` itself trusts — round 2 F2); `cn init` + `cn setup` + assert default deps resolvable + `cn deps lock` + `cn deps restore`; verify each pinned package's installed version matches the pin. (Round 2 F4: dead `BIN_VERSION_OUT` capture replaced with a no-capture sanity invocation.) |
| CI | `.github/workflows/release-smoke.yml` | New workflow. Triggers `release: types: [published]` + `workflow_dispatch`. 4-platform matrix. rc=2 → `::warning::`, rc=1 → `::error::`. |
| CI | `.github/workflows/release.yml` | Build step stamps `-ldflags "-X main.version=${{ github.ref_name }}"` so `cn setup` writes a workable default. |

## Self-coherence

| AC | Evidence |
|---|---|
| **AC1** version-aware reinstall, perf preserved | `restore.restoreOne` reads installed manifest only when vendor dir exists; same-version path returns immediately |
| **AC2** install v1 → bump v2 → restore == v2 | `TestRestoreVersionDriftReinstalls`; v1-only marker assertion proves wipe |
| **AC3** smoke binary pass/fail | `scripts/smoke/90-release-bootstrap.sh` |
| **AC4** CI on tagged releases only | `.github/workflows/release-smoke.yml` (`release: published` + `workflow_dispatch`) |
| **AC5** graceful offline skip | network probe → exit 2 → workflow `::warning::` |
| **AC6** doctor stale-vendor warning | `checkPackages` stale list (drift + no-manifest + unparseable, all tested) |

**Peer audit.** "Decide whether to install": only `restore.restoreOne` — fixed. "Trust what is installed at runtime": `discover` and `activation` consume manifest without enforcement (out of scope by design); `doctor` patched (AC6).

**Schema audit.** `pkg.PackageManifest` gained a `Version` field — additive. `pkgbuild.PackageManifest` is a separate type, untouched. JSON wire format unchanged.

**Harness audit.** Kata 06 + Tier-2 ci.yml write deps.json with src-derived versions matching the built tarball's manifest, so the new doctor stale check stays green.

**Known debt.**
- Smoke is reactive to `release: published`; it covers all future releases, not historical ones.
- Smoke depends on `release.yml`'s ldflags fix for `cn setup`'s default deps to be resolvable.

## Pre-review gate (alpha SKILL.md §2.6) — round 2

Re-validated against round-2 HEAD `93ea1d6` and `origin/main` HEAD `eafc230` immediately before re-requesting review (alpha SKILL.md §2.7).

| # | Row | State |
|---|---|---|
| 1 | branch rebased onto current `main` | ✓ branch base = `eafc230` = `origin/main` HEAD — no drift since round 1 |
| 2 | PR body carries CDD Trace through step 7 | ✓ |
| 3 | tests present | ✓ all original + `TestRunAllPackageManifestUnparseable` (F3) |
| 4 | every AC has evidence | ✓ |
| 5 | known debt is explicit | ✓ |
| 6 | schema / shape audit | ✓ |
| 7 | peer enumeration | ✓ |
| 8 | harness audit | ✓ |
| 9 | post-patch re-audit | ✓ vet + race + full `go test ./...` after each round-2 edit; bash -n on smoke; offline probe still exits 2 |
| 10 | CI green on head commit | ✓ all 7 check runs success on `93ea1d6`: `go`, `kata-tier1`, `kata-tier2`, `Package/source drift (I1)`, `Protocol contract schema sync (I2)`, `notify` ×2 |

**β: ready for round-2 review at `93ea1d6`.**

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | — | Inputs read (round 1) |
| 1 Select | — | — | Selected gap = #230 |
| 2 Branch | branch | cdd | `claude/alpha-tier-3-skills-IZOsO` |
| 3 Bootstrap | — | cdd | Not required (PR-scoped, unreleased, non-triadic) |
| 4 Gap | this body §Gap | — | Two-source disagreement closed |
| 5 Mode | this body §Mode | eng/go, eng/test, eng/tool | MCA / L6 / runtime+tooling |
| 6c Tests | restore_test.go, doctor_test.go | eng/test | drift + leak + unreadable + version drift + half-state + **unparseable (round 2 F3)** |
| 6d Code | restore.go, doctor.go, pkg.go | eng/go | parse/read split honored (round 2 F1: doctor now consumes the pure parser too) |
| 7 Self-coherence | this body §Self-coherence | cdd | AC-by-AC mapped |
| 7a Pre-review | this body §Pre-review gate | cdd | All rows ✓ at round-2 re-review request |
| 8 Review (round 1) | β comment | review | RC; F1 (C) + F2 (B) + F3 (B) + F4 (A) |
| 8 Review (round 2) | pending | review | re-requested at `93ea1d6` |