### PR TITLE
#235 cn build --check: validate command entrypoints + skill paths

### DIFF
--- a/src/go/internal/pkgbuild/build.go
+++ b/src/go/internal/pkgbuild/build.go
@@ -484,7 +484,164 @@ func CheckOne(pkg DiscoveredPackage) CheckResult {
 		r.Issues = append(r.Issues, "no content class directories found")
 	}
 
+	// AC1 (#235): every commands.<X>.entrypoint declared in
+	// cn.package.json must resolve to an existing regular file under
+	// the package root. Reads through pkgtypes.ParseFullManifestData —
+	// the canonical full-manifest parser — so the entrypoint check
+	// shares one schema definition with the rest of the runtime
+	// (eng/go §2.17 "one parser per fact"). The minimal pkg.Manifest
+	// already validated by DiscoverPackages is reused for name/version
+	// only; commands are only present in the full shape.
+	manifestPath := filepath.Join(pkg.SrcDir, "cn.package.json")
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		r.Issues = append(r.Issues, fmt.Sprintf("read cn.package.json: %v", err))
+	} else {
+		full, err := pkgtypes.ParseFullManifestData(manifestData)
+		if err != nil {
+			r.Issues = append(r.Issues, fmt.Sprintf("parse cn.package.json: %v", err))
+		} else {
+			r.Issues = append(r.Issues, checkCommandEntrypoints(pkg.SrcDir, full.CommandEntries())...)
+		}
+	}
+
+	// AC2 (#235): every leaf directory under skills/ must carry a
+	// SKILL.md. Filesystem-as-authority (#261, DESIGN-CONSTRAINTS §1):
+	// activation discovers skills by walking for SKILL.md files, so a
+	// leaf directory missing one is an unreachable skill — the package
+	// ships content the runtime cannot activate. Container directories
+	// with subdirectories (e.g. cnos.eng/skills/eng/ namespacing all
+	// eng/* sub-skills) are exempt because they are not themselves
+	// skills; their children carry the SKILL.md files.
+	r.Issues = append(r.Issues, checkSkillDirectories(pkg.SrcDir)...)
+
 	return r
+}
+
+// checkCommandEntrypoints returns one issue per declared command whose
+// entrypoint does not resolve to an existing regular file under
+// pkgDir. Paths are rejected if they escape pkgDir (path traversal via
+// "..") or if the resolved target is missing or is not a regular file
+// (directory, symlink to a directory, etc.). Permission bits are not
+// checked — issue #235 non-goal: chmod is platform-variable.
+func checkCommandEntrypoints(pkgDir string, commands []pkgtypes.PackageCommandEntry) []string {
+	var issues []string
+	for _, cmd := range commands {
+		if cmd.Entrypoint == "" {
+			issues = append(issues, fmt.Sprintf("command %q: missing entrypoint", cmd.Name))
+			continue
+		}
+		// Resolve the declared path relative to pkgDir and verify it
+		// stays inside the package root. filepath.Clean collapses
+		// "a/../b" sequences; the rel check then catches any path
+		// that walks above pkgDir.
+		entryAbs := filepath.Join(pkgDir, filepath.FromSlash(cmd.Entrypoint))
+		rel, err := filepath.Rel(pkgDir, entryAbs)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			issues = append(issues, fmt.Sprintf("command %q: entrypoint %q escapes package root",
+				cmd.Name, cmd.Entrypoint))
+			continue
+		}
+		info, err := os.Stat(entryAbs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				issues = append(issues, fmt.Sprintf("command %q: entrypoint %q does not exist",
+					cmd.Name, cmd.Entrypoint))
+			} else {
+				issues = append(issues, fmt.Sprintf("command %q: stat entrypoint %q: %v",
+					cmd.Name, cmd.Entrypoint, err))
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			issues = append(issues, fmt.Sprintf("command %q: entrypoint %q is not a regular file",
+				cmd.Name, cmd.Entrypoint))
+		}
+	}
+	return issues
+}
+
+// checkSkillDirectories walks each top-level subdirectory of
+// pkgDir/skills/ and returns one issue per top-level directory that
+// has no SKILL.md anywhere in its subtree. Filesystem-as-authority
+// (#261, DESIGN-CONSTRAINTS §1): the activation walk only registers
+// a skill where it finds a SKILL.md, so a top-level skill directory
+// with no SKILL.md descendants is dead weight — the package ships a
+// directory the runtime cannot interpret as anything.
+//
+// The check is intentionally narrow:
+//
+//   - Top-level only. Deeper subdirectories may legitimately be
+//     resource subdirectories of their parent skill (e.g.
+//     `skills/naturalize/references/ai-tells.md`) or sub-skills with
+//     their own SKILL.md. The two are indistinguishable from layout
+//     alone, so the validator does not flag them. This narrowness is
+//     the cost of filesystem-as-authority: there is no manifest-side
+//     declaration to check against.
+//
+//   - "Subtree contains SKILL.md" is the bar, not "this directory
+//     has SKILL.md." Container namespaces such as
+//     `cnos.eng/skills/eng/` carry no SKILL.md themselves but hold
+//     a flat tree of sub-skills (eng/code/, eng/test/, …), each with
+//     their own SKILL.md. They pass.
+//
+// SKILL.md directly under `skills/` has no derivable skill id (see
+// activation/index.go discoverPackageSkills) and is therefore not
+// considered a skill — the walk skips files at skills/'s root.
+func checkSkillDirectories(pkgDir string) []string {
+	skillsRoot := filepath.Join(pkgDir, pkgtypes.ClassSkills)
+	info, err := os.Stat(skillsRoot)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	topLevel, err := os.ReadDir(skillsRoot)
+	if err != nil {
+		return []string{fmt.Sprintf("read skills/: %v", err)}
+	}
+
+	var issues []string
+	for _, e := range topLevel {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(skillsRoot, e.Name())
+		hasSkillMd, walkErr := containsSkillMd(dir)
+		if walkErr != nil {
+			issues = append(issues, fmt.Sprintf("walk skills/%s: %v", e.Name(), walkErr))
+			continue
+		}
+		if !hasSkillMd {
+			issues = append(issues, fmt.Sprintf("skill directory %q: no SKILL.md found in subtree",
+				filepath.ToSlash(filepath.Join(pkgtypes.ClassSkills, e.Name()))))
+		}
+	}
+	// Stable order across platforms — os.ReadDir returns lexical
+	// order on most filesystems, but readdir order is not specified
+	// by POSIX and we want byte-identical CI output.
+	sort.Strings(issues)
+	return issues
+}
+
+// containsSkillMd reports whether root or any of its descendants
+// contains a regular file named SKILL.md. The walk short-circuits
+// at the first hit via fs.SkipAll.
+func containsSkillMd(root string) (bool, error) {
+	found := false
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && d.Name() == "SKILL.md" {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return found, nil
 }
 
 // --- Lockfile generation ---

--- a/src/go/internal/pkgbuild/build_test.go
+++ b/src/go/internal/pkgbuild/build_test.go
@@ -688,3 +688,227 @@ func writeManifest(t *testing.T, pkgDir, name, version string) {
 	data, _ := json.MarshalIndent(manifest, "", "  ")
 	os.WriteFile(filepath.Join(pkgDir, "cn.package.json"), data, 0644)
 }
+
+// writeManifestWithCommands writes a cn.package.json that declares the
+// given command map. The minimal-shape PackageManifest writeManifest
+// uses cannot represent commands; commands validation needs the full
+// shape.
+func writeManifestWithCommands(t *testing.T, pkgDir, name, version string, commands map[string]map[string]string) {
+	t.Helper()
+	cmds := make(map[string]map[string]string, len(commands))
+	for k, v := range commands {
+		cmds[k] = v
+	}
+	manifest := map[string]any{
+		"schema":   "cn.package.v1",
+		"name":     name,
+		"version":  version,
+		"kind":     "package",
+		"commands": cmds,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "cn.package.json"), data, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// hasIssue reports whether any element of issues contains substr.
+// Used by the AC1/AC2 negative-path tests so the assertion is robust
+// against future tweaks to the human-readable error string.
+func hasIssue(issues []string, substr string) bool {
+	for _, iss := range issues {
+		if strings.Contains(iss, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- #235 AC1: command entrypoint validation ---
+
+// TestCheckOneEntrypointPresent: pass path. Manifest declares a
+// command and the entrypoint exists as a regular file under pkgDir.
+// CheckOne reports no entrypoint issue.
+func TestCheckOneEntrypointPresent(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "alpha", "SKILL.md"), "# alpha\n")
+	mustWrite(t, filepath.Join(pkgDir, "commands", "daily", "cn-daily"), "#!/bin/sh\n")
+	writeManifestWithCommands(t, pkgDir, "test.pkg", "1.0.0", map[string]map[string]string{
+		"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "daily"},
+	})
+
+	packages, err := DiscoverPackages(repoRoot)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	result := CheckOne(packages[0])
+	if hasIssue(result.Issues, "entrypoint") {
+		t.Errorf("expected no entrypoint issue, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneEntrypointMissing: fail path (AC1). Manifest declares a
+// command with an entrypoint that does not exist on disk. CheckOne
+// surfaces a "does not exist" issue naming the command.
+func TestCheckOneEntrypointMissing(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "alpha", "SKILL.md"), "# alpha\n")
+	writeManifestWithCommands(t, pkgDir, "test.pkg", "1.0.0", map[string]map[string]string{
+		"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "daily"},
+	})
+
+	packages, err := DiscoverPackages(repoRoot)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	result := CheckOne(packages[0])
+	if !hasIssue(result.Issues, `command "daily"`) || !hasIssue(result.Issues, "does not exist") {
+		t.Errorf("expected entrypoint-missing issue naming the command, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneEntrypointIsDirectory: fail path. Entrypoint resolves to
+// an existing path that is not a regular file (e.g. a directory).
+// AC1 explicitly requires the entrypoint to be "an existing regular file."
+func TestCheckOneEntrypointIsDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "alpha", "SKILL.md"), "# alpha\n")
+	if err := os.MkdirAll(filepath.Join(pkgDir, "commands", "daily", "cn-daily"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeManifestWithCommands(t, pkgDir, "test.pkg", "1.0.0", map[string]map[string]string{
+		"daily": {"entrypoint": "commands/daily/cn-daily", "summary": "daily"},
+	})
+
+	packages, err := DiscoverPackages(repoRoot)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	result := CheckOne(packages[0])
+	if !hasIssue(result.Issues, "is not a regular file") {
+		t.Errorf("expected non-regular-file issue, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneEntrypointEscapesPackageRoot: fail path. A manifest
+// declaring an entrypoint with a "../" prefix must be rejected even
+// if the resolved path happens to exist outside the package root.
+// Defends the "fact lives under pkgDir" boundary.
+func TestCheckOneEntrypointEscapesPackageRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "alpha", "SKILL.md"), "# alpha\n")
+	// File exists outside pkgDir; the validator must still reject the path.
+	mustWrite(t, filepath.Join(repoRoot, "outside-the-package"), "x")
+	writeManifestWithCommands(t, pkgDir, "test.pkg", "1.0.0", map[string]map[string]string{
+		"escape": {"entrypoint": "../../../outside-the-package", "summary": "evil"},
+	})
+
+	packages, err := DiscoverPackages(repoRoot)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	result := CheckOne(packages[0])
+	if !hasIssue(result.Issues, "escapes package root") {
+		t.Errorf("expected path-escape issue, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneNoCommandsIsValid: a package with no commands declared
+// produces no entrypoint issues. The check is opt-in by manifest
+// declaration; packages that ship only skills/templates/etc. must not
+// be penalized.
+func TestCheckOneNoCommandsIsValid(t *testing.T) {
+	repoRoot := t.TempDir()
+	setupTestRepo(t, repoRoot)
+
+	packages, _ := DiscoverPackages(repoRoot)
+	result := CheckOne(packages[0])
+	if hasIssue(result.Issues, "command") || hasIssue(result.Issues, "entrypoint") {
+		t.Errorf("expected no command/entrypoint issues, got %v", result.Issues)
+	}
+}
+
+// --- #235 AC2: skill directory validation ---
+
+// TestCheckOneSkillDirWithSkillMd: pass path. A leaf skill directory
+// with SKILL.md is valid. setupTestRepo already creates this shape;
+// the test makes the AC2 pass-path explicit so future regressions to
+// the rule are caught directly.
+func TestCheckOneSkillDirWithSkillMd(t *testing.T) {
+	repoRoot := t.TempDir()
+	setupTestRepo(t, repoRoot)
+
+	packages, _ := DiscoverPackages(repoRoot)
+	result := CheckOne(packages[0])
+	if hasIssue(result.Issues, "SKILL.md") {
+		t.Errorf("expected no SKILL.md issue, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneSkillDirMissingSkillMd: fail path (AC2). Top-level
+// directory under skills/ ships only resource files — no SKILL.md
+// anywhere in subtree. The runtime cannot activate it. CheckOne
+// surfaces the directory by path.
+func TestCheckOneSkillDirMissingSkillMd(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	// "ghost" skill dir: only a resource file, no SKILL.md anywhere
+	// in the subtree.
+	mustWrite(t, filepath.Join(pkgDir, "skills", "ghost", "notes.md"), "stray\n")
+	writeManifest(t, pkgDir, "test.pkg", "1.0.0")
+
+	packages, err := DiscoverPackages(repoRoot)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	result := CheckOne(packages[0])
+	if !hasIssue(result.Issues, "skills/ghost") || !hasIssue(result.Issues, "no SKILL.md") {
+		t.Errorf("expected ghost-skill issue naming skills/ghost, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneSkillContainerNamespaceExempt: a top-level "namespace"
+// directory under skills/ that itself has no SKILL.md but contains
+// sub-skills (each with SKILL.md) is valid. This is the
+// cnos.eng/skills/eng/ pattern — eng/ is a flat namespace over
+// eng/code, eng/test, etc. The validator must not flag the parent.
+func TestCheckOneSkillContainerNamespaceExempt(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "eng", "code", "SKILL.md"), "# code\n")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "eng", "test", "SKILL.md"), "# test\n")
+	writeManifest(t, pkgDir, "test.pkg", "1.0.0")
+
+	packages, _ := DiscoverPackages(repoRoot)
+	result := CheckOne(packages[0])
+	if hasIssue(result.Issues, "skills/eng") {
+		t.Errorf("container namespace must not be flagged, got %v", result.Issues)
+	}
+}
+
+// TestCheckOneSkillResourceSubdirExempt: a resource subdirectory
+// inside a skill (e.g. skills/foo/references/) does not need its own
+// SKILL.md. This is the cnos.core/skills/naturalize/references/
+// pattern — the parent skill cites resource markdown alongside its
+// SKILL.md. The validator only checks top-level subdirectories of
+// skills/, so deeper resource dirs are by-construction exempt.
+func TestCheckOneSkillResourceSubdirExempt(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgDir := filepath.Join(repoRoot, "src", "packages", "test.pkg")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "naturalize", "SKILL.md"), "# naturalize\n")
+	mustWrite(t, filepath.Join(pkgDir, "skills", "naturalize", "references", "ai-tells.md"), "ref\n")
+	writeManifest(t, pkgDir, "test.pkg", "1.0.0")
+
+	packages, _ := DiscoverPackages(repoRoot)
+	result := CheckOne(packages[0])
+	if hasIssue(result.Issues, "references") {
+		t.Errorf("resource subdir must not be flagged, got %v", result.Issues)
+	}
+}


### PR DESCRIPTION
Closes #235

## Gap

`cn build --check` (driven by `pkgbuild.CheckOne`) currently validates
only structural presence of content-class directories. A package can
declare `commands.daily.entrypoint = "commands/daily/cn-daily"` with
the file missing, or ship a top-level `skills/<name>/` directory with
no `SKILL.md` anywhere in its subtree, and CI will pass — the tarball
ships broken. This branch closes the gap.

## Mode

- **Mode:** MCA
- **Work shape:** small, single triad cycle
- **Tier 3 skills:** `eng/go`, `eng/test`

## What changed

`internal/pkgbuild/build.go::CheckOne` now reads `cn.package.json` via
the canonical `pkg.ParseFullManifestData` parser and runs two new
validation passes:

- **AC1 (`checkCommandEntrypoints`)** — for every declared command,
  verify the entrypoint resolves to an existing regular file under
  the package root. Rejects path-traversal (`../`), missing files,
  and non-regular-file targets (e.g. directory at the entrypoint
  path). Permission bits are intentionally not checked — the issue
  explicitly names chmod as a non-goal.
- **AC2 (`checkSkillDirectories`)** — for every top-level subdirectory
  of `skills/`, verify at least one `SKILL.md` exists somewhere in
  the subtree. The top-level scope is the narrowest rule that
  catches "ghost skill directory" without false-positives on:
  - resource subdirectories (`skills/<skill>/references/...`) — the
    `cnos.core/skills/naturalize/references/` pattern
  - namespace containers (`cnos.eng/skills/eng/`) that themselves
    carry no `SKILL.md` but hold a flat tree of sub-skills, each
    with its own `SKILL.md`

`internal/pkgbuild/build_test.go` adds 9 tests covering both ACs.

## Self-coherence

| AC | Evidence |
|----|----------|
| **AC1** — fatal error for missing/declared entrypoints | `checkCommandEntrypoints` in `build.go`; `TestCheckOneEntrypointMissing`, `TestCheckOneEntrypointIsDirectory`, `TestCheckOneEntrypointEscapesPackageRoot`, `TestCheckOneEntrypointPresent` (pass path), `TestCheckOneNoCommandsIsValid` (no-commands case) |
| **AC2** — fatal error for missing skill `SKILL.md` | `checkSkillDirectories` + `containsSkillMd` in `build.go`; `TestCheckOneSkillDirMissingSkillMd` (fail), `TestCheckOneSkillDirWithSkillMd` (pass), `TestCheckOneSkillContainerNamespaceExempt` + `TestCheckOneSkillResourceSubdirExempt` (false-positive guards) |
| **AC3** — pass + fail tests for both | 9 new `TestCheckOne*` tests cover pass paths, fail paths, and exempt cases for both ACs |
| **AC4** — I1 surfaces both classes; verified by deliberate-break dry-run | Existing I1 job in `.github/workflows/coherence.yml` already runs `./cn build --check` per-package and exits non-zero on any issue. Verified locally by copying the repo, injecting a fake `commands.fake-cmd.entrypoint` in `cnos.cdd/cn.package.json` and an `skills/orphan-skill/` with only a stray `notes.md`, then running the freshly-built `cn`. Output: <br>`✗ cnos.cdd: 2 issue(s)`<br>&nbsp;&nbsp;`command "fake-cmd": entrypoint "commands/fake-cmd/cn-fake-cmd" does not exist`<br>&nbsp;&nbsp;`skill directory "skills/orphan-skill": no SKILL.md found in subtree`<br>Exit code: 1. Both new error classes flow through the existing exit-code-driven CI failure mechanism — no workflow change needed. |

### Role self-check

- All ACs map to code + test evidence. No ambiguity is pushed onto β.
- Active design constraints honored:
  - **DESIGN-CONSTRAINTS §1** (single source of truth, filesystem-as-authority for skills): the AC2 rule reads filesystem layout, not a manifest field — same authority surface the activation walk in `internal/activation/index.go::discoverPackageSkills` uses for `BuildIndex`.
  - **DESIGN-CONSTRAINTS §3.2** (dispatch boundary): the validator stays inside `internal/pkgbuild/`; `cli/cmd_build.go` is unchanged.
  - **INVARIANTS T-002, T-004**: the new check enforces "manifest claim ↔ filesystem fact" so installed/built shape can be trusted to match the manifest.
- **eng/go §2.17** (one parser per fact): no parallel parser introduced. The new code reads `cn.package.json` once via `pkg.ParseFullManifestData`, the same canonical parser already used by `internal/discover/discover.go` for runtime command discovery. Build-time validator and runtime activation now share one authority.
- **eng/go §2.7** (resource lifecycles): `os.ReadFile` is the entire read path; no handle to defer.
- **eng/go §3.10** (shell/archive safety): no subprocesses or archive extraction added.
- **eng/test §2.7** (negative space mandatory): every meaningful boundary has a "must not happen" test (entrypoint-is-directory, escapes-root, container-exempt, resource-subdir-exempt).
- **eng/test §3.13** (cover new surfaces): every new `Issues` string family has at least one test.

### Peer enumeration

The two surfaces that consume the same authority:

- **Build-time validator** (this PR): `internal/pkgbuild/build.go::CheckOne` — fatal pre-tarball check.
- **Runtime command dispatch**: `internal/discover/discover.go` — silently skips entrypoints that escape package dir; `Run()` re-stats at exec time.
- **Runtime skill activation**: `internal/activation/index.go::discoverPackageSkills` — silently skips directories without `SKILL.md`.

Build-time and runtime now agree on what constitutes a valid command/skill. The build-time check converts what was a silent runtime-time degradation into a noisy build-time failure.

### Harness audit

No new schema introduced. The PR consumes the existing
`pkgtypes.FullPackageManifest` schema; no non-Go producers exist for
`cn.package.json` (it is hand-authored or kernel-emitted).

### Known debt

- The pre-existing `pkgbuild.PackageManifest` minimal-shape parser
  duplicates `pkgtypes.PackageManifest`. This is **out of scope** for
  this issue — eliminating the parallel parser is a separate
  refactor that would change `DiscoveredPackage.Manifest`'s static
  type and ripple through `BuildOne`/`UpdateIndex`/`UpdateChecksums`.
  Filed as latent refactor; not introduced by this diff.

## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | — | — | Issue #235 dispatched as Tier 3 work |
| 1 Select | — | — | Selected #235 (B2 single-issue bundle) |
| 2 Branch | `claude/alpha-tier-3-skills-M8Vce` | cdd | Branch already exists from γ dispatch; verified at origin/main HEAD |
| 3 Bootstrap | — | cdd | Not required: small change, no version directory needed |
| 4 Gap | PR §Gap | cdd | Named: build-check does not validate manifest's commands/entrypoint or skills/<X>/SKILL.md presence |
| 5 Mode | PR §Mode | cdd, eng/go, eng/test | MCA, Tier 3 = eng/go + eng/test |
| 6a Design | — | design | Not required: §3.2 dispatch boundary already established; the change is one validator pass inside `internal/pkgbuild/` |
| 6b Plan | — | plan | Not required: AC1 → AC2 → AC3 → AC4 is the natural sequence per issue |
| 6c Tests | `build_test.go` | eng/test | 9 new `TestCheckOne*` tests; pass + fail + exempt for each AC |
| 6d Code | `build.go` | eng/go | `checkCommandEntrypoints` + `checkSkillDirectories` + `containsSkillMd` helpers; CheckOne extended |
| 6e Docs | — | document | Not required: doc comments inline in `build.go` explain the rules; no canonical doc surface changed |
| 7 Self-coherence | this PR body §Self-coherence | cdd | AC-by-AC mapping above |
| 7a Pre-review | this PR body | cdd | Pre-review gate: branch at origin/main HEAD (transient row, observed at PR-open: HEAD f7d27b4, base 48d99a3, 0 behind); tests + race + vet green; AC4 evidence captured; peer + harness audit done; awaiting CI on head commit |

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test -race ./internal/pkgbuild/...` — green
- [x] `go vet ./...` — clean
- [x] `go build -o /tmp/cn ./cmd/cn && /tmp/cn build --check` against live `src/packages/` — all 5 packages valid
- [x] AC4 dry-run: deliberate-break of `cnos.cdd` in a copy surfaces both new errors with exit 1
- [ ] CI green on head commit (waiting for I1 + protocol-contract + Telegram-notify jobs)



---
_Generated by [Claude Code](https://claude.ai/code/session_014QHoo7JWLNpxsSw8wtcV5X)_