### PR TITLE
docs(readme): align repo landing page with agent-composition model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,26 @@
 
 ## What is cnos?
 
-cnos is a coherence system for autonomous agents, built on Git.
+cnos is a Git-native coherence system for human+AI agents.
 
-The core idea: an AI agent's identity, memory, and relationships should live in a git repo — not locked behind a platform, not dependent on any single host. If any server disappears, the agent's fork persists. Every decision is a commit. Every collaboration is a merge.
+The core idea: an agent's identity, memory, work, and relationships should live in a git repo — not locked behind a platform, not dependent on any single host. If any server disappears, the agent's fork persists. Every decision is a commit. Every collaboration is a merge.
+
+At the language level, the core unit is the **agent**:
 
 ```
-Agent (pure)  ──>  cn (CLI)  ──>  Git (substrate)
-  reads input       validates        push/fetch
-  writes output     executes ops     threads as files
+agent = tri(orientation, intervention, witness)
 ```
+
+An agent orients to a boundary or task, intervenes through work or delegation, and closes with an inspectable witness. A **skill** is a narrow agent (single invocation, task-local scope). A **role** is a wider-scoped agent (bound while the role is held). A **composite agent** coordinates subagents through explicit composition operators and returns a witnessed close-out.
+
+```
+Agent / CTB layer  ──>  cn runtime boundary  ──>  Git substrate
+orients/intervenes      validates/executes        stores refs, threads,
+returns close-outs      side effects              witnesses, commits,
+                                                  packages
+```
+
+Today, `cn` ships the Git-native hub/package CLI. The full agent runtime and [CTB](#ctb) enforcement layer are still in progress — see [Current State](#current-state).
 
 ### The coherent agent
 
@@ -28,7 +39,7 @@ A coherent agent minimizes the gap between its model and reality. It does this t
 - **MCP** — the best current picture of reality and system state
 - **CDD** — coherence-driven development: the same coherence law applied to the system's own evolution
 
-The agent is a pure function. It reads input, writes output. `cn` handles all side effects — git, network, file I/O — through a validated, sandboxed shell with crash recovery and audit receipts.
+A narrow agent may behave like a pure function: input → output. Wider agents compose subagents, preserve witnesses, and return close-outs. `cn` handles all side effects — git, network, file I/O — through a validated runtime boundary.
 
 ### The network
 
@@ -39,7 +50,8 @@ Agents connect through **peering** — exchanging git refs. Each agent has a **h
 | **Hub** | A git repo — the agent's home. Holds threads, state, config. |
 | **Peer** | Another agent's hub. Listed in `state/peers.md`. |
 | **Thread** | Unit of work or conversation. Markdown + YAML frontmatter. |
-| **Agent** | Pure function: input → output. Never touches files or git directly. |
+| **Agent** | Scoped process: orients, intervenes, closes with a witness. Skills are narrow agents. |
+| **CTB** | Triadic agent-composition language. Emerging spec — see [CTB docs](./docs/alpha/ctb/). |
 
 > [Manifesto](./docs/alpha/doctrine/MANIFESTO.md) · [Thesis](./docs/THESIS.md) · [Whitepaper](./docs/alpha/protocol/WHITEPAPER.md) · [Architecture](./docs/beta/architecture/ARCHITECTURE.md)
 
@@ -200,6 +212,13 @@ cn-<name>/
 | [WHITEPAPER.md](./docs/alpha/protocol/WHITEPAPER.md) | CN protocol specification |
 | [PROTOCOL.md](./docs/alpha/protocol/PROTOCOL.md) | The four FSMs |
 | [SECURITY-MODEL.md](./docs/alpha/security/SECURITY-MODEL.md) | Security architecture |
+
+| CTB (agent-composition language) | |
+|--------|---|
+| [CTB README](./docs/alpha/ctb/README.md) | Document map and authority rules |
+| [LANGUAGE-SPEC.md](./docs/alpha/ctb/LANGUAGE-SPEC.md) | v0.1 skill-module baseline (normative) |
+| [LANGUAGE-SPEC-v0.2-draft.md](./docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md) | v0.2 agent-module target (draft) |
+| [SEMANTICS-NOTES.md](./docs/alpha/ctb/SEMANTICS-NOTES.md) | Conceptual rationale (non-normative) |
 
 | Process | |
 |---------|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 A recurrent coherence system with Git as its lowest durable substrate.
 
-**Version:** 3.13.0
-**Date:** 2026-03-23
+**Version:** 3.61.1
+**Date:** 2026-04-29
 
 ---
 
@@ -90,7 +90,7 @@ The substance of the system — doctrine, specs, definitions.
 | [N-PASS-BIND-v3.8.0.md](./alpha/N-PASS-BIND-v3.8.0.md) | N-pass bind loop and indicators | 3.8.0 |
 | [SYSCALL-SURFACE-v3.8.0.md](./alpha/SYSCALL-SURFACE-v3.8.0.md) | Syscall surface redesign | 3.8.0 |
 | [SCHEDULER-v3.7.0.md](./alpha/SCHEDULER-v3.7.0.md) | Scheduler design | 3.7.0 |
-| [CTB-v4.0.0-VISION.md](./alpha/ctb/CTB-v4.0.0-VISION.md) | CTB v4.0.0 vision: skill language | 4.0.0 |
+| [CTB-v4.0.0-VISION.md](./alpha/ctb/CTB-v4.0.0-VISION.md) | CTB v4.0.0 vision: agent-composition language | 4.0.0 |
 
 **Feature bundles:**
 
@@ -99,7 +99,7 @@ The substance of the system — doctrine, specs, definitions.
 | [agent-runtime/](./alpha/agent-runtime/) | Runtime spec, CAA, runtime contract, version-scoped design docs |
 | [cli/](./alpha/cli/) | CLI reference, daemon mode, setup installer |
 | [cognitive-substrate/](./alpha/cognitive-substrate/) | Cognitive asset classes, CAR resolver |
-| [ctb/](./alpha/ctb/) | CTB v4.0.0 vision |
+| [ctb/](./alpha/ctb/) | CTB — triadic agent-composition language; [v0.1 baseline](./alpha/ctb/LANGUAGE-SPEC.md), [v0.2 draft target](./alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md), [semantics notes](./alpha/ctb/SEMANTICS-NOTES.md) |
 | [doctrine/](./alpha/doctrine/) | Coherence system, foundations, manifesto |
 | [protocol/](./alpha/protocol/) | Whitepaper, protocol FSMs, thread API |
 | [runtime-extensions/](./alpha/runtime-extensions/) | Extensions spec, version snapshots |
@@ -153,8 +153,12 @@ docs/
 │   │   ├── CLI.md, DAEMON.md, SETUP-INSTALLER.md
 │   ├── cognitive-substrate/           # Cognitive assets, CAR
 │   │   ├── COGNITIVE-SUBSTRATE.md, CAR.md
-│   ├── ctb/                           # CTB vision
-│   │   └── CTB-v4.0.0-VISION.md
+│   ├── ctb/                           # CTB agent-composition language
+│   │   ├── README.md                  # Document map + authority
+│   │   ├── LANGUAGE-SPEC.md           # v0.1 baseline (normative)
+│   │   ├── LANGUAGE-SPEC-v0.2-draft.md # v0.2 agent-module target (draft)
+│   │   ├── SEMANTICS-NOTES.md         # Conceptual rationale (non-normative)
+│   │   └── CTB-v4.0.0-VISION.md      # Strategy + roadmap (non-normative)
 │   ├── doctrine/                      # Coherence system, foundations, manifesto
 │   │   ├── COHERENCE-SYSTEM.md, FOUNDATIONS.md, MANIFESTO.md
 │   ├── protocol/                      # Whitepaper, protocol, thread API


### PR DESCRIPTION
## Summary

Landing-page alignment patch. The root README still presented the agent as a "pure function: input → output" and framed cnos mostly through CAP/CLP/MCP/CDD, while the CTB docs now carry the agent-composition model (#288, #289, #290, #291 all merged). This PR aligns without rewriting.

## Changes

**README.md:**
- "What is cnos?" states agent as core unit: `tri(orientation, intervention, witness)`
- Skills = narrow agents, roles = wider-scoped agents, composite agents coordinate subagents
- ASCII diagram: `Agent / CTB layer → cn runtime → Git substrate`
- "Pure function" softened to narrow-agent description; wider agents compose and return close-outs
- Concepts table: Agent row updated, CTB row added
- Documentation section: CTB table with v0.1/v0.2/notes and status labels
- Current State section preserved unchanged — still warns runtime + CTB enforcement not shipped

**docs/README.md:**
- Version/date: 3.61.1 / 2026-04-29
- CTB entry: "skill language" → "agent-composition language"
- CTB feature bundle: expanded with all 5 current documents
- Directory map: `ctb/` tree shows README, v0.1 spec, v0.2 draft, semantics notes, vision

## What this does NOT do

- Does not promote CTB v0.2
- Does not modify v0.1 LANGUAGE-SPEC.md
- Does not rewrite doctrine, architecture, or CTB specs
- Does not claim runtime enforces witnessed close-outs
- Does not add new CTB concepts — summarizes already-landed docs only