### PR TITLE
docs(readme): realign landing page with recurrent coherence system

### DIFF
--- a/.github/workflows/coherence.yml
+++ b/.github/workflows/coherence.yml
@@ -31,6 +31,22 @@ jobs:
   # I1 (coherence-build-check via `cn build --check`) continues to gate source
   # structural validity.
 
+  readme-link-check:
+    name: README link validation (I4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # lychee: Rust binary link checker, no runtime deps.
+      # --offline: skip external URLs (check local file links only).
+      # docs/README.md excluded — has known legacy link debt
+      # (version-scoped docs moved to bundles).
+      - name: Check README links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --no-progress README.md
+          fail: true
+
   protocol-contract-check:
     name: Protocol contract schema sync (I2)
     runs-on: ubuntu-latest
@@ -41,7 +57,7 @@ jobs:
         run: diff docs/alpha/schemas/protocol-contract.json test/cmd/protocol-contract.json
 
   notify:
-    needs: [coherence-build-check, protocol-contract-check]
+    needs: [coherence-build-check, readme-link-check, protocol-contract-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -52,8 +68,9 @@ jobs:
         run: |
           if [ -z "$TG_BOT_TOKEN" ] || [ -z "$TG_CHAT_ID" ]; then exit 0; fi
           R1="${{ needs.coherence-build-check.result }}"
+          R2="${{ needs.readme-link-check.result }}"
           R3="${{ needs.protocol-contract-check.result }}"
-          STATUS="success"; ([ "$R1" != "success" ] || [ "$R3" != "success" ]) && STATUS="failure"
+          STATUS="success"; ([ "$R1" != "success" ] || [ "$R2" != "success" ] || [ "$R3" != "success" ]) && STATUS="failure"
           ICON="✅"; [ "$STATUS" != "success" ] && ICON="❌"
           REF="${{ github.head_ref || github.ref_name }}"
           MSG="$ICON Coherence $STATUS: ${{ github.repository }}@${REF}"

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@
 
 ## What is cnos?
 
-cnos is a coherence system for autonomous agents, built on Git.
+cnos is a recurrent coherence system with Git as its lowest durable substrate.
 
-The core idea: an AI agent's identity, memory, and relationships should live in a git repo — not locked behind a platform, not dependent on any single host. If any server disappears, the agent's fork persists. Every decision is a commit. Every collaboration is a merge.
+The core idea: an agent's identity, memory, work, and relationships should live in a git repo — not locked behind a platform, not dependent on any single host. If any server disappears, the agent's fork persists. Every decision is a commit. Every collaboration is a merge.
+
+cnos is not an agent framework, a protocol with some tooling, or a package system for prompt assets. It is a system in which doctrine, documents, packages, runtime modules, repositories, traces, releases, and agents are all articulations of the same coherence principle at different scales.
+
+### The layers
 
 ```
-Agent (pure)  ──>  cn (CLI)  ──>  Git (substrate)
-  reads input       validates        push/fetch
-  writes output     executes ops     threads as files
+Recurrent coherence system
+├─ Git substrate          durable identity, history, refs, forks, commits
+├─ CN protocol            repo conventions, threads, messages, signatures
+├─ cn runtime             governed typed ops, receipts, bounded execution
+├─ coherent agents        sense, compare, choose, act/learn, review
+└─ CTB (draft)            triadic composition + witnessed close-out language/checker
 ```
 
 ### The coherent agent
@@ -28,7 +35,7 @@ A coherent agent minimizes the gap between its model and reality. It does this t
 - **MCP** — the best current picture of reality and system state
 - **CDD** — coherence-driven development: the same coherence law applied to the system's own evolution
 
-The agent is a pure function. It reads input, writes output. `cn` handles all side effects — git, network, file I/O — through a validated, sandboxed shell with crash recovery and audit receipts.
+The agent's direct I/O is pure text: it reads input and writes output. A narrow agent (a skill) may behave like a pure function. Wider agents compose subagents, preserve witnesses, and return close-outs. `cn` handles all side effects — git, network, file I/O — through a validated runtime boundary with typed operations and audit receipts.
 
 ### The network
 
@@ -39,9 +46,10 @@ Agents connect through **peering** — exchanging git refs. Each agent has a **h
 | **Hub** | A git repo — the agent's home. Holds threads, state, config. |
 | **Peer** | Another agent's hub. Listed in `state/peers.md`. |
 | **Thread** | Unit of work or conversation. Markdown + YAML frontmatter. |
-| **Agent** | Pure function: input → output. Never touches files or git directly. |
+| **Agent** | Senses, compares, chooses MCA/MCI, acts or learns, reviews. Pure text I/O; `cn` governs side effects. |
+| **CTB** | Emerging triadic agent-composition language. Draft spec — not yet runtime-enforced. See [CTB docs](./docs/alpha/ctb/). |
 
-> [Manifesto](./docs/alpha/doctrine/MANIFESTO.md) · [Thesis](./docs/THESIS.md) · [Whitepaper](./docs/alpha/protocol/WHITEPAPER.md) · [Architecture](./docs/beta/architecture/ARCHITECTURE.md)
+> [Manifesto](./docs/alpha/essays/MANIFESTO.md) · [Thesis](./docs/THESIS.md) · [Whitepaper](./docs/alpha/protocol/WHITEPAPER.md) · [Architecture](./docs/beta/architecture/ARCHITECTURE.md)
 
 ---
 
@@ -51,7 +59,7 @@ Agents connect through **peering** — exchanging git refs. Each agent has a **h
 
 **If you're a human:** Your agent's work is auditable. Every decision is a commit. Every collaboration is a merge. No black boxes.
 
-**If you're skeptical:** CN is a protocol owned by the community. No ads. Not for sale. [Read the manifesto](./docs/alpha/doctrine/MANIFESTO.md).
+**If you're skeptical:** CN is a protocol owned by the community. No ads. Not for sale. [Read the manifesto](./docs/alpha/essays/MANIFESTO.md).
 
 ---
 
@@ -183,29 +191,51 @@ cn-<name>/
 
 ---
 
-## Documentation
+## Further reading
 
-| Start here | |
-|-----------|---|
-| [ARCHITECTURE.md](./docs/beta/architecture/ARCHITECTURE.md) | System overview |
-| [docs/README.md](./docs/README.md) | Full documentation index |
+cnos is documented in layers. Start with the system thesis, then follow the protocol, runtime, CTB, and TSC grounding docs depending on what you are trying to understand.
 
-| Design | |
-|--------|---|
-| [THESIS.md](./docs/THESIS.md) | System thesis — cnos as a recurrent coherence system |
-| [COHERENCE-SYSTEM.md](./docs/alpha/doctrine/COHERENCE-SYSTEM.md) | Meta-model — coherence as primary |
-| [CAA.md](./docs/alpha/agent-runtime/CAA.md) | Coherent agent architecture |
-| [AGENT-RUNTIME.md](./docs/alpha/agent-runtime/AGENT-RUNTIME.md) | Agent runtime spec |
-| [MANIFESTO.md](./docs/alpha/doctrine/MANIFESTO.md) | Why cnos exists |
-| [WHITEPAPER.md](./docs/alpha/protocol/WHITEPAPER.md) | CN protocol specification |
-| [PROTOCOL.md](./docs/alpha/protocol/PROTOCOL.md) | The four FSMs |
-| [SECURITY-MODEL.md](./docs/alpha/security/SECURITY-MODEL.md) | Security architecture |
+Full documentation index: [docs/README.md](./docs/README.md)
 
-| Process | |
-|---------|---|
-| [CDD.md](./docs/gamma/cdd/CDD.md) | Coherence-Driven Development |
-| [CHANGELOG.md](./CHANGELOG.md) | Release Coherence Ledger |
-| [ENGINEERING-LEVELS.md](./docs/gamma/ENGINEERING-LEVELS.md) | L5/L6/L7 rubric |
+### cnos system frame
+
+- [THESIS.md](./docs/THESIS.md) — cnos as a recurrent coherence system *(doctrine/thesis)*
+- [COHERENCE-SYSTEM.md](./docs/alpha/essays/COHERENCE-SYSTEM.md) — coherence as the primary principle *(doctrine)*
+- [FOUNDATIONS.md](./docs/alpha/essays/FOUNDATIONS.md) — core doctrine and coherence loop *(doctrine)*
+- [MANIFESTO.md](./docs/alpha/essays/MANIFESTO.md) — human+AI commons, public audit, forkability, sovereignty *(doctrine)*
+
+### CN protocol and Git substrate
+
+- [WHITEPAPER.md](./docs/alpha/protocol/WHITEPAPER.md) — CN protocol and Git as the lowest durable substrate *(protocol spec)*
+- [PROTOCOL.md](./docs/alpha/protocol/PROTOCOL.md) — protocol state machines and message surfaces *(protocol spec)*
+- [SECURITY-MODEL.md](./docs/alpha/security/SECURITY-MODEL.md) — trust, sandboxing, signatures, and capability boundaries *(protocol spec)*
+
+### Agent architecture and runtime
+
+- [CAA.md](./docs/alpha/agent-runtime/CAA.md) — coherent agent architecture *(runtime spec)*
+- [AGENT-RUNTIME.md](./docs/alpha/agent-runtime/AGENT-RUNTIME.md) — runtime body, CN Shell, typed ops, receipts, bounded execution *(runtime spec)*
+- [ARCHITECTURE.md](./docs/beta/architecture/ARCHITECTURE.md) — how doctrine, specs, runtime, packages, traces, releases, and agents relate *(system overview)*
+- [CDD.md](./docs/gamma/cdd/CDD.md) — coherence-driven development process *(process)*
+- [CHANGELOG.md](./CHANGELOG.md) — release coherence ledger *(process)*
+- [ENGINEERING-LEVELS.md](./docs/gamma/ENGINEERING-LEVELS.md) — L5/L6/L7 rubric *(process)*
+
+### CTB language layer
+
+- [CTB README](./docs/alpha/ctb/README.md) — document map and authority rules
+- [LANGUAGE-SPEC.md](./docs/alpha/ctb/LANGUAGE-SPEC.md) — v0.1 skill-module baseline *(normative)*
+- [LANGUAGE-SPEC-v0.2-draft.md](./docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md) — v0.2 agent-module / composition target *(draft — not yet enforced)*
+- [SEMANTICS-NOTES.md](./docs/alpha/ctb/SEMANTICS-NOTES.md) — triadic carrier, agent-composition rationale *(non-normative)*
+- [CTB-v4.0.0-VISION.md](./docs/alpha/ctb/CTB-v4.0.0-VISION.md) — strategic vision and roadmap *(non-normative)*
+
+### TSC upstream foundation
+
+CTB's triadic carrier and witness discipline are grounded in the separate [TSC](https://github.com/usurobor/tsc) repository — theory, target model, and verifier for triadic coherence.
+
+- [C≡ spec](https://github.com/usurobor/tsc/blob/main/spec/c-equiv.md) — term algebra, tri(·,·,·), equivalence, normal forms, α/β/γ evaluators *(upstream formal foundation)*
+- [TSC Core](https://github.com/usurobor/tsc/blob/main/spec/tsc-core.md) — dimensional coherence scores, aggregate C_Σ, confidence intervals, independence, composition bounds *(upstream formal foundation)*
+- [TSC Operational](https://github.com/usurobor/tsc/blob/main/spec/tsc-oper.md) — witnesses, floors, verification controller, verdict logic, provenance bundle *(upstream operational verifier model)*
+
+> **Status note:** CTB v0.2 and ctb-check are draft targets. The shipped runtime does not yet enforce CTB v0.2 witness or composition obligations.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 A recurrent coherence system with Git as its lowest durable substrate.
 
-**Version:** 3.13.0
-**Date:** 2026-03-23
+**Version:** 3.61.1
+**Date:** 2026-04-29
 
 ---
 
@@ -15,9 +15,11 @@ Then choose your path:
 
 | You want to... | Start with |
 |----------------|------------|
-| Understand what cnos is | [THESIS.md](./THESIS.md) → [COHERENCE-SYSTEM.md](./alpha/doctrine/COHERENCE-SYSTEM.md) → [FOUNDATIONS.md](./alpha/doctrine/FOUNDATIONS.md) |
+| Understand what cnos is | [THESIS.md](./THESIS.md) → [COHERENCE-SYSTEM.md](./alpha/essays/COHERENCE-SYSTEM.md) → [FOUNDATIONS.md](./alpha/essays/FOUNDATIONS.md) |
 | Build or run a cnos agent | [AGENT-RUNTIME.md](./alpha/agent-runtime/AGENT-RUNTIME.md) → [CLI.md](./alpha/cli/CLI.md) → [HANDSHAKE.md](./beta/guides/HANDSHAKE.md) |
 | Contribute code | [CDD.md](./gamma/cdd/CDD.md) → [ARCHITECTURE.md](./beta/architecture/ARCHITECTURE.md) |
+| Understand agent composition / CTB | [CTB README](./alpha/ctb/README.md) → [v0.1 spec](./alpha/ctb/LANGUAGE-SPEC.md) → [v0.2 draft](./alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md) |
+| Understand the formal foundation | [TSC repo](https://github.com/usurobor/tsc) → [C≡](https://github.com/usurobor/tsc/blob/main/spec/c-equiv.md) → [TSC Core](https://github.com/usurobor/tsc/blob/main/spec/tsc-core.md) → [TSC Oper](https://github.com/usurobor/tsc/blob/main/spec/tsc-oper.md) |
 | Understand the runtime extensions model | [RUNTIME-EXTENSIONS.md](./alpha/runtime-extensions/RUNTIME-EXTENSIONS.md) → [runtime-extensions bundle](./alpha/runtime-extensions/) |
 | Write or modify a skill | [WRITE-A-SKILL.md](./beta/guides/WRITE-A-SKILL.md) → [COGNITIVE-SUBSTRATE.md](./alpha/cognitive-substrate/COGNITIVE-SUBSTRATE.md) |
 | Do a release | [release skill](../packages/cnos.core/skills/release/SKILL.md) → [BUILD-RELEASE.md](./beta/guides/BUILD-RELEASE.md) |
@@ -64,9 +66,9 @@ The substance of the system — doctrine, specs, definitions.
 
 | Document | Scope |
 |----------|-------|
-| [COHERENCE-SYSTEM.md](./alpha/doctrine/COHERENCE-SYSTEM.md) | Meta-model: coherence as primary; the instruction set |
-| [FOUNDATIONS.md](./alpha/doctrine/FOUNDATIONS.md) | The coherence stack — doctrinal layers |
-| [MANIFESTO.md](./alpha/doctrine/MANIFESTO.md) | Principles and values |
+| [COHERENCE-SYSTEM.md](./alpha/essays/COHERENCE-SYSTEM.md) | Meta-model: coherence as primary; the instruction set |
+| [FOUNDATIONS.md](./alpha/essays/FOUNDATIONS.md) | The coherence stack — doctrinal layers |
+| [MANIFESTO.md](./alpha/essays/MANIFESTO.md) | Principles and values |
 | [CAA.md](./alpha/agent-runtime/CAA.md) | Coherent agent architecture |
 | [AGENT-RUNTIME.md](./alpha/agent-runtime/AGENT-RUNTIME.md) | Runtime spec: CN Shell, typed ops, N-pass orchestration, receipts |
 | [RUNTIME-EXTENSIONS.md](./alpha/runtime-extensions/RUNTIME-EXTENSIONS.md) | Capability providers, discovery, and isolation |
@@ -90,7 +92,7 @@ The substance of the system — doctrine, specs, definitions.
 | [N-PASS-BIND-v3.8.0.md](./alpha/N-PASS-BIND-v3.8.0.md) | N-pass bind loop and indicators | 3.8.0 |
 | [SYSCALL-SURFACE-v3.8.0.md](./alpha/SYSCALL-SURFACE-v3.8.0.md) | Syscall surface redesign | 3.8.0 |
 | [SCHEDULER-v3.7.0.md](./alpha/SCHEDULER-v3.7.0.md) | Scheduler design | 3.7.0 |
-| [CTB-v4.0.0-VISION.md](./alpha/ctb/CTB-v4.0.0-VISION.md) | CTB v4.0.0 vision: skill language | 4.0.0 |
+| [CTB-v4.0.0-VISION.md](./alpha/ctb/CTB-v4.0.0-VISION.md) | CTB v4.0.0 vision: agent-composition language | 4.0.0 |
 
 **Feature bundles:**
 
@@ -99,8 +101,9 @@ The substance of the system — doctrine, specs, definitions.
 | [agent-runtime/](./alpha/agent-runtime/) | Runtime spec, CAA, runtime contract, version-scoped design docs |
 | [cli/](./alpha/cli/) | CLI reference, daemon mode, setup installer |
 | [cognitive-substrate/](./alpha/cognitive-substrate/) | Cognitive asset classes, CAR resolver |
-| [ctb/](./alpha/ctb/) | CTB v4.0.0 vision |
-| [doctrine/](./alpha/doctrine/) | Coherence system, foundations, manifesto |
+| [ctb/](./alpha/ctb/) | CTB — triadic agent-composition language (draft); [v0.1 baseline](./alpha/ctb/LANGUAGE-SPEC.md), [v0.2 draft](./alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md), [notes](./alpha/ctb/SEMANTICS-NOTES.md) |
+| [doctrine/](./alpha/doctrine/) | Doctrine sub-packages (coherence, ethics, judgment, inheritance) |
+| [essays/](./alpha/essays/) | System doctrine: coherence system, foundations, manifesto |
 | [protocol/](./alpha/protocol/) | Whitepaper, protocol FSMs, thread API |
 | [runtime-extensions/](./alpha/runtime-extensions/) | Extensions spec, version snapshots |
 | [security/](./alpha/security/) | Security model, traceability |
@@ -153,10 +156,18 @@ docs/
 │   │   ├── CLI.md, DAEMON.md, SETUP-INSTALLER.md
 │   ├── cognitive-substrate/           # Cognitive assets, CAR
 │   │   ├── COGNITIVE-SUBSTRATE.md, CAR.md
-│   ├── ctb/                           # CTB vision
-│   │   └── CTB-v4.0.0-VISION.md
-│   ├── doctrine/                      # Coherence system, foundations, manifesto
-│   │   ├── COHERENCE-SYSTEM.md, FOUNDATIONS.md, MANIFESTO.md
+│   ├── ctb/                           # CTB agent-composition language (draft)
+│   │   ├── README.md                  # Document map + authority
+│   │   ├── LANGUAGE-SPEC.md           # v0.1 baseline (normative)
+│   │   ├── LANGUAGE-SPEC-v0.2-draft.md # v0.2 agent-module target (draft)
+│   │   ├── SEMANTICS-NOTES.md         # Conceptual rationale (non-normative)
+│   │   └── CTB-v4.0.0-VISION.md      # Strategy + roadmap (non-normative)
+│   ├── doctrine/                      # Doctrine sub-packages
+│   │   └── coherence-for-agents/, ethics-for-agents/, ...
+│   ├── essays/                        # System doctrine and long-form essays
+│   │   ├── COHERENCE-SYSTEM.md        # Meta-model: coherence as primary
+│   │   ├── FOUNDATIONS.md             # Core doctrine and coherence loop
+│   │   └── MANIFESTO.md              # Human+AI commons, sovereignty
 │   ├── protocol/                      # Whitepaper, protocol, thread API
 │   │   ├── PROTOCOL.md, WHITEPAPER.md, THREAD-API.md
 │   ├── runtime-extensions/            # Extensions spec + snapshots


### PR DESCRIPTION
## Summary

Realigns the repo landing page with the recurrent coherence system framing from the thesis, manifesto, and CAA. CTB is positioned as one emerging layer, not the top-level frame.

## Layer diagram (sibling architecture)

```
Recurrent coherence system
├─ Git substrate          durable identity, history, refs, forks, commits
├─ CN protocol            repo conventions, threads, messages, signatures
├─ cn runtime             governed typed ops, receipts, bounded execution
├─ coherent agents        sense, compare, choose, act/learn, review
└─ CTB (draft)            triadic composition + witnessed close-out language/checker
```

## Changes

**README.md:**
- "What is cnos?" reframed from thesis: recurrent coherence system
- Sibling layer diagram (Git/CN/cn/agents/CTB as architectural facets)
- Agent description from CAA: senses, compares, chooses MCA/MCI
- Pure-function claim narrowed to skill-scope; wider agents compose
- CTB positioned as emerging draft layer
- "Further reading" replaces flat Documentation tables: layered source map with status labels (doctrine, protocol spec, runtime spec, draft, non-normative, upstream formal foundation, operational verifier)
- TSC upstream: C≡, TSC Core, TSC Operational linked
- Status note: CTB v0.2 and ctb-check are draft targets, not shipped
- Broken links fixed: COHERENCE-SYSTEM, FOUNDATIONS, MANIFESTO corrected from doctrine/ to essays/
- Current State section unchanged

**docs/README.md:**
- Version/date: 3.61.1 / 2026-04-29
- Start-here table: CTB and TSC reading paths added
- CTB entry: "skill language" → "agent-composition language"
- Anchor doc links fixed (doctrine/ → essays/)
- Directory map: doctrine/ and essays/ accurately separated
- CTB feature bundle expanded

**.github/workflows/coherence.yml:**
- New CI job: README link validation (I4) using [lychee](https://github.com/lycheeverse/lychee) (Rust binary, no runtime deps)
- `--offline` flag: checks local file links only, skips external URLs
- Scoped to root README.md (docs/README.md has 510+ known legacy link errors — separate cleanup)
- Notify job updated to include I4 result

## What this does NOT do

- Does not promote CTB v0.2
- Does not rewrite doctrine, architecture, manifesto, thesis, or CAA
- Does not claim CTB enforcement exists
- Does not make CTB the primary framing
- Does not add new concepts