### PR TITLE
chore(ci): expand lychee link check to full repo with progressive ignore

### DIFF
--- a/.github/workflows/coherence.yml
+++ b/.github/workflows/coherence.yml
@@ -31,20 +31,21 @@ jobs:
   # I1 (coherence-build-check via `cn build --check`) continues to gate source
   # structural validity.
 
-  readme-link-check:
-    name: README link validation (I4)
+  link-check:
+    name: Repo link validation (I4)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       # lychee: Rust binary link checker, no runtime deps.
       # --offline: skip external URLs (check local file links only).
-      # docs/README.md excluded — has known legacy link debt
-      # (version-scoped docs moved to bundles).
-      - name: Check README links with lychee
+      # --config lychee.toml: progressive ignore list for known pre-existing
+      # broken refs (frozen historical snapshots, schema-placeholder links).
+      # See lychee.toml for entries; tracker: #300.
+      - name: Check repo links with lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --offline --no-progress README.md
+          args: --offline --no-progress --config lychee.toml '**/*.md'
           fail: true
 
   protocol-contract-check:
@@ -57,7 +58,7 @@ jobs:
         run: diff docs/alpha/schemas/protocol-contract.json test/cmd/protocol-contract.json
 
   notify:
-    needs: [coherence-build-check, readme-link-check, protocol-contract-check]
+    needs: [coherence-build-check, link-check, protocol-contract-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +69,7 @@ jobs:
         run: |
           if [ -z "$TG_BOT_TOKEN" ] || [ -z "$TG_CHAT_ID" ]; then exit 0; fi
           R1="${{ needs.coherence-build-check.result }}"
-          R2="${{ needs.readme-link-check.result }}"
+          R2="${{ needs.link-check.result }}"
           R3="${{ needs.protocol-contract-check.result }}"
           STATUS="success"; ([ "$R1" != "success" ] || [ "$R2" != "success" ] || [ "$R3" != "success" ]) && STATUS="failure"
           ICON="✅"; [ "$STATUS" != "success" ] && ICON="❌"

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Then choose your path:
 | Understand the formal foundation | [TSC repo](https://github.com/usurobor/tsc) → [C≡](https://github.com/usurobor/tsc/blob/main/spec/c-equiv.md) → [TSC Core](https://github.com/usurobor/tsc/blob/main/spec/tsc-core.md) → [TSC Oper](https://github.com/usurobor/tsc/blob/main/spec/tsc-oper.md) |
 | Understand the runtime extensions model | [RUNTIME-EXTENSIONS.md](./alpha/runtime-extensions/RUNTIME-EXTENSIONS.md) → [runtime-extensions bundle](./alpha/runtime-extensions/) |
 | Write or modify a skill | [WRITE-A-SKILL.md](./beta/guides/WRITE-A-SKILL.md) → [COGNITIVE-SUBSTRATE.md](./alpha/cognitive-substrate/COGNITIVE-SUBSTRATE.md) |
-| Do a release | [release skill](../packages/cnos.core/skills/release/SKILL.md) → [BUILD-RELEASE.md](./beta/guides/BUILD-RELEASE.md) |
+| Do a release | [release skill](../src/packages/cnos.cdd/skills/cdd/release/SKILL.md) → [BUILD-RELEASE.md](./beta/guides/BUILD-RELEASE.md) |
 
 ---
 
@@ -88,10 +88,10 @@ The substance of the system — doctrine, specs, definitions.
 
 | Document | Feature | Version |
 |----------|---------|---------|
-| [RUNTIME-CONTRACT-v3.10.0.md](./alpha/RUNTIME-CONTRACT-v3.10.0.md) | Wake-up self-model contract | 3.10.0 |
-| [N-PASS-BIND-v3.8.0.md](./alpha/N-PASS-BIND-v3.8.0.md) | N-pass bind loop and indicators | 3.8.0 |
-| [SYSCALL-SURFACE-v3.8.0.md](./alpha/SYSCALL-SURFACE-v3.8.0.md) | Syscall surface redesign | 3.8.0 |
-| [SCHEDULER-v3.7.0.md](./alpha/SCHEDULER-v3.7.0.md) | Scheduler design | 3.7.0 |
+| [RUNTIME-CONTRACT-v3.10.0.md](./alpha/agent-runtime/3.10.0/DESIGN.md) | Wake-up self-model contract | 3.10.0 |
+| [N-PASS-BIND-v3.8.0.md](./alpha/agent-runtime/3.8.0/N-PASS-BIND.md) | N-pass bind loop and indicators | 3.8.0 |
+| [SYSCALL-SURFACE-v3.8.0.md](./alpha/agent-runtime/3.8.0/SYSCALL-SURFACE.md) | Syscall surface redesign | 3.8.0 |
+| [SCHEDULER-v3.7.0.md](./alpha/agent-runtime/3.7.0/DESIGN.md) | Scheduler design | 3.7.0 |
 | [CTB-v4.0.0-VISION.md](./alpha/ctb/CTB-v4.0.0-VISION.md) | CTB v4.0.0 vision: agent-composition language | 4.0.0 |
 
 **Feature bundles:**

--- a/docs/alpha/agent-runtime/AGENT-RUNTIME.md
+++ b/docs/alpha/agent-runtime/AGENT-RUNTIME.md
@@ -21,7 +21,7 @@
 - Receipt pass field uses numeric labels (`"1"`, `"2"`, ...) under N-pass; `cn.receipts.v1` schema unchanged
 - `state/runtime.json` now includes `max_passes` for operator visibility
 - Backward compatible: `max_passes=2` reproduces existing N-pass behavior
-- See: [`N-PASS-BIND-v3.8.0.md`](N-PASS-BIND-v3.8.0.md) and [`PLAN-v3.8.0-n-pass-bind.md`](../gamma/plans/PLAN-v3.8.0-n-pass-bind.md) for full design and plan
+- See: [`N-PASS-BIND-v3.8.0.md`](3.8.0/N-PASS-BIND.md) and [`PLAN-v3.8.0-n-pass-bind.md`](../../gamma/plans/PLAN-v3.8.0-n-pass-bind.md) for full design and plan
 
 **v3.8.0** — Syscall Surface Coherence Amendment:
 - Implement `fs_glob` observe op (was advertised but returned `not_yet_implemented`)
@@ -30,7 +30,7 @@
 - Add `offset` and `limit` fields to `fs_read` for chunked observation of large files
 - Make `fs_patch` external dependency on `patch(1)` explicit: `cn doctor` checks for it; receipts reflect failure
 - New receipt reason: `nothing_staged` (git_commit when index has no staged changes)
-- See: [`SYSCALL-SURFACE-v3.8.0.md`](SYSCALL-SURFACE-v3.8.0.md) for full design
+- See: [`SYSCALL-SURFACE-v3.8.0.md`](3.8.0/SYSCALL-SURFACE.md) for full design
 
 **v3.7.0** — Scheduler Unification (one loop, two schedulers):
 - Replace the daemon-vs-cron behavioral split with **one protocol loop, one processing engine, two schedulers**
@@ -43,7 +43,7 @@
 - Add `scheduler` config block: `sync_interval_sec`, `review_interval_sec`, `oneshot_drain_limit`, `daemon_drain_limit`
 - Add scheduler projection to `state/ready.json`: `scheduler.mode`, `last_sync_at`, `last_sync_status`, `last_maintenance_at`, `last_maintenance_status`
 - Add trace events: `maintenance.start/.complete`, `sync.start/.ok/.error`, `inbox.materialized`, `outbox.flushed`, `drain.start/.complete/.stopped`, `scheduler.tick/.idle/.degraded`
-- See [`SCHEDULER-v3.7.0.md`](SCHEDULER-v3.7.0.md) and [`PLAN-v3.7.0.md`](PLAN-v3.7.0.md) for full design and implementation plan
+- See [`SCHEDULER-v3.7.0.md`](3.7.0/DESIGN.md) and [`PLAN-v3.7.0.md`](../../gamma/plans/PLAN-v3.7.0-scheduler.md) for full design and implementation plan
 
 **v3.6.0** — Output Plane Separation and sink-safe rendering:
 - Introduce strict separation between **control plane** (frontmatter, coordination ops, typed `ops:` manifest) and **presentation plane** (human-facing text projected to sinks such as Telegram/Discord)
@@ -53,7 +53,7 @@
 - Add required projection events: `projection.render.start`, `.ok`, `.blocked`, `.fallback`
 
 **v3.3.7** — Observability / traceability architecture alignment:
-- Add [`TRACEABILITY.md`](TRACEABILITY.md) as the normative observability spec
+- Add [`TRACEABILITY.md`](../security/TRACEABILITY.md) as the normative observability spec
 - Clarify that runtime traceability now has three layers:
   - **events** — append-only lifecycle/state transition log (`logs/events/YYYYMMDD.jsonl`)
   - **projections** — current truth snapshots (`state/ready.json`, `state/runtime.json`, `state/coherence.json`)
@@ -69,7 +69,7 @@
   - **mind** — doctrine, mindsets, skills, capabilities, LLM call lifecycle
   - **body** — lock, queue, FSM, pass selection, recovery, finalize
   - **sensors** — transport ingress/egress, offsets, projection, UX signals
-- Clarify that [`TRACEABILITY.md`](TRACEABILITY.md) supersedes ad hoc runtime lifecycle logging:
+- Clarify that [`TRACEABILITY.md`](../security/TRACEABILITY.md) supersedes ad hoc runtime lifecycle logging:
   - IO-pair archives remain authoritative for deliberation
   - receipts remain authoritative for typed capability execution
   - structured events become authoritative for lifecycle, readiness, and transition reasoning
@@ -1056,7 +1056,7 @@ Observe artifacts are injected into Pass B context as bounded excerpts (see Budg
 3. Apply coordination op phase rules (see table above): execute safe, defer unsafe
 4. Write artifacts to `state/artifacts/<trigger_id>/<op_id>.*`
 5. Write receipts to `state/receipts/<trigger_id>.json`
-6. Archive IO pair (Pass A) per IO-pair archival invariant (see [TRACEABILITY.md §11.1](TRACEABILITY.md#111-io-pairs-remain-authoritative-for-deliberation))
+6. Archive IO pair (Pass A) per IO-pair archival invariant (see [TRACEABILITY.md §11.1](../security/TRACEABILITY.md#111-io-pairs-remain-authoritative-for-deliberation))
 
 #### Pass B (decision / effect)
 
@@ -1072,7 +1072,7 @@ Observe artifacts are injected into Pass B context as bounded excerpts (see Budg
    - If ALL effect ops completed with `status: ok` → execute coordination ops in listed order; FSM transitions applied
    - If ANY effect op has `status: error` or `status: denied` → skip terminal coordination ops (`done`, `fail`, `delete`, `delegate`, `send`, `defer`) with receipt `status: skipped`, `reason: effects_failed`; allow only `reply`/`surface` so the agent can report the failure
    - If no typed effect ops were proposed → execute coordination ops normally
-7. Archive IO pair (Pass B) per IO-pair archival invariant (see [TRACEABILITY.md §11.1](TRACEABILITY.md#111-io-pairs-remain-authoritative-for-deliberation))
+7. Archive IO pair (Pass B) per IO-pair archival invariant (see [TRACEABILITY.md §11.1](../security/TRACEABILITY.md#111-io-pairs-remain-authoritative-for-deliberation))
 
 This ordering ensures the system never advances narrative state (FSM) when the world action didn't succeed — consistent with CAP: act on world, then update model, never the reverse.
 
@@ -1099,7 +1099,7 @@ Ops exceeding budgets receive receipt `status: denied`, `reason: budget_exceeded
 
 ### Path Sandbox
 
-Typed ops that reference filesystem paths (`fs_read`, `fs_write`) or execute commands (`exec`) are subject to path and environment sandboxing. These rules are shared vocabulary across CN Shell, [SECURITY-MODEL.md](SECURITY-MODEL.md), and [SETUP-INSTALLER.md](SETUP-INSTALLER.md).
+Typed ops that reference filesystem paths (`fs_read`, `fs_write`) or execute commands (`exec`) are subject to path and environment sandboxing. These rules are shared vocabulary across CN Shell, [SECURITY-MODEL.md](../security/SECURITY-MODEL.md), and [SETUP-INSTALLER.md](../cli/SETUP-INSTALLER.md).
 
 #### Path normalization and validation order
 
@@ -1534,7 +1534,7 @@ WantedBy=multi-user.target
 
 ## Migration Path
 
-*v3.0 migration (OC → native runtime) is complete. Phase-by-phase build plan moved to [PLAN.md](../gamma/plans/PLAN.md).*
+*v3.0 migration (OC → native runtime) is complete. Phase-by-phase build plan moved to [PLAN.md](../../gamma/plans/PLAN.md).*
 
 ### Success Criteria
 
@@ -2358,12 +2358,12 @@ The renderer MUST block it and use a fallback or skip projection.
 
 ### cnos Internal
 - [Coherent Agent Architecture](./CAA.md) — What the agent *is* structurally
-- [Agent Ops Skill](../../src/agent/skills/agent/agent-ops/SKILL.md) — Legacy coordination op format and agent-facing output discipline
-- [Security Model](./SECURITY-MODEL.md) — Agent sandbox, protected files, audit trail
-- [Traceability](./TRACEABILITY.md) — event stream, state projections, readiness, and transition reasoning
-- [Daemon Architecture](./DAEMON.md) — Plugin direction (this doc is the first plugin)
-- [Protocol Specification](./PROTOCOL.md) — FSM definitions
-- [Architecture](../beta/architecture/ARCHITECTURE.md) — Module layers, data flow, agent I/O protocol
+- [Agent Ops Skill](../../../src/packages/cnos.core/skills/agent/agent-ops/SKILL.md) — Legacy coordination op format and agent-facing output discipline
+- [Security Model](../security/SECURITY-MODEL.md) — Agent sandbox, protected files, audit trail
+- [Traceability](../security/TRACEABILITY.md) — event stream, state projections, readiness, and transition reasoning
+- [Daemon Architecture](../cli/DAEMON.md) — Plugin direction (this doc is the first plugin)
+- [Protocol Specification](../protocol/PROTOCOL.md) — FSM definitions
+- [Architecture](../../beta/architecture/ARCHITECTURE.md) — Module layers, data flow, agent I/O protocol
 
 ### External
 - [Telegram Bot API — getUpdates](https://core.telegram.org/bots/api#getupdates)

--- a/docs/alpha/cli/CLI.md
+++ b/docs/alpha/cli/CLI.md
@@ -241,7 +241,7 @@ cn-<name>/
  +-- spec/
 ```
 
-See [ARCHITECTURE.md](../beta/architecture/ARCHITECTURE.md) for full directory layout details.
+See [ARCHITECTURE.md](../../beta/architecture/ARCHITECTURE.md) for full directory layout details.
 
 ## Implementation
 
@@ -310,6 +310,6 @@ Installed to `/usr/local/bin/cn`.
 
 ## Related
 
-- [AGENT-RUNTIME.md](AGENT-RUNTIME.md) — Full runtime spec (CN Shell, typed ops, N-pass orchestration, receipts)
-- [SECURITY-MODEL.md](SECURITY-MODEL.md) — Security architecture
+- [AGENT-RUNTIME.md](../agent-runtime/AGENT-RUNTIME.md) — Full runtime spec (CN Shell, typed ops, N-pass orchestration, receipts)
+- [SECURITY-MODEL.md](../security/SECURITY-MODEL.md) — Security architecture
 - [SETUP-INSTALLER.md](SETUP-INSTALLER.md) — Install script specification

--- a/docs/alpha/cli/DAEMON.md
+++ b/docs/alpha/cli/DAEMON.md
@@ -4,7 +4,7 @@
 **Created:** 2026-02-05
 **Updated:** 2026-03-12
 
-> **See also:** [SCHEDULER-v3.7.0](SCHEDULER-v3.7.0.md) — the unified scheduler
+> **See also:** [SCHEDULER-v3.7.0](../agent-runtime/3.7.0/DESIGN.md) — the unified scheduler
 > design that implements the core of this vision. The plugin architecture below
 > remains a future direction.
 
@@ -118,11 +118,11 @@ cn enforces security by architecture:
 
 This means agents **cannot go rogue** — they can only affect their designated space through controlled, audited operations.
 
-See [SECURITY-MODEL.md](./SECURITY-MODEL.md) for full details.
+See [SECURITY-MODEL.md](../security/SECURITY-MODEL.md) for full details.
 
 ## Open Questions
 
-- ~~Daemon process management~~ → systemd (documented in [AUTOMATION.md](../how-to/AUTOMATION.md))
+- ~~Daemon process management~~ → systemd (documented in [AUTOMATION.md](../../beta/guides/AUTOMATION.md))
 - Plugin discovery and loading (future)
 - ~~Config format~~ → `.cn/config.json` with `runtime.scheduler` block
 - ~~Telegram auth/tokens~~ → `.cn/secrets.env` or env vars
@@ -130,4 +130,4 @@ See [SECURITY-MODEL.md](./SECURITY-MODEL.md) for full details.
 
 ---
 
-*Original vision doc. See [SCHEDULER-v3.7.0](SCHEDULER-v3.7.0.md) for current implementation.*
+*Original vision doc. See [SCHEDULER-v3.7.0](../agent-runtime/3.7.0/DESIGN.md) for current implementation.*

--- a/docs/alpha/cli/SETUP-INSTALLER.md
+++ b/docs/alpha/cli/SETUP-INSTALLER.md
@@ -130,7 +130,7 @@ Edge cases:
 
 ### 5.6 Path Sandbox alignment (CN Shell)
 
-CN Shell ([AGENT-RUNTIME.md](AGENT-RUNTIME.md) §Path Sandbox) deny-lists the `.cn/` prefix for typed filesystem ops. This is intentional: `.cn/` contains configuration and secrets (including `.cn/secrets.env`).
+CN Shell ([AGENT-RUNTIME.md](../agent-runtime/AGENT-RUNTIME.md) §Path Sandbox) deny-lists the `.cn/` prefix for typed filesystem ops. This is intentional: `.cn/` contains configuration and secrets (including `.cn/secrets.env`).
 
 Implications for `cn setup`:
 
@@ -138,7 +138,7 @@ Implications for `cn setup`:
 - **Path checks MUST apply to the canonical resolved path** (after `..` collapse and symlink resolution), to prevent symlink bypasses into `.cn/`.
 - **`cn setup` MUST NOT create secrets or config outside `.cn/`** — doing so would place them in paths reachable by typed ops.
 
-This subsection is the back-link to the shared vocabulary defined in AGENT-RUNTIME.md §Path Sandbox and referenced by [SECURITY-MODEL.md](SECURITY-MODEL.md) §CN Shell Addendum.
+This subsection is the back-link to the shared vocabulary defined in AGENT-RUNTIME.md §Path Sandbox and referenced by [SECURITY-MODEL.md](../security/SECURITY-MODEL.md) §CN Shell Addendum.
 
 ## 6. `cn setup` UX / Flow
 

--- a/docs/alpha/cognitive-substrate/CAR.md
+++ b/docs/alpha/cognitive-substrate/CAR.md
@@ -278,9 +278,9 @@ cn deps vendor         Commit vendor tree for airgapped use
 
 ## Related Documents
 
-- [CAA.md](./CAA.md) — Coherent agent architecture (what the agent *is* structurally; CAR describes how cognition *arrives*)
-- [AGENT-RUNTIME.md](./AGENT-RUNTIME.md) — Agent runtime (execution layer)
-- [FOUNDATIONS.md](./FOUNDATIONS.md) — Doctrine and coherence stack
+- [CAA.md](../agent-runtime/CAA.md) — Coherent agent architecture (what the agent *is* structurally; CAR describes how cognition *arrives*)
+- [AGENT-RUNTIME.md](../agent-runtime/AGENT-RUNTIME.md) — Agent runtime (execution layer)
+- [FOUNDATIONS.md](../essays/FOUNDATIONS.md) — Doctrine and coherence stack
 
 ---
 

--- a/docs/alpha/cognitive-substrate/COGNITIVE-SUBSTRATE.md
+++ b/docs/alpha/cognitive-substrate/COGNITIVE-SUBSTRATE.md
@@ -254,7 +254,7 @@ The same contract is persisted to `state/runtime-contract.json` for:
 - `cn doctor` validation
 - traceability reference
 
-See [`RUNTIME-CONTRACT-v2.md`](RUNTIME-CONTRACT-v2.md) for full design.
+See [`RUNTIME-CONTRACT-v2.md`](../agent-runtime/RUNTIME-CONTRACT-v2.md) for full design.
 
 ---
 

--- a/docs/alpha/doctrine/judgment-for-agents/JUDGMENT-FOR-AGENTS.md
+++ b/docs/alpha/doctrine/judgment-for-agents/JUDGMENT-FOR-AGENTS.md
@@ -11,7 +11,7 @@ Governing question: How does an agent choose when multiple boundaries conflict a
 Related:
 - [Coherence for Agents](../coherence-for-agents/COHERENCE-FOR-AGENTS.md) — derives shared and inspectable boundaries for agent conduct
 - [Ethics for Agents](../ethics-for-agents/ETHICS-FOR-AGENTS.md) — extends boundary preservation through standing, asymmetry, conflict, and repair
-- [FOUNDATIONS](../../FOUNDATIONS.md) — theory/practice dependency stack
+- [FOUNDATIONS](../../essays/FOUNDATIONS.md) — theory/practice dependency stack
 - [COHERENCE.md](https://github.com/usurobor/cnos/blob/main/src/packages/cnos.core/doctrine/COHERENCE.md) — canonical TSC doctrine
 - [CAP](https://github.com/usurobor/cnos/blob/main/src/packages/cnos.core/doctrine/CAP.md) — MCA/MCI move doctrine
 - [CBP](https://github.com/usurobor/cnos/blob/main/src/packages/cnos.core/doctrine/CBP.md) — relational conduct doctrine

--- a/docs/alpha/essays/FOUNDATIONS.md
+++ b/docs/alpha/essays/FOUNDATIONS.md
@@ -207,11 +207,11 @@ This file states the theory/practice dependency stack.
 
 | Document | Role |
 |----------|------|
-| [THESIS.md](../THESIS.md) | The whole system as a recurrent coherence system |
+| [THESIS.md](../../THESIS.md) | The whole system as a recurrent coherence system |
 | [COHERENCE-SYSTEM.md](./COHERENCE-SYSTEM.md) | Meta-model: MCP, CMP, CAP, CLP across scales |
-| [CAA.md](./CAA.md) | What a coherent agent is structurally |
-| [AGENT-RUNTIME.md](./AGENT-RUNTIME.md) | How coherent action runs |
-| [CAR.md](./CAR.md) | How cognition arrives locally |
-| [CDD.md](../gamma/cdd/CDD.md) | How cnos itself evolves coherently |
+| [CAA.md](../agent-runtime/CAA.md) | What a coherent agent is structurally |
+| [AGENT-RUNTIME.md](../agent-runtime/AGENT-RUNTIME.md) | How coherent action runs |
+| [CAR.md](../cognitive-substrate/CAR.md) | How cognition arrives locally |
+| [CDD.md](../../gamma/cdd/CDD.md) | How cnos itself evolves coherently |
 
 FOUNDATIONS explains the ground. The other docs explain the practices built on it.

--- a/docs/alpha/protocol/WHITEPAPER.md
+++ b/docs/alpha/protocol/WHITEPAPER.md
@@ -14,7 +14,7 @@ date: 2026-03-13
 **Author(s):** usurobor (aka Axiom) (human & AI)
 **Date:** 2026-03-13
 
-> **Scope:** This paper defines the CN protocol and Git substrate thesis. It does not explain the full cnos system architecture. For cnos as a recurrent coherence system, see [`THESIS.md`](../THESIS.md).
+> **Scope:** This paper defines the CN protocol and Git substrate thesis. It does not explain the full cnos system architecture. For cnos as a recurrent coherence system, see [`THESIS.md`](../../THESIS.md).
 
 ---
 
@@ -327,12 +327,12 @@ The cnos project implements this protocol and extends it with layers not specifi
 
 | Layer | Document | Scope |
 |-------|----------|-------|
-| **System thesis** | [`THESIS.md`](../THESIS.md) | cnos as a recurrent coherence system |
-| **Agent architecture** | [`CAA.md`](./CAA.md) | Structural definition of a coherent agent |
-| **Runtime** | [`AGENT-RUNTIME.md`](./AGENT-RUNTIME.md) | CN Shell, typed ops, N-pass orchestration |
-| **Cognitive packages** | [`CAR.md`](./CAR.md) | Local, versioned, installable cognition |
-| **Observability** | [`TRACEABILITY.md`](./TRACEABILITY.md) | Reconstructable mind/body/sensor state |
-| **Development method** | [`CDD.md`](../gamma/cdd/CDD.md) | Coherence-driven development |
+| **System thesis** | [`THESIS.md`](../../THESIS.md) | cnos as a recurrent coherence system |
+| **Agent architecture** | [`CAA.md`](../agent-runtime/CAA.md) | Structural definition of a coherent agent |
+| **Runtime** | [`AGENT-RUNTIME.md`](../agent-runtime/AGENT-RUNTIME.md) | CN Shell, typed ops, N-pass orchestration |
+| **Cognitive packages** | [`CAR.md`](../cognitive-substrate/CAR.md) | Local, versioned, installable cognition |
+| **Observability** | [`TRACEABILITY.md`](../security/TRACEABILITY.md) | Reconstructable mind/body/sensor state |
+| **Development method** | [`CDD.md`](../../gamma/cdd/CDD.md) | Coherence-driven development |
 
 This paper does not track cnos implementation status. For current system architecture, start with THESIS.md.
 

--- a/docs/alpha/runtime-extensions/README.md
+++ b/docs/alpha/runtime-extensions/README.md
@@ -15,15 +15,15 @@ Capability providers, discovery, and isolation in cnos. The extension model for 
 | Document | Class | Description |
 |----------|-------|-------------|
 | [RUNTIME-EXTENSIONS.md](./RUNTIME-EXTENSIONS.md) | Canonical spec | Full extensions spec — providers, discovery, lifecycle, isolation |
-| [v1.0.6/README.md](./v1.0.6/README.md) | Snapshot manifest | Version directory manifest — enumerates canonical files at v1.0.6 |
-| [v1.0.6/SPEC.md](./v1.0.6/SPEC.md) | Frozen spec | Spec frozen at v1.0.6 (converged draft) |
+| [v1.0.6/README.md](./1.0.6/README.md) | Snapshot manifest | Version directory manifest — enumerates canonical files at v1.0.6 |
+| [v1.0.6/SPEC.md](./1.0.6/SPEC.md) | Frozen spec | Spec frozen at v1.0.6 (converged draft) |
 
 ---
 
 ## Reading Order
 
 1. **[RUNTIME-EXTENSIONS.md](./RUNTIME-EXTENSIONS.md)** — start here for the current model
-2. **[v1.0.6/SPEC.md](./v1.0.6/SPEC.md)** — reference snapshot if you need the exact text at v1.0.6
+2. **[v1.0.6/SPEC.md](./1.0.6/SPEC.md)** — reference snapshot if you need the exact text at v1.0.6
 
 ---
 
@@ -31,7 +31,7 @@ Capability providers, discovery, and isolation in cnos. The extension model for 
 
 | Version | Directory | Highlights |
 |---------|-----------|-----------|
-| v1.0.6 | [v1.0.6/](./v1.0.6/) | Open op model + dispatch, source/install separation, marketplace-readiness |
+| v1.0.6 | [v1.0.6/](./1.0.6/) | Open op model + dispatch, source/install separation, marketplace-readiness |
 | v1.0.0–v1.0.5 | — | Superseded: initial drafts, package layout alignment, lifecycle states |
 
 ---

--- a/docs/alpha/security/SECURITY-MODEL.md
+++ b/docs/alpha/security/SECURITY-MODEL.md
@@ -31,7 +31,7 @@ Security by architecture: the agent has no direct access to git or filesystem. A
 +-------------------------------------+
 ```
 
-The agent's direct I/O is exactly two files (`state/input.md` for reading, `state/output.md` for writing). Post-call, `cn` may execute governed typed ops on the agent's behalf (see CN Shell Addendum below), but the agent itself never touches additional files. `cn` reads the output, validates the requested operations against FSM state transitions, and executes only valid ones. See [PROTOCOL.md](PROTOCOL.md) for the typed state machines that enforce protocol correctness.
+The agent's direct I/O is exactly two files (`state/input.md` for reading, `state/output.md` for writing). Post-call, `cn` may execute governed typed ops on the agent's behalf (see CN Shell Addendum below), but the agent itself never touches additional files. `cn` reads the output, validates the requested operations against FSM state transitions, and executes only valid ones. See [PROTOCOL.md](../protocol/PROTOCOL.md) for the typed state machines that enforce protocol correctness.
 
 ## Attack Surface Reduction
 
@@ -115,7 +115,7 @@ All transition functions return `Ok state | Error string`. Invalid transitions a
 
 ## CN Shell Addendum (v3.3+)
 
-The CN Shell capability runtime ([AGENT-RUNTIME.md](AGENT-RUNTIME.md), §CN Shell) introduces governed post-call capabilities (`fs_read`, `fs_write`, `git_diff`, `exec`, etc.) that extend the agent's vocabulary beyond coordination ops. This does NOT change the core security architecture — it refines it:
+The CN Shell capability runtime ([AGENT-RUNTIME.md](../agent-runtime/AGENT-RUNTIME.md), §CN Shell) introduces governed post-call capabilities (`fs_read`, `fs_write`, `git_diff`, `exec`, etc.) that extend the agent's vocabulary beyond coordination ops. This does NOT change the core security architecture — it refines it:
 
 | Property | Pre-CN Shell | With CN Shell |
 |----------|-------------|---------------|
@@ -155,4 +155,4 @@ Security is enforced across the module stack:
 | `cn_commands.ml` | Peer add/remove, commit/push scoped to hub |
 | `cn_hub.ml` | Hub discovery, path constants |
 
-See [ARCHITECTURE.md](../beta/architecture/ARCHITECTURE.md) for module structure and dependency layers.
+See [ARCHITECTURE.md](../../beta/architecture/ARCHITECTURE.md) for module structure and dependency layers.

--- a/docs/alpha/security/TRACEABILITY.md
+++ b/docs/alpha/security/TRACEABILITY.md
@@ -5,7 +5,7 @@
 **Version:** 1.0
 **Audience:** Operators, runtime implementers, incident responders
 **Supersedes:** ad hoc operational logging model in `LOGGING.md`
-**Complements:** [`CAA.md`](CAA.md), [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md), [`CAR.md`](CAR.md)
+**Complements:** [`CAA.md`](../agent-runtime/CAA.md), [`AGENT-RUNTIME.md`](../agent-runtime/AGENT-RUNTIME.md), [`CAR.md`](../cognitive-substrate/CAR.md)
 
 ---
 
@@ -569,7 +569,7 @@ Each blocked/fallback event SHOULD include a `reason_code`:
 - `xml_tool_syntax` — pseudo-tool XML wrappers (`<observe>`, `<fs_read>`, etc.)
 - `no_presentation_payload` — no safe candidate available
 
-See: [AGENT-RUNTIME §v3.6.0](./AGENT-RUNTIME.md) for the output-plane separation spec.
+See: [AGENT-RUNTIME §v3.6.0](../agent-runtime/AGENT-RUNTIME.md) for the output-plane separation spec.
 
 ### 12.2 Idempotency trace
 
@@ -736,8 +736,8 @@ This replaces ad hoc lifecycle logging with a system that can answer, from files
 
 ## Related
 
-- [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md) — runtime lifecycle this document observes
-- [`CAA.md`](CAA.md) — capability architecture whose execution events are traced
-- [`CAR.md`](CAR.md) — package resolver whose load events are traced
+- [`AGENT-RUNTIME.md`](../agent-runtime/AGENT-RUNTIME.md) — runtime lifecycle this document observes
+- [`CAA.md`](../agent-runtime/CAA.md) — capability architecture whose execution events are traced
+- [`CAR.md`](../cognitive-substrate/CAR.md) — package resolver whose load events are traced
 - [`SECURITY-MODEL.md`](SECURITY-MODEL.md) — audit trail as security mechanism
-- [`AUDIT.md`](AUDIT.md) — audit architecture
+- [`AUDIT.md`](../../beta/evidence/AUDIT.md) — audit architecture

--- a/docs/beta/architecture/ARCHITECTURE.md
+++ b/docs/beta/architecture/ARCHITECTURE.md
@@ -188,7 +188,7 @@ All state machines live in `cn_protocol.ml`. States are algebraic types. Transit
 | Transport Sender | Pending → BranchCreated → Pushing → Pushed → Delivered | Outbox delivery |
 | Transport Receiver | Fetched → Materializing → Materialized → Cleaned | Inbox materialization |
 
-Full state diagrams and transition tables: [PROTOCOL.md](../alpha/protocol/PROTOCOL.md).
+Full state diagrams and transition tables: [PROTOCOL.md](../../alpha/protocol/PROTOCOL.md).
 
 ### How they compose
 
@@ -252,10 +252,10 @@ hub/
 
 | Document | Relation |
 |----------|----------|
-| [THESIS.md](../THESIS.md) | The whole — this doc maps its internal relations |
-| [COHERENCE-SYSTEM.md](../alpha/doctrine/COHERENCE-SYSTEM.md) | Meta-model that this doc makes relational |
-| [CAA.md](../alpha/agent-runtime/CAA.md) | Agent structure — this doc maps it to runtime modules |
-| [AGENT-RUNTIME.md](../alpha/agent-runtime/AGENT-RUNTIME.md) | Runtime spec — this doc shows how it relates to FSMs and observability |
-| [PROTOCOL.md](../alpha/protocol/PROTOCOL.md) | FSM design — this doc shows how FSMs compose |
-| [CDD.md](../gamma/cdd/CDD.md) | Development method — governs how all these relations evolve |
-| [AUDIT.md](./evidence/AUDIT.md) | Evidence — tracks which relations are current vs stale |
+| [THESIS.md](../../THESIS.md) | The whole — this doc maps its internal relations |
+| [COHERENCE-SYSTEM.md](../../alpha/essays/COHERENCE-SYSTEM.md) | Meta-model that this doc makes relational |
+| [CAA.md](../../alpha/agent-runtime/CAA.md) | Agent structure — this doc maps it to runtime modules |
+| [AGENT-RUNTIME.md](../../alpha/agent-runtime/AGENT-RUNTIME.md) | Runtime spec — this doc shows how it relates to FSMs and observability |
+| [PROTOCOL.md](../../alpha/protocol/PROTOCOL.md) | FSM design — this doc shows how FSMs compose |
+| [CDD.md](../../gamma/cdd/CDD.md) | Development method — governs how all these relations evolve |
+| [AUDIT.md](../evidence/AUDIT.md) | Evidence — tracks which relations are current vs stale |

--- a/docs/beta/evidence/AUDIT.md
+++ b/docs/beta/evidence/AUDIT.md
@@ -15,7 +15,7 @@
 
 | Document | Status | Action | Notes |
 |----------|--------|--------|-------|
-| **ARCHITECTURE.md** | NEW | Created | Top-level entry point. See [../ARCHITECTURE.md](../ARCHITECTURE.md) |
+| **ARCHITECTURE.md** | NEW | Created | Top-level entry point. See [../architecture/ARCHITECTURE.md](../architecture/ARCHITECTURE.md) |
 | **MANIFESTO.md** | Current | Keep | Foundational values doc. Not a technical spec. |
 | **WHITEPAPER.md** | Moved | Current | CN protocol spec (v3.0.0). §10 rewritten as relationship table. System thesis in `docs/THESIS.md`. |
 | **WHITEPAPER-v2.0.3.pdf** | Current | Keep | PDF companion to whitepaper. |

--- a/docs/beta/guides/DOJO.md
+++ b/docs/beta/guides/DOJO.md
@@ -24,11 +24,11 @@ Kata numbers are scoped to belt: `<belt>.<sequence>`.
 
 | #   | Belt | Name                                           | Kata file                                                   |
 |-----|------|------------------------------------------------|-------------------------------------------------------------|
-| 1.1 | ⚪    | Introduce yourself in `yyyyddmmhhmmss-hello-world` | [kata.md](../../../src/agent/skills/agent/hello-world/kata.md) |
-| 1.2 | ⚪    | Complete your first daily reflection           | [kata.md](../../../src/agent/skills/agent/reflect/kata.md)         |
-| 1.3 | ⚪    | Wire yourself to an existing hub              | [kata.md](../../../src/agent/skills/agent/self-cohere/kata.md) |
-| 1.4 | ⚪    | Configure agent identity through conversation | [kata.md](../../../src/agent/skills/agent/configure-agent/kata.md) |
-| 2.1 | 🟡    | Keep GitHub stars in sync with subscriptions  | [kata.md](../../../src/agent/skills/ops/star-sync/kata.md)     |
+| 1.1 | ⚪    | Introduce yourself in `yyyyddmmhhmmss-hello-world` | [kata.md](../../../src/packages/cnos.core/skills/agent/hello-world/kata.md) |
+| 1.2 | ⚪    | Complete your first daily reflection           | [kata.md](../../../src/packages/cnos.core/skills/agent/reflect/kata.md)         |
+| 1.3 | ⚪    | Wire yourself to an existing hub              | [kata.md](../../../src/packages/cnos.core/skills/agent/self-cohere/kata.md) |
+| 1.4 | ⚪    | Configure agent identity through conversation | [kata.md](../../../src/packages/cnos.core/skills/agent/configure-agent/kata.md) |
+| 2.1 | 🟡    | Keep GitHub stars in sync with subscriptions  | [kata.md](../../../src/packages/cnos.core/skills/ops/star-sync/kata.md)     |
 | 3.1 | 🟠    | *TBD*                                          | —                                                           |
 | 4.1 | 🟢    | *TBD*                                          | —                                                           |
 | 5.1 | 🔵    | *TBD*                                          | —                                                           |

--- a/docs/gamma/plans/PLAN-v3.10.0-runtime-contract.md
+++ b/docs/gamma/plans/PLAN-v3.10.0-runtime-contract.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Date:** 2026-03-23
-**Implements:** [`RUNTIME-CONTRACT-v3.10.0.md`](../../alpha/RUNTIME-CONTRACT-v3.10.0.md)
+**Implements:** [`RUNTIME-CONTRACT-v3.10.0.md`](../../alpha/agent-runtime/3.10.0/DESIGN.md)
 **Scope:** Replace overloaded capabilities block with structured Runtime Contract (self_model + workspace + capabilities).
 **Issues:** #56
 

--- a/docs/gamma/plans/PLAN-v3.8.0-n-pass-bind.md
+++ b/docs/gamma/plans/PLAN-v3.8.0-n-pass-bind.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Date:** 2026-03-21
-**Implements:** [`N-PASS-BIND-v3.8.0.md`](../../alpha/N-PASS-BIND-v3.8.0.md)
+**Implements:** [`N-PASS-BIND-v3.8.0.md`](../../alpha/agent-runtime/3.8.0/N-PASS-BIND.md)
 **Scope:** Replace the hardcoded two-pass orchestration with a bounded N-pass bind loop and add sink-aware processing indicators (Telegram typing first).
 **Issues:** #50, #48
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,35 @@
+# lychee link checker config
+#
+# Used by the I4 link-validation job in .github/workflows/coherence.yml to
+# scan **/*.md across the repo. Each `exclude` regex below is a known
+# pre-existing broken reference being tracked for burn-down.
+#
+# Tracker: https://github.com/usurobor/cnos/issues/300
+# Target: keep this list under 50 entries; remove entries as the underlying
+# debt is resolved.
+
+exclude = [
+    # docs/beta/architecture/3.14.4/ARCHITECTURE.md is a frozen historical
+    # snapshot of the canonical architecture doc. Its relative-path links
+    # predate the docs reorg and resolve outside the repo. The canonical at
+    # docs/beta/architecture/ARCHITECTURE.md has been fixed. Snapshots are
+    # read-only by repository policy and are not maintained against later
+    # tree reshuffles.
+    "file://.*/docs/beta/architecture/alpha/.*",
+    "file://.*/docs/beta/architecture/gamma/CDD\\.md$",
+    "file://.*/docs/beta/architecture/THESIS\\.md$",
+    "file://.*/docs/beta/architecture/3\\.14\\.4/evidence/AUDIT\\.md$",
+
+    # docs/alpha/runtime-extensions/1.0.6/README.md is a frozen snapshot
+    # ("MUST NOT be modified in later commits"). Its `../../RUNTIME-EXTENSIONS.md`
+    # back-link was correct at the time of freeze (when the canonical lived one
+    # level higher) but resolves outside the bundle today.
+    "file://.*/docs/alpha/RUNTIME-EXTENSIONS\\.md$",
+
+    # src/packages/cnos.cdd/skills/cdd/issue/SKILL.md teaches issue-authoring
+    # by example; the schema placeholders `(...)` and `(link)` are
+    # illustrative text, not real link targets. Lychee parses them as broken
+    # links because the surrounding markdown is `[text](placeholder)`.
+    "file://.*/src/packages/cnos\\.cdd/skills/cdd/issue/\\.{3}$",
+    "file://.*/src/packages/cnos\\.cdd/skills/cdd/issue/link$",
+]

--- a/src/packages/cnos.core/skills/agent/emoji-language/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/emoji-language/SKILL.md
@@ -64,7 +64,7 @@ emoji shorthand → structured shorthand → CTB expressions
 
 This skill is the first layer. As patterns stabilize, frequently-used sequences become structured commands. Eventually, the most precise operations graduate to CTB expressions for deterministic, verifiable agent coordination.
 
-See: [CTB v4.0.0 Vision](docs/alpha/ctb/CTB-v4.0.0-VISION.md)
+See: [CTB v4.0.0 Vision](../../../../../../docs/alpha/ctb/CTB-v4.0.0-VISION.md)
 
 ## 5. Anti-patterns
 


### PR DESCRIPTION
Closes #300.

## Summary

I4 (link-check) now scans `**/*.md` across the repo instead of just `README.md`, gated by a new `lychee.toml` containing a progressive ignore list of pre-existing broken refs. Job renamed `readme-link-check` → `link-check`.

## Triage of the 93 initial errors

**Fixed (82 instances) — path-only changes, no doc content rewritten.**

- doctrine/-rooted refs to `FOUNDATIONS`, `THESIS`, `COHERENCE-SYSTEM` repointed at `essays/` and `docs/` root after the doctrine→essays move
- sibling-style refs (`./AGENT-RUNTIME.md`, `./CAA.md`, `./CAR.md`, `./TRACEABILITY.md`, etc.) updated to cross-bundle paths after the `agent-runtime/` / `security/` / `cognitive-substrate/` split
- cli/ → security/ and cli/ → agent-runtime/ rewires for SECURITY-MODEL / AGENT-RUNTIME / SETUP-INSTALLER cross-refs
- version-scoped doc names (`SCHEDULER-v3.7.0.md`, `N-PASS-BIND-v3.8.0.md`, `SYSCALL-SURFACE-v3.8.0.md`, `RUNTIME-CONTRACT-v3.10.0.md`) repointed to their bundles in `agent-runtime/<version>/`
- `docs/beta/guides/DOJO.md` kata.md links updated to `src/packages/cnos.core/skills/...`
- `docs/beta/architecture/ARCHITECTURE.md` relative-path depth fixes after the file's repositioning under `architecture/`
- `runtime-extensions/README.md` directory naming aligned (`v1.0.6/` → `1.0.6/`)

**Ignored (11 instances) — cannot be fixed without violating other repo policies.** Each entry in `lychee.toml` carries a why-comment:

- `docs/beta/architecture/3.14.4/ARCHITECTURE.md` — frozen historical snapshot; canonical at `docs/beta/architecture/ARCHITECTURE.md` fixed
- `docs/alpha/runtime-extensions/1.0.6/README.md` back-link — snapshot is "MUST NOT be modified in later commits" by repository policy
- `src/packages/cnos.cdd/skills/cdd/issue/SKILL.md` `(...)` and `(link)` — schema-placeholder examples teaching issue authoring, not real link targets

## Verification

```
$ lychee --offline --config lychee.toml '**/*.md'
🔍 479 Total  🔗 236 Unique  ✅ 342 OK  🚫 0 Errors  👻 137 Excluded
```

7 ignore entries — well under the issue's 50-entry target, leaving room to burn down further as the underlying snapshots are unfrozen or the example placeholders are escaped.

## Test plan

- [ ] CI: `Repo link validation (I4)` passes on this branch
- [ ] CI: existing I1 / I2 / notify jobs unaffected
- [ ] No doc content changed beyond link targets

## What this does NOT do

- Does not delete or rewrite doc content
- Does not check external URLs (kept `--offline`)
- Does not unfreeze any historical snapshot


---
_Generated by [Claude Code](https://claude.ai/code/session_013zRPtog9tUrN5eGJe3Uv8p)_