### PR TITLE
docs(ctb): tighten v0.2 draft and SEMANTICS-NOTES per #297 review

### DIFF
--- a/docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md
+++ b/docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md
@@ -1,7 +1,9 @@
 # CTB Language Spec
 
 **Version:** 0.2 (draft-normative)
+
 **Date:** 2026-04-28
+
 **Status:** Draft-normative migration target. Conceptually supersedes v0.1 by unifying "skill" and "agent" into one primitive, but does not govern current v0.1 conformance until promoted. Until promotion, `LANGUAGE-SPEC.md` (v0.1) governs conformance.
 
 ---

--- a/docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md
+++ b/docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md
@@ -2,13 +2,15 @@
 
 **Version:** 0.2 (draft-normative)
 **Date:** 2026-04-28
-**Status:** Normative reference for the agent-module / invocation layer of CTB. Supersedes v0.1 by unifying "skill" and "agent" into one primitive.
+**Status:** Draft-normative migration target. Conceptually supersedes v0.1 by unifying "skill" and "agent" into one primitive, but does not govern current v0.1 conformance until promoted. Until promotion, `LANGUAGE-SPEC.md` (v0.1) governs conformance.
 
 ---
 
 ## 0. Purpose and status
 
 This document specifies the language-level model of CTB: what an agent is, what it declares, how it is named, scoped, invoked, composed, and bounded against effects.
+
+It is a **draft migration target**, not the active normative spec. v0.1 (`LANGUAGE-SPEC.md`) governs current conformance until v0.2 is explicitly promoted. v0.2 conceptually supersedes v0.1 by collapsing "skill" and "agent" into one primitive; that supersession takes effect through promotion, not through this document's existence.
 
 The core simplification over v0.1: there is one primitive — the **agent**. What v0.1 called a "skill" is a narrow-scope agent with a single axis and short lifetime. What practice calls a "role" is an agent with role-local scope and a loop. What practice calls a "triad" is three agents composing into one agent at the next scale. The composition model is the same at every level: dispatch with scoped authority.
 
@@ -391,6 +393,16 @@ A `try`/`recover` composition MUST preserve the failed witness. Recovery MUST NO
 
 These obligations connect to judgment doctrine: the agent must name the boundary it protects, the boundary it breaches, and the residual debt it does not call closure.
 
+### 6.5 Composition dimensions
+
+The operators distribute across three composition dimensions:
+
+| Dimension | Operators | What composes |
+|-----------|-----------|---------------|
+| Horizontal (sequence, handoff) | `>>`, `>>=` | Witness chains: A's close-out feeds B's orientation |
+| Vertical (boundary, parallel isolation) | `\|\|\|`, `case`, `wait`/`join` | Scoped operands: each runs in its own authority region |
+| Deep (recurrence, repair, debt) | `fix`, `try`/`recover` | History: failure becomes witness, not silence; iteration preserves debt |
+
 ### 6.6 Bounded `fix`
 
 A `fix` composition MUST be bounded. A bound is a declared condition that prevents the repair loop from running indefinitely.
@@ -450,16 +462,6 @@ A debt close-out MUST carry:
 - A debt close-out MUST NOT present unresolved debt as accepted closure.
 - A consuming agent MAY accept a debt close-out, but MUST treat the debt as an active obligation unless it explicitly judges, waives, escalates, or resolves it.
 
-### 6.5 Composition dimensions
-
-The operators distribute across three composition dimensions:
-
-| Dimension | Operators | What composes |
-|-----------|-----------|---------------|
-| Horizontal (sequence, handoff) | `>>`, `>>=` | Witness chains: A's close-out feeds B's orientation |
-| Vertical (boundary, parallel isolation) | `\|\|\|`, `case`, `wait`/`join` | Scoped operands: each runs in its own authority region |
-| Deep (recurrence, repair, debt) | `fix`, `try`/`recover` | History: failure becomes witness, not silence; iteration preserves debt |
-
 ---
 
 ## 7. Global aspects
@@ -511,7 +513,7 @@ Two evaluations of the same agent on the same inputs MUST produce equal plans.
 
 A composition is well-formed if and only if:
 
-1. Every agent declares `name`, `description`, `governing_question`, and `scope`.
+1. Every agent declares `name`, `description`, `governing_question`, `scope`, and `type` (the agent-type it satisfies, per §2.1).
 2. Public agents declare `visibility: public`.
 3. Every dispatch target is reachable through the caller's `calls` or `calls_dynamic`.
 4. No agent inherits from another.
@@ -592,7 +594,7 @@ agent write-essay : coherent-agent =
   >>= join-essay-evidence
   >> case verdict of
        accepted -> close
-       repair   -> fix (revise >> re-review) until accepted else close-with-debt
+       repair   -> fix(max=2) (revise >> re-review) until accepted else close-with-debt
        blocked  -> close-with-debt
 
 -- Specialized: code production as a triadic cycle
@@ -604,7 +606,7 @@ agent write-code : coherent-agent =
   >>= join-code-evidence
   >> case verdict of
        accepted -> close
-       repair   -> fix (patch >> re-test) until accepted else close-with-debt
+       repair   -> fix(max=2) (patch >> re-test) until accepted else close-with-debt
        blocked  -> close-with-debt
 ```
 
@@ -631,7 +633,7 @@ Both `write-essay` and `write-code` satisfy `coherent-agent`. Both use `|||` for
 
 The witness and close-out model (§5.4–§5.6, §6.7) can fail if witness fields become persuasive accounting structure rather than accountable evidence. A conformant-looking close-out is not sufficient. Until a checker or runtime enforces v0.2 obligations, an agent may produce a well-structured witness that is not mechanically connected to what actually happened. This risk is called **witness theater**.
 
-A v0.2 implementation SHOULD mitigate witness theater by checking that:
+This section is non-normative; the modal verbs in this list are recommendations for implementers, not conformance requirements. A v0.2 implementation should mitigate witness theater by checking that:
 
 - required witness fields are present
 - evidence fields are non-vacuous where required

--- a/docs/alpha/ctb/SEMANTICS-NOTES.md
+++ b/docs/alpha/ctb/SEMANTICS-NOTES.md
@@ -1,7 +1,9 @@
 # CTB Semantics Notes
 
 **Status:** Conceptual rationale and design discussion. Non-normative.
+
 **Date:** 2026-04-26
+
 **Companion to:** `LANGUAGE-SPEC.md` (normative), `CTB-v4.0.0-VISION.md` (strategic).
 
 ---

--- a/docs/alpha/ctb/SEMANTICS-NOTES.md
+++ b/docs/alpha/ctb/SEMANTICS-NOTES.md
@@ -14,6 +14,17 @@ This document collects that material. It is the place where conceptual moves are
 
 If a claim here ever becomes load-bearing for an implementer, it should migrate into the spec.
 
+### Reading map
+
+This file is a notes collection, not a single linear argument. The sections cluster:
+
+- §§1–12 — v0.1 skill-module rationale (preserved as written).
+- §13 — the agent-as-primitive turn and its FP correspondence.
+- §14 — composition-operator rationale and prior-art survey.
+- §15 — triadic-carrier grounding in TSC and ctb-check implications.
+
+Earlier sections record what was already running before the spec named it. Later sections record what the spec must eventually express.
+
 ---
 
 ## 1. Skills are modules plus callable signatures
@@ -279,7 +290,9 @@ These are exactly the operators in any concurrent effect system. The agent-speci
 
 ### 14.2 CDD expressed in operators
 
-The CDD triadic cycle, currently ~300 lines of prose algorithms across CDD.md and three role skills, is one composition expression:
+> **Note.** The example below uses the legacy CDD polling/parallel-dispatch model (β polls while α implements). The currently emerging CDD direction is identity-rotation/bounded-role-invocation (γ dispatches roles, roles return, γ decides next call); see #295 / #310 for the in-flight update. Treat this section as one parallel-agent expression of CDD, not as the canonical future dispatch model.
+
+The CDD triadic cycle, currently expressed as prose algorithms across CDD.md and three role skills, can be written as one composition expression:
 
 ```
 cdd-cycle =
@@ -337,27 +350,27 @@ The composition operators in §14.1 were not invented here. Four traditions inde
 
 **Erlang/OTP: supervision trees as composition.**
 
-The CDD triad IS an Erlang supervision tree. γ is the root supervisor; α and β are child workers. The RC loop is a `one_for_one` restart: γ restarts α while β continues watching. "Let it crash" is the same principle as "return a witness to the caller" — don't handle errors locally, let the supervisor decide.
+The CDD triad resembles an Erlang-style supervision tree. γ acts as the root supervisor; α and β as child workers. The RC loop has the shape of a `one_for_one` restart: γ restarts α while β continues watching. "Let it crash" tracks the same principle as "return a witness to the caller" — don't handle errors locally, let the supervisor decide.
 
-OTP behaviours (`gen_server`, `gen_statem`) are agent archetypes: contracts a process implements, not classes it inherits from. Our agent shapes (narrow/role/composite) map directly: `gen_server` = narrow agent (request-response), `gen_statem` = role agent (state machine with loop), `supervisor` = composite agent.
+OTP behaviours (`gen_server`, `gen_statem`) read as agent archetypes: contracts a process implements, not classes it inherits from. Our agent shapes (narrow/role/composite) map onto them: `gen_server` parallels a narrow agent (request-response), `gen_statem` parallels a role agent (state machine with loop), `supervisor` parallels a composite agent.
 
 **Process calculi: session types and choreography.**
 
-CDD.md is a choreography — it describes the global interaction pattern from an omniscient view. Each role skill is the local endpoint projection. The rule "role skill must not contradict CDD.md" is the choreographic faithfulness condition: if projections are faithful, the system is deadlock-free.
+CDD.md reads as a choreography — it describes the global interaction pattern from an omniscient view. Each role skill can be read as the local endpoint projection. The rule "role skill must not contradict CDD.md" mirrors the choreographic faithfulness condition: if projections are faithful, the system is deadlock-free.
 
-Session types give agent signatures a formal reading. α's session type: `!implement . !self-cohere . !request-review . μX.(?RC . !fix . X + ?A . !closeout)` — send implementation, send self-coherence, send review-request, then loop (receive RC, send fix, repeat) or (receive approve, send closeout). This IS the α algorithm. The LANGUAGE-SPEC signature (`inputs`, `outputs`, `calls`) is already a session type — it just lacks the temporal structure (what comes first, what repeats).
+Session types give agent signatures a formal reading. α's session type can be sketched as `!implement . !self-cohere . !request-review . μX.(?RC . !fix . X + ?A . !closeout)` — send implementation, send self-coherence, send review-request, then loop (receive RC, send fix, repeat) or (receive approve, send closeout). The α algorithm can be read as a local endpoint projection of this global protocol. The LANGUAGE-SPEC signature (`inputs`, `outputs`, `calls`) approximates a session type — it just lacks the temporal structure (what comes first, what repeats).
 
-Channel restriction (`(ν c) P`) maps to scoped artifacts. `.cdd/unreleased/{N}/` is a restricted channel — only agents in this cycle can read/write it. Scope IS the ν-binder.
+Channel restriction (`(ν c) P`) maps to scoped artifacts. `.cdd/unreleased/{N}/` behaves as a restricted channel — only agents in this cycle can read/write it. Scope plays the role of the ν-binder.
 
 **Rx/Reactive Streams: observable composition.**
 
-Agents emit streams of artifacts, not single returns. α doesn't return once — it emits self-coherence, then review-request, then fixes, then closeout. Rx models this: agents are Observables, the artifact directory is a ReplaySubject (late subscribers see history), and composition operators (`merge`, `concat`, `zip`, `takeUntil`, `retry`) map to our `|||`, `>>`, `wait`, loop-condition, and `fix`.
+Agents emit streams of artifacts, not single returns. α does not return once — it emits self-coherence, then review-request, then fixes, then closeout. Rx models this kind of pattern: agents read as Observables, the artifact directory reads as a ReplaySubject (late subscribers see history), and composition operators (`merge`, `concat`, `zip`, `takeUntil`, `retry`) parallel our `|||`, `>>`, `wait`, loop-condition, and `fix`.
 
-Rx adds push/pull unification and cancellation — both gaps in the current model. An agent should be disposable: γ cancelling α because the issue was superseded is `dispose()`.
+Rx adds push/pull unification and cancellation — both gaps in the current model. An agent should be disposable: γ cancelling α because the issue was superseded is the `dispose()` shape.
 
 **Schlapbach (2026): process calculus for agentic protocols.**
 
-Recent work formalizing MCP and SGD as π-calculus processes proves that protocol safety is equivalent to schema completeness. For CTB: signature completeness IS verifiable safety. The paper also formalizes capability confinement as a process invariant — the same structure as our "no upward mutation" rule.
+Schlapbach (2026) gives a process-calculus treatment of agentic tool protocols, formalizing MCP and SGD as π-calculus processes. For CTB, the useful lesson is that protocol safety depends on complete, machine-readable interaction surfaces: signature completeness underwrites verifiable safety. The paper also models capability confinement as a process invariant, which parallels the CTB "no upward mutation" rule.
 
 **What CTB should borrow:**
 


### PR DESCRIPTION
## Summary

Focused cleanup pass on the CTB docs landed in #297. Conceptual content is preserved; this PR only addresses status truth, internal consistency, authority hygiene, and one real Markdown rendering issue.

Scope (two files only):

- `docs/alpha/ctb/LANGUAGE-SPEC-v0.2-draft.md`
- `docs/alpha/ctb/SEMANTICS-NOTES.md`

### Fixes

`LANGUAGE-SPEC-v0.2-draft.md`
- Status header now says **draft-normative migration target**; explicitly states v0.1 (`LANGUAGE-SPEC.md`) governs current conformance until v0.2 is promoted. Removes the previous overclaim that v0.2 is the active normative reference.
- §6 sub-sections renumbered into order: §6.5 Composition dimensions now sits between §6.4 Operator obligations and §6.6 Bounded fix (was §6.5 floating after §6.7).
- §10 well-formedness adds `type` to required-field list, matching §2.1.
- §13 worked example: both `fix` loops are now `fix(max=2) ... else close-with-debt`, so the spec's own examples obey the bounded-`fix` rule §6.6 teaches.
- §15 (Non-normative risk: witness theater) drops the IETF `SHOULD`; explicitly identifies the modal verbs in that section as recommendations for implementers, not conformance requirements.
- Metadata block: blank-line-separated Version/Date/Status so each renders as its own paragraph in GitHub blob view (consecutive `**Field:**` lines without blank-line gaps collapse into one paragraph in GFM).

`SEMANTICS-NOTES.md`
- Adds a short reading map after §0 so the file is scannable as a notes collection (§§1–12 v0.1 rationale, §13 agent turn, §14 composition operators + prior art, §15 TSC grounding).
- §14.2 marks the CDD parallel/polling example as **legacy**, with a pointer to the in-flight identity-rotation/bounded-role-invocation direction (#295 / #310).
- §14.4 softens absolute prior-art claims (Erlang/OTP, session types, Rx, Schlapbach) from `IS` / `=` into `resembles` / `parallels` / `can be read as`. Schlapbach is named directly rather than referenced obliquely.
- Metadata block: same blank-line-separation as the spec.

### Non-goals

- No promotion of v0.2.
- No edits to `LANGUAGE-SPEC.md` (v0.1).
- No new theory.
- No 80-column hard-wrap of prose. Block structure (headings, tables, code fences, horizontal rules, lists) was already on separate physical lines; only the metadata block at the top needed structural separation.

## Test plan

- [ ] Render both files on the PR diff view and confirm Version/Date/Status read as separate paragraphs.
- [ ] Confirm §6 sub-section TOC reads §6.1 → §6.7 in numerical order.
- [ ] Confirm §10 lists `name`, `description`, `governing_question`, `scope`, `type`.
- [ ] Confirm §13 worked example uses `fix(max=2)` for both `write-essay` and `write-code`.
- [ ] Confirm §15 first list reads as recommendations (lowercase `should`), not conformance.
- [ ] Confirm SEMANTICS-NOTES §14.2 carries the legacy/polling note above the operator example.
- [ ] Confirm §14.4 no longer uses absolute `IS` claims.

Closes follow-up to #297.

https://claude.ai/code/session_01UQGSkzPp9ZkVfkVZhTqB2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQGSkzPp9ZkVfkVZhTqB2U)_