### PR TITLE
wake: complete D1 + AC18 attribution (apply D18 properly)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Read",
-      "Write",
-      "Bash"
-    ]
-  }
-}

--- a/.github/workflows/claude-wake.yml
+++ b/.github/workflows/claude-wake.yml
@@ -62,5 +62,13 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          bot_name: "sigma@cnos.cn-sigma.cnos"
+          bot_id: "41898282"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Read", "Write", "Edit", "MultiEdit", "Glob", "Grep", "Bash"]
+              }
+            }
           prompt: |
             Activate and attach as https://github.com/usurobor/cn-sigma.


### PR DESCRIPTION
## What

Lands cn-sigma **D24/AI1 + D24/AI3** (with D24-amendment-correction and D26) on cnos `main`. This is the bootstrap operator-merge that the wake worker structurally cannot apply to itself.

## Why

D24 was dispatched at `cn-sigma:.cn-sigma/threads/activations/cnos/20260618.md` T21:00Z (with amendments through T23:30Z). A prior wake session made commit `084912b` carrying these changes, but it never landed on `main` — the wake worker's session lacks `Edit` on `.github/*` and `Bash rm`, which are exactly the permissions D24 tries to grant. Chicken-and-egg; cleared only by an operator-authorized merge.

Confirmed orphaned in `cn-sigma:.cn-sigma/threads/activations/cnos/20260619.md` T06:14:12Z.

## Diff

**`.github/workflows/claude-wake.yml`** — under `anthropics/claude-code-action@v1`:
- `bot_name: "sigma@cnos.cn-sigma.cnos"` — foreign-activation 4-token form (`<agent>@<activation-body>.<home-body>.<substrate>`) per `cn-sigma:.cn-sigma/threads/adhoc/20260618-committer-identity-convention.md`
- `bot_id: "41898282"`
- inline `settings:` block granting `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, `Bash` to the wake worker

**`.claude/settings.local.json`** — removed. The `settings:` block in the workflow now carries the same allowlist; the `.claude/` file was D1's original ask.

## What this lands → what cascades closed

- D24/AI3 (settings.local.json deletion) — closes when this merges
- D24/AI4 (verify `git log` author attribution) — verifiable on the next wake fire after merge
- D19 (PR #456 round-3 review) — Sigma-at-cnos can dispatch once it has Edit perms
- D20 (deep-pass) — same
- Wave step 3 — advances; steps 4–8 unblock behind Checkpoint B

## Known partial-fix caveat

`git log` author will read `sigma@cnos.cn-sigma.cnos` after this lands. **GitHub's Contributors panel will still attribute commits to `claude[bot]`** because that attribution is App-scoped, not git-author-scoped. The wake still authenticates via the `claude[bot]` App's OAuth token (`bot_id: "41898282"` is the claude[bot] App ID).

Full claude-free identity separation requires registering Sigma as its own GitHub App with its own credentials. **Tracked at cnos#449** (agent/registration). D24 is the partial fix the directive explicitly scoped; the App-level work is deferred.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Trigger a wake by opening an issue with `claude-wake` in the title (or wait for next scheduled fire)
- [ ] `git log -1 origin/main --format='%h %an %ae'` — author shows `sigma@cnos.cn-sigma.cnos`
- [ ] Verify the wake run's `permission_denials_count` is 0 (settings allowlist now in effect)
- [ ] Confirm `.claude/settings.local.json` is gone from `main`

## References

- Directive: `cn-sigma:.cn-sigma/threads/activations/cnos/20260618.md` §T21:00:00Z (D24 + amendments through 23:30Z + D26)
- Orphan diagnosis: `cn-sigma:.cn-sigma/threads/activations/cnos/20260619.md` §T06:14:12Z
- Identity convention: `cn-sigma:.cn-sigma/threads/adhoc/20260618-committer-identity-convention.md`
- Reviewer convergence: `cn-sigma:.cn-sigma/threads/adhoc/20260618-committer-identity-reviewer-request.md`
- Substrate origin: cnos#444 (AC18), cnos#459 (cdd/committer-identity canonical-form spec)
- Deferred follow-up: cnos#449 (agent/registration — Sigma App)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiTPVhrsaWXLRoH15au8mX)_