### PR TITLE
agent-admin/label-doctrine: cnos.core label control plane (closes #468)

### DIFF
--- a/src/packages/cnos.core/labels.json
+++ b/src/packages/cnos.core/labels.json
@@ -33,14 +33,14 @@
     },
     {
       "name": "status:review",
-      "description": "Implementation complete; awaiting β verdict.",
+      "description": "Cell complete; awaiting external/operator review of the receipt/result.",
       "color": "5319e7",
       "owner": "cnos.core",
       "group": "lifecycle"
     },
     {
       "name": "status:changes",
-      "description": "β requested changes; γ to repair the prompt and re-dispatch.",
+      "description": "External review requested changes; issue must be revised before re-dispatch.",
       "color": "d93f0b",
       "owner": "cnos.core",
       "group": "lifecycle"

--- a/src/packages/cnos.core/labels.json
+++ b/src/packages/cnos.core/labels.json
@@ -1,0 +1,63 @@
+{
+  "schema": "cn.labels.v1",
+  "owner": "cnos.core",
+  "doctrine": "src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md",
+  "labels": [
+    {
+      "name": "status:backlog",
+      "description": "Well-formed scope but not yet refined to dispatch readiness.",
+      "color": "ededed",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:ready",
+      "description": "Spec'd; ACs converged; awaiting operator authorization.",
+      "color": "c2e0c6",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:todo",
+      "description": "Operator-authorized; dispatch wake may claim.",
+      "color": "0e8a16",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:in-progress",
+      "description": "Claimed by a dispatch wake; cycle running.",
+      "color": "fbca04",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:review",
+      "description": "Implementation complete; awaiting β verdict.",
+      "color": "5319e7",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:changes",
+      "description": "β requested changes; γ to repair the prompt and re-dispatch.",
+      "color": "d93f0b",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "status:blocked",
+      "description": "Gated on external input (operator, infra, external authority).",
+      "color": "b60205",
+      "owner": "cnos.core",
+      "group": "lifecycle"
+    },
+    {
+      "name": "dispatch:cell",
+      "description": "This issue is an executable implementation cell. Eligible to be claimed by a dispatch wake when paired with status:todo and a matching protocol:{id}.",
+      "color": "1d76db",
+      "owner": "cnos.core",
+      "group": "dispatchability"
+    }
+  ]
+}

--- a/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
@@ -55,8 +55,8 @@ Every open issue carries **exactly one** `status:*` label. The label names where
 | `status:ready` | spec'd; ACs converged; awaiting operator authorization | `status:todo`, `status:backlog` |
 | `status:todo` | operator-authorized; dispatch wake may claim | `status:in-progress` |
 | `status:in-progress` | claimed by a dispatch wake; cycle running | `status:review`, `status:blocked` |
-| `status:review` | implementation complete; awaiting β verdict | `status:changes`, closed |
-| `status:changes` | β requested changes; γ to repair the prompt and re-dispatch | `status:ready`, `status:todo` |
+| `status:review` | cell complete; awaiting external/operator review of the receipt/result | `status:changes`, closed |
+| `status:changes` | external review requested changes; issue must be revised before re-dispatch | `status:ready`, `status:todo` |
 | `status:blocked` | gated on external input (operator, infra, external authority) | `status:ready`, `status:todo` |
 
 Closed issue = done. There is no `status:done` (closing the issue is the terminal state).
@@ -77,7 +77,7 @@ Every `dispatch:cell` issue carries **exactly one** `protocol:{id}` label. The q
 
 | Qualifier | Owner | What its presence asserts |
 |---|---|---|
-| `protocol:cdd` | `cnos.cdd` | runtime = CDD γ/α/β triad; cell runs the standard CDD cycle |
+| `protocol:cdd` | `cnos.cdd` | runtime = CDD cycle (per cnos.cdd's spec) |
 | `protocol:cdr` | `cnos.cdr` | runtime = CDR research-cell shape (per cnos.cdr's spec) |
 | `protocol:cdw` | `cnos.cdw` (when the package exists) | runtime = CDW writing-cell shape (per cnos.cdw's spec) |
 | `protocol:{name}` | future package | each future protocol package registers its own qualifier at install |
@@ -191,7 +191,10 @@ The skill format:
 
 - **Cross-layer label creation.** A package creates a label it does not own (e.g., cnos.cdd creates `status:todo`). _Fix:_ per-package install commands create only labels in the package's owned set; `cn install` checks ownership before write.
 - **Missing protocol qualifier.** A `dispatch:cell` issue without `protocol:{id}`. _Fix:_ dispatch wakes reject the issue with `degraded_reason: dispatch_protocol_missing` and a repair-instruction comment (per cnos#454 AC9).
-- **Cross-protocol claim attempt.** A wake owning `{P}` tries to claim a cell labeled `protocol:{Q}` where `Q ≠ P`. _Fix:_ wake silently skips (the matching wake will claim on its sweep); not a drift event.
+- **Cross-protocol mismatch.** A wake owning `{P}` encounters a cell labeled `protocol:{Q}` where `Q ≠ P`. The handling differs by the wake's entry path:
+  - **Scheduled sweep:** the wake passes over the cell silently (it is not eligible under the wake's selector). The matching wake claims it on its own sweep. Not a drift event.
+  - **Attempted claim / event-targeted dispatch** (e.g., the wake was invoked on this specific issue via a label-trigger or explicit dispatch handle and discovers the protocol mismatch at claim-time): the wake **rejects** the claim and **reports** `degraded_reason: dispatch_protocol_mismatch` with a comment naming the mismatch (per cnos#454 AC9 drift-handling catalogue). This is a drift event.
+  The distinction matters because a sweep over a heterogeneous queue is expected behavior, but a targeted claim attempt landing on a wrong-protocol cell signals upstream label drift or a misrouted trigger and must surface for repair.
 - **Sigma defines new label.** Sigma adds a label not declared by any package's doctrine. _Fix:_ this is a Sigma-admin boundary violation; new labels must originate from a package's doctrine update + manifest change.
 - **Lifecycle skip.** An issue moves from `status:ready` directly to `status:in-progress` without `status:todo`. _Fix:_ dispatch wakes require `status:todo` for claim; transition discipline is enforced by the dispatch protocol (cnos#454 AC4 + AC7).
 

--- a/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: label-doctrine
+description: cnos's GitHub issue-label control plane — generic lifecycle and dispatchability labels owned by cnos.core, plus the per-package protocol qualifier rule that namespaces multi-protocol dispatch.
+artifact_class: skill
+kata_surface: none
+governing_question: Which labels does cnos use, who owns each, and what may Sigma do with them?
+visibility: public
+parent: agent
+triggers:
+  - label
+  - status
+  - dispatch
+  - protocol qualifier
+  - issue queue
+scope: task-local
+inputs:
+  - none (doctrine reference)
+outputs:
+  - canonical generic label set
+  - protocol qualifier rule
+  - ownership split between cnos.core and protocol packages
+  - Sigma admin boundary on labels
+requires:
+  - none (foundational; consumed by `cnos.core/skills/agent/dispatch-protocol/SKILL.md` per cnos#454, the wake-template renderer per cnos#450, and the agent-admin wake provider per cnos#467)
+---
+
+# Label doctrine
+
+cnos's issue-label control plane. Two layers, two owners.
+
+## Core Principle
+
+**Labels are a control plane, not free text.** Each label has an owner (a package), a meaning (what carrying it asserts about the issue), and a role in the dispatch protocol. Without ownership, label semantics drift across packages; without semantics, the dispatch protocol cannot select work safely.
+
+Labels split into two layers:
+
+- **Generic** — lifecycle and dispatchability. Owned by `cnos.core`. The same set in every cnos-using repo.
+- **Per-protocol qualifier** — names which package's runtime owns a given cell. Owned by the protocol package. New packages add their qualifier as part of their install.
+
+Sigma (the human-facing admin/console actor) may *apply* labels when authorized by the operator. Sigma does **not** own label semantics, define new labels, or execute the cells the labels gate.
+
+---
+
+## 1. Generic label set (owned by cnos.core)
+
+The generic labels live at `cnos.core`. They are installed in a repo by `cn install cnos.core`. The data manifest is at `src/packages/cnos.core/labels.json`.
+
+### 1.1. Lifecycle labels
+
+Every open issue carries **exactly one** `status:*` label. The label names where the issue is in its lifecycle.
+
+| Label | Meaning | Allowed transitions |
+|---|---|---|
+| `status:backlog` | well-formed scope but not yet refined to dispatch readiness | `status:ready` |
+| `status:ready` | spec'd; ACs converged; awaiting operator authorization | `status:todo`, `status:backlog` |
+| `status:todo` | operator-authorized; dispatch wake may claim | `status:in-progress` |
+| `status:in-progress` | claimed by a dispatch wake; cycle running | `status:review`, `status:blocked` |
+| `status:review` | implementation complete; awaiting β verdict | `status:changes`, closed |
+| `status:changes` | β requested changes; γ to repair the prompt and re-dispatch | `status:ready`, `status:todo` |
+| `status:blocked` | gated on external input (operator, infra, external authority) | `status:ready`, `status:todo` |
+
+Closed issue = done. There is no `status:done` (closing the issue is the terminal state).
+
+### 1.2. Dispatchability label
+
+| Label | Meaning |
+|---|---|
+| `dispatch:cell` | this issue is an executable implementation cell. Eligible to be claimed by a dispatch wake when paired with `status:todo` and a matching `protocol:{id}`. |
+
+Issues that are NOT cells (master trackers, RFCs, planning issues, design notes, conversations) MUST NOT carry `dispatch:cell`. A `kind/wave` (or `tracking`) master that coordinates cells is not itself a cell — sub-issues are.
+
+---
+
+## 2. Protocol qualifier (owned per package)
+
+Every `dispatch:cell` issue carries **exactly one** `protocol:{id}` label. The qualifier names which package's runtime owns this cell's execution.
+
+| Qualifier | Owner | What its presence asserts |
+|---|---|---|
+| `protocol:cdd` | `cnos.cdd` | runtime = CDD γ/α/β triad; cell runs the standard CDD cycle |
+| `protocol:cdr` | `cnos.cdr` | runtime = CDR research-cell shape (per cnos.cdr's spec) |
+| `protocol:cdw` | `cnos.cdw` (when the package exists) | runtime = CDW writing-cell shape (per cnos.cdw's spec) |
+| `protocol:{name}` | future package | each future protocol package registers its own qualifier at install |
+
+The qualifier label is created in the repo when the owning package is installed via `cn install {pkg}`. cnos.core does NOT create these labels — that would conflate the layers.
+
+### 2.1. Required for dispatch
+
+The authoritative dispatchable selector (defined in detail by `cnos.core/skills/agent/dispatch-protocol/SKILL.md` per cnos#454):
+
+```
+open
++ dispatch:cell
++ protocol:{P}            ← matches the wake's owning package
++ status:todo
+- status:in-progress
+- status:blocked
+- status:review
+- status:changes
+```
+
+A wake owned by package `{P}` claims **only** issues whose `protocol:{P}` matches. Cross-protocol claims are a protocol violation. A `dispatch:cell + status:todo` issue WITHOUT a `protocol:{id}` label is under-specified and is rejected by every dispatch wake's selector.
+
+### 2.2. Where the cell goes
+
+Once claimed, the issue is passed to the owning package's runtime — whichever package owns the matched `protocol:{id}`. The generic dispatch protocol does not name any specific runtime; runtime selection is implicit in the qualifier match.
+
+---
+
+## 3. Ownership split
+
+The two layers have distinct owners and distinct install paths.
+
+| Layer | Owner package | Install responsibility |
+|---|---|---|
+| Generic lifecycle + dispatchability | `cnos.core` (or a future `cnos.agent` sub-package) | `cn install cnos.core` creates `status:backlog`, `status:ready`, `status:todo`, `status:in-progress`, `status:review`, `status:changes`, `status:blocked`, `dispatch:cell` |
+| Per-protocol qualifier | each protocol package | `cn install cnos.cdd` creates `protocol:cdd`; `cn install cnos.cdr` creates `protocol:cdr`; per-package |
+
+Crossing the split is a doctrine violation:
+
+- cnos.core MUST NOT create `protocol:{id}` labels — those are package-owned
+- A protocol package MUST NOT create generic lifecycle labels — those are cnos.core-owned
+- A protocol package MAY depend on cnos.core (its install assumes the generic set exists in the repo)
+
+Installs are idempotent on label creation. Repeated `cn install cnos.cdd` runs are no-ops on label state.
+
+---
+
+## 4. Sigma admin boundary
+
+Sigma is the human-facing admin/console actor. Per `cn-sigma:.cn-sigma/spec/OPERATOR.md §"CDD role assignment"`, Sigma plays δ in CDD cycles and the agent-admin role in channel/wake work. Sigma's relationship with labels is bounded.
+
+### 4.1. Sigma may
+
+- **apply** `status:*` labels when instructed by the operator (e.g., flip `status:ready → status:todo` after operator approval)
+- **apply** `protocol:{id}` labels when the issue body clearly cites a single protocol; ask the operator when ambiguous
+- **apply** `dispatch:cell` when an issue clearly meets the cell criteria (concrete ACs, single-protocol scope, ready for implementation)
+- **report** which issues are dispatchable under each protocol
+- **suggest** label changes to the operator
+
+### 4.2. Sigma may not
+
+- **define** new labels or alter the semantics of existing labels — that is package-owned doctrine (this skill + the protocol packages' contracts)
+- **invent** new lifecycle states or dispatchability markers
+- **execute** the cells the labels gate — execution is the dispatch wake's job, and each dispatch wake belongs to a protocol package
+- **own** the issue queue or its selection algorithm — that's the dispatch protocol (cnos#454)
+- **own** any protocol's `protocol:{id}` label — that's the protocol package
+
+Sigma's role with labels is **route / refine / report**, not **define / execute**. This matches Sigma's broader admin/console scope: read directives, surface state, prepare work for the right runtime, never run the runtime itself.
+
+---
+
+## 5. Manifest
+
+The generic labels' data manifest is at `src/packages/cnos.core/labels.json`. The manifest is data-only — a `cn install cnos.core` consumer (out of scope here; downstream cycle) reads it and creates the labels in the repo. The manifest lives in `cnos.core` so it travels with the package.
+
+Each entry has at minimum:
+
+| Field | Purpose |
+|---|---|
+| `name` | label name (e.g., `status:todo`) |
+| `description` | one-line meaning |
+| `color` | hex color (no `#`) |
+| `owner` | always `cnos.core` for generic labels |
+| `group` | `lifecycle` or `dispatchability` |
+
+Implementers MAY add fields (e.g., `constraints`, `notes`); the manifest schema is forward-compatible.
+
+---
+
+## 6. Cross-references
+
+This skill is part of the wake-orchestration cluster (cnos#467). It defines doctrine consumed by:
+
+- **cnos#454** (`agent/dispatch-protocol`) — defines the claim mechanics, lifecycle transitions, drift handling, and concurrency discipline; consumes this skill's label set and ownership rules
+- **cnos#450** (`agent/wake-template`) — renders package-owned wake providers; each rendered wake pins its `protocol:{P}` filter at render time per this skill's qualifier rule
+- **cnos#467** (`agent/wake-orchestration`) — the master architecture; this skill is its first sub (cnos#468)
+
+Adjacent operator/persona doctrine:
+
+- `cn-sigma:.cn-sigma/spec/OPERATOR.md §"CDD role assignment"` — Sigma's CDD role; admin boundary context
+- `cn-sigma:.cn-sigma/spec/PERSONA.md` — Sigma identity
+
+The skill format:
+
+- `cnos.core/skills/agent/cap/SKILL.md` — example skill format reference
+
+---
+
+## 7. Failure modes
+
+- **Cross-layer label creation.** A package creates a label it does not own (e.g., cnos.cdd creates `status:todo`). _Fix:_ per-package install commands create only labels in the package's owned set; `cn install` checks ownership before write.
+- **Missing protocol qualifier.** A `dispatch:cell` issue without `protocol:{id}`. _Fix:_ dispatch wakes reject the issue with `degraded_reason: dispatch_protocol_missing` and a repair-instruction comment (per cnos#454 AC9).
+- **Cross-protocol claim attempt.** A wake owning `{P}` tries to claim a cell labeled `protocol:{Q}` where `Q ≠ P`. _Fix:_ wake silently skips (the matching wake will claim on its sweep); not a drift event.
+- **Sigma defines new label.** Sigma adds a label not declared by any package's doctrine. _Fix:_ this is a Sigma-admin boundary violation; new labels must originate from a package's doctrine update + manifest change.
+- **Lifecycle skip.** An issue moves from `status:ready` directly to `status:in-progress` without `status:todo`. _Fix:_ dispatch wakes require `status:todo` for claim; transition discipline is enforced by the dispatch protocol (cnos#454 AC4 + AC7).
+
+---
+
+## 8. Versioning
+
+This skill is doctrine-adjacent. Future changes follow the constitutive-change approval discipline that governs other doctrine-adjacent skills. Drift between this skill and `cnos.core/labels.json` is resolved in favor of this skill (the manifest must match the doctrine).
+
+If a future cycle introduces a new lifecycle state, a new dispatchability marker, or a new label-ownership tier, this skill is the canonical source; the manifest follows.


### PR DESCRIPTION
**Closes #468** (Sub 1 of #467 wake-orchestration master tracker).

## What

Two new files at `cnos.core`:

1. **`src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md`** (204 lines)
   The canonical doctrine for cnos's GitHub issue-label control plane. Defines:
   - **§1** Generic label set owned by `cnos.core` — 7 lifecycle labels (`status:backlog/ready/todo/in-progress/review/changes/blocked`) + 1 dispatchability marker (`dispatch:cell`)
   - **§2** Protocol qualifier rule (`protocol:{id}`) owned per protocol package; the authoritative dispatchable selector composition
   - **§3** Ownership split (cnos.core owns generic; protocol packages own their qualifier; crossing the split is a doctrine violation)
   - **§4** Sigma admin boundary — may apply labels when authorized; may not define semantics or execute cells
   - **§5** Manifest pointer
   - **§6** Cross-references to #467 / #454 / #450
   - **§7** Failure modes + §8 Versioning

2. **`src/packages/cnos.core/labels.json`** (63 lines)
   Data-only manifest declaring the 8 generic labels cnos.core owns. Each entry has `name`, `description`, `color`, `owner`, `group`. JSON-validated. Forward-compatible (implementers may add fields).

## AC verification (per #468)

| AC | Status | Evidence |
|---|---|---|
| AC1: Skill at canonical path | ✅ | `src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md` exists; cnos skill frontmatter conforms |
| AC2: Generic label set enumerated with semantics | ✅ | §1.1 (lifecycle, 7 labels) + §1.2 (dispatch:cell); each with 1-line semantics + transition rules |
| AC3: Protocol qualifier rule stated | ✅ | §2 — rule + concrete cdd/cdr/cdw examples + extensibility pattern |
| AC4: Ownership split documented | ✅ | §3 table + crossing-the-split prohibition |
| AC5: Sigma admin boundary stated | ✅ | §4.1 (may) + §4.2 (may not); cites cn-sigma OPERATOR.md |
| AC6: Cross-refs to #467, #454, #450 | ✅ | §6 references section |
| AC7: Label manifest at cnos.core/labels.json | ✅ | File exists; JSON parses; 8 entries; all required fields present; `cn.labels.v1` schema |

## Bootstrap exception (per reviewer convergence)

This cycle was executed through the **pre-dispatch operator-routed CDD path** (γ+α+β collapsed onto δ at the γ-interface session; operator merges) because the package-owned dispatch wakes that would normally claim a `dispatch:cell + protocol:cdd + status:todo` cycle **do not exist yet** — this skill itself defines the doctrine those wakes will later consume. Chicken-and-egg, acknowledged.

Specifically:
- #468 carries `dispatch:cell` + `protocol:cdd` as forward-compatible markers, but does NOT carry `status:todo` — the dispatcher doesn't exist; nothing would claim it.
- The labels themselves (`status:*`, `dispatch:cell`) are not yet created in this repo as actual GitHub labels — that's downstream work (a `cn install cnos.core` or `cn label install` command, both out of scope for this sub).

Once Subs 2-5 of #467 land and a CDD dispatch wake exists, future cells can be authored under the doctrine this PR ships, labeled with `status:todo`, and claimed automatically by `cdd-dispatch`.

## Scope discipline (per #468 In/Out tables)

**In:** the skill + the manifest. Nothing else.

**Explicitly NOT in this PR:**
- `cn install` command (downstream)
- `cn wake install` renderer (Sub 3)
- Agent-admin wake provider (Sub 2)
- CDD dispatch wake provider (Sub 4)
- δ wake-invoked mode skill (Sub 5)
- End-to-end smoke (Sub 6)
- Dispatch claim mechanics (cnos#454's deliverable)
- Wake yaml content (cnos#450's deliverable)
- Per-protocol package install commands creating `protocol:{id}` labels (per-package cycles)
- Migration of existing labels (`P0/P1/P2/P3`, `kind/*`, `area/*`) — separate consideration

## Test plan

- [x] JSON manifest parses (`python3 -c "json.load(open(...))"` succeeded; 8 labels; single owner `cnos.core`; groups `lifecycle` + `dispatchability`)
- [x] Skill frontmatter conforms to cnos skill format (mirrors `cap/SKILL.md` shape)
- [x] All 8 manifest entries match §1.1 + §1.2 of skill (label-by-label cross-check)
- [ ] Operator review of doctrine
- [ ] Merge to main; closes #468
- [ ] Sub 2 (`agent-admin/wake-provider: cnos.core agent-admin wake`) files next per #467 sequential dispatch

## References

- **cnos#467** master tracker (foundational architecture; package-owned wake providers)
- **cnos#468** this sub (label doctrine)
- **cnos#454** dispatch-protocol (consumes the label set + ownership rules; amended for protocol qualifier)
- **cnos#450** wake-template (consumes the per-package label-install contract; amended for package-owned renderers)
- `cn-sigma:.cn-sigma/spec/OPERATOR.md §"CDD role assignment"` — Sigma admin context

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiTPVhrsaWXLRoH15au8mX)_