### PR TITLE
chore: protocol-qualifier label rename — cnos.cdd → cnos.cds (doctrine correction; framework vs concrete protocol)

### DIFF
--- a/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+++ b/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
@@ -100,7 +100,7 @@ jobs:
 
             When a cell-shaped directive arrives in the home thread:
 
-            - **MUST NOT** execute the cell inline. The admin wake is not the CDD/CDR/CDW runtime; running a cell inside the admin wake collapses the role-separation invariant cnos#467 establishes.
+            - **MUST NOT** execute the cell inline. The admin wake is not the CDS/CDR/CDW protocol runtime, and it does not run the CDD cell framework inline; running a cell inside the admin wake collapses the role-separation invariant cnos#467 establishes.
             - **MUST** defer per the defer-path below.
             - **MUST** make the deferral observable in today's channel log entry (the channel entry is the operator's signal that the directive arrived and was correctly routed).
 

--- a/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+++ b/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
@@ -112,10 +112,10 @@ jobs:
 
             When a cell-shaped directive arrives:
 
-            1. **Classify the protocol.** Read the directive; identify the protocol that owns the cell's runtime (cnos.cdd → `protocol:cdd`; cnos.cdr → `protocol:cdr`; cnos.cdw (future) → `protocol:cdw`).
+            1. **Classify the protocol.** Read the directive; identify the concrete protocol that owns the cell's runtime (cnos.cds → `protocol:cds` for software cells; cnos.cdr → `protocol:cdr` for research cells; cnos.cdw (future) → `protocol:cdw` for writing cells). Note: cnos.cdd is the generic cell-runtime framework, not a concrete protocol; cells are labeled with the concrete protocol's qualifier, never `protocol:cdd`.
             2. **Check for the dispatch wake.** Determine whether the protocol's dispatch wake is installed in this repo (today: presence of a rendered `.github/workflows/cnos-{protocol}-dispatch.yml`; or equivalent substrate artifact). The means of detection is substrate-specific; the *logical* check is: does this repo have a dispatch wake for this protocol?
             3. **If installed:** defer to the dispatch wake. Concretely: ensure the underlying issue carries the dispatchable selector `open + dispatch:cell + protocol:{P} + status:todo` (per cnos#454 + cnos#468 §2.1) — applying the missing labels per §6 above only if operator-authorized. Then the dispatch wake will claim the cell on its next firing. In today's channel entry, name the deferral: "Cell-shaped directive for protocol:{P} deferred to {protocol}-dispatch wake; issue #N now labeled for claim."
-            4. **If not installed:** surface to operator. In today's channel entry, name the directive, name the missing dispatch wake, and name the operator action (e.g. "Cell-shaped directive for protocol:cdd arrived; no cdd-dispatch wake installed in this repo. Operator action: install cnos.cdd and run `cn wake install cdd-dispatch` per cnos#467 Sub 4."). Do not attempt the cell.
+            4. **If not installed:** surface to operator. In today's channel entry, name the directive, name the missing dispatch wake, and name the operator action (e.g. "Cell-shaped directive for protocol:cds arrived; no cds-dispatch wake installed in this repo. Operator action: install cnos.cds and run `cn wake install cds-dispatch` per cnos#467 Sub 4."). Do not attempt the cell.
 
             ---
 

--- a/src/packages/cnos.core/orchestrators/agent-admin/prompt.md
+++ b/src/packages/cnos.core/orchestrators/agent-admin/prompt.md
@@ -58,10 +58,10 @@ The same boundary applies when an issue this wake creates or refines is cell-sha
 
 When a cell-shaped directive arrives:
 
-1. **Classify the protocol.** Read the directive; identify the protocol that owns the cell's runtime (cnos.cdd → `protocol:cdd`; cnos.cdr → `protocol:cdr`; cnos.cdw (future) → `protocol:cdw`).
+1. **Classify the protocol.** Read the directive; identify the concrete protocol that owns the cell's runtime (cnos.cds → `protocol:cds` for software cells; cnos.cdr → `protocol:cdr` for research cells; cnos.cdw (future) → `protocol:cdw` for writing cells). Note: cnos.cdd is the generic cell-runtime framework, not a concrete protocol; cells are labeled with the concrete protocol's qualifier, never `protocol:cdd`.
 2. **Check for the dispatch wake.** Determine whether the protocol's dispatch wake is installed in this repo (today: presence of a rendered `.github/workflows/cnos-{protocol}-dispatch.yml`; or equivalent substrate artifact). The means of detection is substrate-specific; the *logical* check is: does this repo have a dispatch wake for this protocol?
 3. **If installed:** defer to the dispatch wake. Concretely: ensure the underlying issue carries the dispatchable selector `open + dispatch:cell + protocol:{P} + status:todo` (per cnos#454 + cnos#468 §2.1) — applying the missing labels per §6 above only if operator-authorized. Then the dispatch wake will claim the cell on its next firing. In today's channel entry, name the deferral: "Cell-shaped directive for protocol:{P} deferred to {protocol}-dispatch wake; issue #N now labeled for claim."
-4. **If not installed:** surface to operator. In today's channel entry, name the directive, name the missing dispatch wake, and name the operator action (e.g. "Cell-shaped directive for protocol:cdd arrived; no cdd-dispatch wake installed in this repo. Operator action: install cnos.cdd and run `cn wake install cdd-dispatch` per cnos#467 Sub 4."). Do not attempt the cell.
+4. **If not installed:** surface to operator. In today's channel entry, name the directive, name the missing dispatch wake, and name the operator action (e.g. "Cell-shaped directive for protocol:cds arrived; no cds-dispatch wake installed in this repo. Operator action: install cnos.cds and run `cn wake install cds-dispatch` per cnos#467 Sub 4."). Do not attempt the cell.
 
 ---
 

--- a/src/packages/cnos.core/orchestrators/agent-admin/prompt.md
+++ b/src/packages/cnos.core/orchestrators/agent-admin/prompt.md
@@ -46,7 +46,7 @@ A **cell-shaped directive** is any directive that asks for implementation work o
 
 When a cell-shaped directive arrives in the home thread:
 
-- **MUST NOT** execute the cell inline. The admin wake is not the CDD/CDR/CDW runtime; running a cell inside the admin wake collapses the role-separation invariant cnos#467 establishes.
+- **MUST NOT** execute the cell inline. The admin wake is not the CDS/CDR/CDW protocol runtime, and it does not run the CDD cell framework inline; running a cell inside the admin wake collapses the role-separation invariant cnos#467 establishes.
 - **MUST** defer per the defer-path below.
 - **MUST** make the deferral observable in today's channel log entry (the channel entry is the operator's signal that the directive arrived and was correctly routed).
 

--- a/src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json
+++ b/src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json
@@ -60,7 +60,7 @@
     "other agents' .cn-{other}/ surfaces (writer-locality per AGENT-ACTIVATION-LOG-v0 §0)"
   ],
   "defer_path": {
-    "cell_shaped_directive": "Defer to the relevant protocol:{P} dispatch wake if installed in this repo (e.g. cnos.cdd's cdd-dispatch wake for protocol:cdd cells). If no dispatch wake for the protocol is installed, surface to operator via the channel log entry: name the directive, name the missing dispatch wake, name the cycle the operator should install (e.g. 'cn wake install cdd-dispatch'). The admin wake MUST NOT execute the cell inline under any circumstance — doing so collapses the agent-admin / dispatch boundary that cnos#467 establishes.",
+    "cell_shaped_directive": "Defer to the relevant protocol:{P} dispatch wake if installed in this repo (e.g. cnos.cds's cds-dispatch wake for protocol:cds cells; cnos.cdr's cdr-dispatch wake for protocol:cdr cells). If no dispatch wake for the protocol is installed, surface to operator via the channel log entry: name the directive, name the missing dispatch wake, name the cycle the operator should install (e.g. 'cn wake install cds-dispatch'). The admin wake MUST NOT execute the cell inline under any circumstance — doing so collapses the agent-admin / dispatch boundary that cnos#467 establishes.",
     "off_role_directive": "When a directive falls outside the admin role (e.g. a code-change request, a renderer invocation, a release-cut), the admin wake appends a 'directive-out' or 'substantive' channel entry naming the misroute and the appropriate role/wake/operator action; the admin wake does NOT attempt the work. The channel entry is the operator's signal to re-route.",
     "ambiguous_directive": "When the directive's role is ambiguous (could be admin or could be cell-shaped), defer to operator per cnos.core/skills/agent/attach §3.8 ('defer to operator on ambiguity, do not guess'); the channel entry names the ambiguity and the candidate interpretations."
   },
@@ -105,7 +105,7 @@
     ],
     "downstream_consumers": [
       "cnos#450 (Sub 3 — cn wake install renderer; consumes this manifest)",
-      "cnos#467 Sub 4 (cnos.cdd dispatch wake provider; pattern-copies from this form, declares role: dispatch)",
+      "cnos#467 Sub 4 (cnos.cds dispatch wake provider; pattern-copies from this form, declares role: dispatch; cnos.cdd is the framework, cnos.cds is the concrete software protocol)",
       "cnos#467 Sub 6 (cycle-complete artifact reading; extends this wake's class_taxonomy + prompt with cycle-complete behavior)"
     ]
   }

--- a/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
@@ -124,7 +124,7 @@ Crossing the split is a doctrine violation:
 - A protocol package MUST NOT create generic lifecycle labels — those are cnos.core-owned
 - A protocol package MAY depend on cnos.core (its install assumes the generic set exists in the repo)
 
-Installs are idempotent on label creation. Repeated `cn install cnos.cdd` runs are no-ops on label state.
+Installs are idempotent on label creation. Repeated `cn install cnos.core` runs are no-ops on generic label state; repeated `cn install cnos.cds` (or `cnos.cdr`, future `cnos.cdw`) runs are no-ops on each concrete protocol's `protocol:{id}` label state.
 
 ---
 
@@ -191,7 +191,7 @@ The skill format:
 
 ## 7. Failure modes
 
-- **Cross-layer label creation.** A package creates a label it does not own (e.g., cnos.cdd creates `status:todo`). _Fix:_ per-package install commands create only labels in the package's owned set; `cn install` checks ownership before write.
+- **Cross-layer label creation.** A package creates a label it does not own (e.g., cnos.cds creates `status:todo`, or cnos.core creates `protocol:cds`). _Fix:_ per-package install commands create only labels in the package's owned set; `cn install` checks ownership before write.
 - **Missing protocol qualifier.** A `dispatch:cell` issue without `protocol:{id}`. _Fix:_ dispatch wakes reject the issue with `degraded_reason: dispatch_protocol_missing` and a repair-instruction comment (per cnos#454 AC9).
 - **Cross-protocol mismatch.** A wake owning `{P}` encounters a cell labeled `protocol:{Q}` where `Q ≠ P`. The handling differs by the wake's entry path:
   - **Scheduled sweep:** the wake passes over the cell silently (it is not eligible under the wake's selector). The matching wake claims it on its own sweep. Not a drift event.

--- a/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/label-doctrine/SKILL.md
@@ -77,10 +77,12 @@ Every `dispatch:cell` issue carries **exactly one** `protocol:{id}` label. The q
 
 | Qualifier | Owner | What its presence asserts |
 |---|---|---|
-| `protocol:cdd` | `cnos.cdd` | runtime = CDD cycle (per cnos.cdd's spec) |
+| `protocol:cds` | `cnos.cds` | runtime = CDS software-cell shape (per cnos.cds's spec) |
 | `protocol:cdr` | `cnos.cdr` | runtime = CDR research-cell shape (per cnos.cdr's spec) |
 | `protocol:cdw` | `cnos.cdw` (when the package exists) | runtime = CDW writing-cell shape (per cnos.cdw's spec) |
 | `protocol:{name}` | future package | each future protocol package registers its own qualifier at install |
+
+**Note on cnos.cdd:** `cnos.cdd` is the generic *cell-runtime framework* — it defines the γ/α/β/δ role contracts, the cell mechanics, and the dispatch protocol that the concrete protocol packages (`cnos.cds`, `cnos.cdr`, `cnos.cdw`, ...) all use under the hood. It does **not** own a `protocol:cdd` qualifier of its own; cells are always labeled with the qualifier of the concrete protocol whose runtime executes them (a software cell carries `protocol:cds`, not `protocol:cdd`).
 
 The qualifier label is created in the repo when the owning package is installed via `cn install {pkg}`. cnos.core does NOT create these labels — that would conflate the layers.
 
@@ -114,7 +116,7 @@ The two layers have distinct owners and distinct install paths.
 | Layer | Owner package | Install responsibility |
 |---|---|---|
 | Generic lifecycle + dispatchability | `cnos.core` (or a future `cnos.agent` sub-package) | `cn install cnos.core` creates `status:backlog`, `status:ready`, `status:todo`, `status:in-progress`, `status:review`, `status:changes`, `status:blocked`, `dispatch:cell` |
-| Per-protocol qualifier | each protocol package | `cn install cnos.cdd` creates `protocol:cdd`; `cn install cnos.cdr` creates `protocol:cdr`; per-package |
+| Per-protocol qualifier | each concrete protocol package | `cn install cnos.cds` creates `protocol:cds`; `cn install cnos.cdr` creates `protocol:cdr`; per-package (cnos.cdd is the framework, not a concrete protocol; it does not create a protocol qualifier) |
 
 Crossing the split is a doctrine violation:
 

--- a/src/packages/cnos.core/skills/agent/wake-provider/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/wake-provider/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wake-provider
-description: The wake-provider declaration contract. Defines what a cnos package declares to provide a wake (identity, responsibilities, input/output contract, allowed/disallowed surfaces, defer-path, prompt template) and the split between what the package declares vs what the substrate renderer materializes. The agent-admin wake provider (cnos.core, sibling `orchestrators/agent-admin/wake-provider.json`) is the reference instance; cnos.cdd's dispatch wake provider (Sub 4 of cnos#467) will be authored against this contract alone.
+description: The wake-provider declaration contract. Defines what a cnos package declares to provide a wake (identity, responsibilities, input/output contract, allowed/disallowed surfaces, defer-path, prompt template) and the split between what the package declares vs what the substrate renderer materializes. The agent-admin wake provider (cnos.core, sibling `orchestrators/agent-admin/wake-provider.json`) is the reference instance; cnos.cds's dispatch wake provider (Sub 4 of cnos#467) — the first concrete-protocol dispatch wake — will be authored against this contract alone.
 artifact_class: skill
 kata_surface: none
 governing_question: What does a cnos package declare to provide a wake, and which fields of the declaration are the package's authority vs the substrate renderer's authority?
@@ -117,7 +117,7 @@ Every wake-provider manifest MUST declare these fields, in this rough order (the
 |---|---|---|
 | `schema` | string, MUST equal `"cn.wake-provider.v1"` | Identifies this file as a wake-provider declaration consumable by `cn wake install`. The renderer dispatches by schema. |
 | `name` | string, kebab-case, repo-unique | The wake's identifier (e.g. `agent-admin`, `cds-dispatch`). The renderer derives the substrate artifact name from this (today: `.github/workflows/cnos-{name}.yml`). |
-| `package` | string | The owning package (e.g. `cnos.core`, `cnos.cdd`). Authoritative for ownership; the renderer verifies the manifest lives under the named package's directory tree. |
+| `package` | string | The owning package (e.g. `cnos.core` for the agent-admin wake; `cnos.cds` for the CDS dispatch wake; cnos.cdr / cnos.cdw for their respective dispatch wakes). Authoritative for ownership; the renderer verifies the manifest lives under the named package's directory tree. Note: dispatch wakes belong to concrete protocol packages (cds/cdr/cdw); `cnos.cdd` is the generic cell-runtime framework and does not own a dispatch wake itself. |
 | `role` | string, enum: `admin` \| `dispatch` \| `observer` | The wake's role class. `admin` = channel sync + admin-only directive handling, never executes cells. `dispatch` = claims cells matching its protocol selector and runs the protocol's runtime. `observer` = reads-only; emits reports but does not act. The agent-admin wake declares `admin`. |
 | `responsibilities` | array of strings, non-empty | The enumerated capabilities the wake's prompt commits to. The renderer does not interpret these (they are prose for the agent); the package authors them so they are observable in the declaration without reading the prompt. |
 | `admin_only` | boolean | When `true`, the wake MUST NOT execute cells. The prompt template is required to enforce this; the renderer is required to surface it (e.g. via permission allowlist restriction in the materialized substrate artifact). `role: admin` implies `admin_only: true`. |
@@ -309,7 +309,7 @@ This skill is part of the wake-orchestration cluster (cnos#467). It defines the 
 - **cnos#468** (`agent/label-doctrine`) — the label control plane any admin wake's prompt cites for label-application discipline. The agent-admin wake provider's prompt template carries this citation.
 - **cnos#470** (this cycle; Sub 2 of #467) — authors this skill and the agent-admin wake provider as the reference instance.
 - **cnos#450** (`agent/wake-template`, amended) — the Sub 3 renderer (`cn wake install`) consumes this contract. The renderer dispatches by `schema`; required-field validation is its responsibility; substrate emission is its sole authority.
-- **cnos#454** (`agent/dispatch-protocol`, amended) — defines the claim mechanics for *dispatch*-role wakes; not consumed by admin-role wakes. Future per-package dispatch wake providers (cnos.cdd Sub 4; future cnos.cdr, cnos.cdw) cite both this contract and #454.
+- **cnos#454** (`agent/dispatch-protocol`, amended) — defines the claim mechanics for *dispatch*-role wakes; not consumed by admin-role wakes. Future per-package dispatch wake providers (cnos.cds Sub 4; future cnos.cdr, cnos.cdw) cite both this contract and #454. (cnos.cdd is the generic cell-runtime framework, not a concrete dispatch wake owner.)
 
 Adjacent skills and conventions:
 

--- a/src/packages/cnos.core/skills/agent/wake-provider/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/wake-provider/SKILL.md
@@ -116,7 +116,7 @@ Every wake-provider manifest MUST declare these fields, in this rough order (the
 | Field | Type | Purpose |
 |---|---|---|
 | `schema` | string, MUST equal `"cn.wake-provider.v1"` | Identifies this file as a wake-provider declaration consumable by `cn wake install`. The renderer dispatches by schema. |
-| `name` | string, kebab-case, repo-unique | The wake's identifier (e.g. `agent-admin`, `cdd-dispatch`). The renderer derives the substrate artifact name from this (today: `.github/workflows/cnos-{name}.yml`). |
+| `name` | string, kebab-case, repo-unique | The wake's identifier (e.g. `agent-admin`, `cds-dispatch`). The renderer derives the substrate artifact name from this (today: `.github/workflows/cnos-{name}.yml`). |
 | `package` | string | The owning package (e.g. `cnos.core`, `cnos.cdd`). Authoritative for ownership; the renderer verifies the manifest lives under the named package's directory tree. |
 | `role` | string, enum: `admin` \| `dispatch` \| `observer` | The wake's role class. `admin` = channel sync + admin-only directive handling, never executes cells. `dispatch` = claims cells matching its protocol selector and runs the protocol's runtime. `observer` = reads-only; emits reports but does not act. The agent-admin wake declares `admin`. |
 | `responsibilities` | array of strings, non-empty | The enumerated capabilities the wake's prompt commits to. The renderer does not interpret these (they are prose for the agent); the package authors them so they are observable in the declaration without reading the prompt. |
@@ -205,7 +205,7 @@ To declare a new wake provider in package `{pkg}`:
 5. **Do NOT touch the substrate.** No edits under `.github/workflows/`. The renderer emits the substrate artifact at `cn wake install` time (Sub 3 of cnos#467).
 6. **Verify substrate-agnostic:** `grep -ciE 'github|workflow|yaml|GITHUB_TOKEN|runs-on|claude-code-action' wake-provider.json prompt.md` MUST return 0 *except* for an explicit `relationship_to_substrate` field or a "relationship to existing claude-wake.yml" section that names the artifact being superseded (descriptive reference, not substrate emission).
 
-The agent-admin wake provider (cnos.core, sibling `orchestrators/agent-admin/wake-provider.json`) is the reference instance of this contract. The cnos.cdd dispatch wake provider (Sub 4 of cnos#467) will pattern-copy from it: `cnos.cdd/orchestrators/cdd-dispatch/wake-provider.json` + `prompt.md`, declaring `role: dispatch` instead of `role: admin`.
+The agent-admin wake provider (cnos.core, sibling `orchestrators/agent-admin/wake-provider.json`) is the reference instance of this contract. The cnos.cds dispatch wake provider (Sub 4 of cnos#467) will pattern-copy from it: `cnos.cds/orchestrators/cds-dispatch/wake-provider.json` + `prompt.md`, declaring `role: dispatch` instead of `role: admin`. (cnos.cds is the concrete software protocol; cnos.cdd is the generic cell-runtime framework that cds and the other concrete protocol packages — cnos.cdr, cnos.cdw — use under the hood. Dispatch wakes belong to concrete protocols, not to the framework.)
 
 ---
 


### PR DESCRIPTION
## What

Corrects a doctrine error shipped across cnos#468 + cnos#470 + cnos#476: I framed `cnos.cdd` as a concrete protocol package with its own `protocol:cdd` label and `cdd-dispatch` wake. Per operator correction (and reviewer iteration):

- **`cnos.cdd` is the generic cell-runtime framework** (γ/α/β/δ role contracts, cell mechanics, dispatch protocol)
- **`cnos.cds` / `cnos.cdr` / `cnos.cdw` are concrete protocol packages** (software / research / writing) that use `cnos.cdd`'s cell-runtime
- Protocol qualifiers name **concrete protocols** (`protocol:cds`, never `protocol:cdd`)
- Dispatch wakes belong to **concrete protocol packages** (`cds-dispatch` owned by cnos.cds, etc.; cnos.cdd does not own a dispatch wake)

## Architecture unchanged

The package-owned wakes architecture, two-layer label control plane, admin/dispatch role separation, package-vs-renderer authority split — all correct as shipped. Only the naming of the concrete-protocol-package slot was wrong.

## Scope (2 commits, 5 files)

**Commit `7ab62cb9` — initial sweep:**
- `cnos.core/skills/agent/label-doctrine/SKILL.md` (qualifier table + install example + Note on cnos.cdd)
- `cnos.core/skills/agent/wake-provider/SKILL.md` (name example + Sub 4 reference)
- `cnos.core/orchestrators/agent-admin/wake-provider.json` (defer_path + downstream_consumers)
- `cnos.core/orchestrators/agent-admin/prompt.md` (classification step + defer-path example)
- `cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` (mirror of prompt.md edits)

**Commit `4b633bb2` — reviewer iteration cleanup:**
- `label-doctrine/SKILL.md`: idempotence statement + failure-mode example (still said `cn install cnos.cdd creates status:todo`)
- `wake-provider/SKILL.md`: frontmatter description (still named Sub 4 as cnos.cdd's) + `package` field example + cross-reference
- `prompt.md` + `golden.yml`: "not the CDD/CDR/CDW runtime" → "not the CDS/CDR/CDW protocol runtime, and does not run the CDD cell framework inline" (non-blocking polish; preserves the warning while honoring framework-vs-protocol distinction)

After cleanup, **all remaining `cnos.cdd` references in cnos.core are correct framework pointers** (CDD's generic skills, CDD-as-framework descriptions, or explicit "cnos.cdd is the framework" clarifications). Verified via grep audit.

## NOT changed

- `cnos.core/commands/install-wake/cn-install-wake` (renderer; no doctrine references)
- `.github/workflows/install-wake-golden.yml` (CI guards; no doctrine references)
- `cnos.core/labels.json` (only enumerates generic labels; no protocol qualifiers)
- `.cdd/releases/docs/2026-06-21/*/` (cycle/470 + cycle/476 archived artifacts; historical record)

## Issue body amendments (separate, complete)

Authoritative top-comments posted on each affected open issue (per the "or add authoritative top comments" reviewer allowance):
- cnos#467 [comment](https://github.com/usurobor/cnos/issues/467#issuecomment-4763717662)
- cnos#454 [comment](https://github.com/usurobor/cnos/issues/454#issuecomment-4763718250)
- cnos#450 [comment](https://github.com/usurobor/cnos/issues/450#issuecomment-4763718886)
- cnos#478 [comment](https://github.com/usurobor/cnos/issues/478#issuecomment-4763719551) + label fixed (`protocol:cdd` → `protocol:cds`)
- cnos#479 [comment](https://github.com/usurobor/cnos/issues/479#issuecomment-4763720217) + label fixed (`protocol:cdd` → `protocol:cds`)

Each comment names the rename mapping (`protocol:cdd` → `protocol:cds`; `cdd-dispatch` → `cds-dispatch`; etc.) and is marked authoritative until the body itself is rewritten (deferred; pure-rename body rewrites carry drift risk).

## Test plan

- [x] JSON parses (`wake-provider.json`)
- [x] YAML parses (`cnos-agent-admin.golden.yml`)
- [x] Grep audit: remaining `cnos.cdd` references are all framework pointers (verified)
- [x] Comments posted on 5 open issues
- [x] Labels corrected on cnos#478 + cnos#479
- [ ] CI `install-wake-golden` workflow stays green (renderer inline-substitution of prompt.md → golden matches — edits are mirrored line-for-line)
- [ ] Merge to main
- [ ] Sub 4 of cnos#467 (when filed) uses the corrected doctrine: `cnos.cds dispatch wake provider`, `protocol:cds`, `cds-dispatch`

## Bootstrap exception

Operator-routed direct correction (γ-interface drafts, operator merges) for a doctrine renaming. The architectural change is zero — only the slot name in the concrete-protocol-package layer. A full CDD cell for a 5-file string-replacement was deemed overkill; the correction itself is the empirical demonstration that pure renames can ride on the operator-merge gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiTPVhrsaWXLRoH15au8mX)_