### PR TITLE
essays: add Dumb Models, Smart Cells (convention over vendor runtime)

### DIFF
--- a/docs/alpha/essays/DUMB-MODELS-SMART-CELLS.md
+++ b/docs/alpha/essays/DUMB-MODELS-SMART-CELLS.md
@@ -1,0 +1,138 @@
+---
+title: "Dumb Models, Smart Cells"
+subtitle: "Convention over Vendor Runtime for Agent Systems"
+version: v0.1.0
+status: DRAFT
+author: usurobor (aka Axiom) (human & AI)
+date: 2026-06-22
+---
+
+# Dumb Models, Smart Cells
+## Convention over Vendor Runtime for Agent Systems
+
+**Status:** v0.1.0 (DRAFT — position paper)
+**Author(s):** usurobor (aka Axiom) (human & AI)
+**Date:** 2026-06-22
+
+> **Scope:** This paper argues where agent-system intelligence should live. It does not specify the CN wire format (see [`WHITEPAPER.md`](../protocol/WHITEPAPER.md)) or the full cnos architecture (see [`THESIS.md`](../../THESIS.md)). It is a companion to both.
+
+---
+
+## 0. Abstract
+
+**Governing question: where should agent-system intelligence live — inside a proprietary LLM runtime, or inside open conventions, cells, packages, receipts, and repo state?**
+
+cnos answers: outside the model. The language model is a powerful but **replaceable executor**. Workflow, memory, identity, and proof live in the convention layer the system owns, not in the vendor runtime it rents.
+
+"Dumb" here means **non-authoritative**, not low-capability. cnos routes hard, high-context work to frontier models on purpose ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §3). The model can be the smartest component in the system and still hold no durable authority over workflow, state, or trust. Capability is rented; authority is owned.
+
+The argument is an analogy developers already know. Rails treated the database as a powerful but replaceable engine behind conventions — ActiveRecord, migrations, convention over configuration — so application logic lived in the framework, not in vendor-specific stored procedures. cnos treats the LLM the same way: a powerful but replaceable engine behind cells, packages, receipts, and dispatch conventions, so agent logic lives in the repo, not in the vendor runtime.
+
+This paper shows the boundary is not aspirational. It is already drawn in the provider contract ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §21: *Package distributes. Extension declares. Provider executes. Kernel decides.*).
+
+---
+
+## 1. Where does intelligence drift by default?
+
+Into the vendor runtime.
+
+The dominant framing of AI systems says the LLM is the intelligence, tools make it useful, memory makes it durable, and orchestration makes it autonomous ([`THESIS.md`](../../THESIS.md) §1). Followed to its conclusion, that framing pushes every durable concern *into the vendor*: the vendor stores the memory, the vendor runs the agent loop, the vendor defines the threads, the vendor holds the keys.
+
+The cost is structural, not cosmetic. A system organized this way is stateless in essence, fragile in operation, hard to audit, and dependent on a centralized service for its own correctness ([`THESIS.md`](../../THESIS.md) §1). The Moltbook incident is the concrete case: identity lived in a vendor database, one key leak compromised every agent, and write access broke the moment the vendor changed auth ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §1). When identity depends on a platform, losing the platform means losing agency.
+
+The drift is the default because it is the path of least resistance. Each vendor feature — managed memory, an assistants API, a hosted agent loop — is individually convenient and collectively a lock-in surface. The question is not whether vendor runtimes are capable. It is whether the things a system must keep should live where the system cannot reach them.
+
+---
+
+## 2. What did Rails teach about replaceable engines?
+
+That conventions outlast engines.
+
+Relational databases in 2004 were powerful, mature, and mutually incompatible. The naive design put application logic where the engine was strongest: stored procedures, vendor SQL dialects, database-specific triggers. That logic was fast and unportable. Switching engines meant rewriting the application.
+
+Rails inverted the dependency. ActiveRecord, migrations, and convention over configuration treated the database as an engine *behind* a convention the framework owned. The database stayed powerful — it still indexed, joined, and enforced constraints — but it stopped being the home of application logic. You could run the same app on Postgres, MySQL, or SQLite because the durable shape lived in the framework, not the engine.
+
+The lesson generalizes: **put the durable, portable intelligence in the convention layer, and treat the powerful component as a replaceable engine behind it.** A convention you own survives an engine you swap.
+
+---
+
+## 3. How does cnos make the model a replaceable engine?
+
+By defining it as a provider the kernel governs, not an authority the system obeys.
+
+The provider contract is explicit about the boundary ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md)):
+
+> **Package distributes. Extension declares. Provider executes. Kernel decides.** (§21)
+
+An LLM backend is a provider — `cnos.llm.local`, `cnos.llm.anthropic` — sitting in the same execution slot as `cnos.net.http` or `cnos.transport.git` (§2.1). It declares what it implements and what it needs; the kernel decides whether it is enabled, which ops it owns, what permissions and limits apply, and whether it is invoked at all (§12). A provider may not widen its own permission envelope (§10). Multiple providers can implement the same capability family without changing the kernel (§3, §19.1). That is the replaceable-engine property, made a runtime invariant.
+
+Model selection is the second half of the move. cnos puts routing in the body/runtime policy layer, not in a skill or a prompt:
+
+> The runtime has no explicit, inspectable policy for when a task should stay local and when it should escalate to a remote frontier model. ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Problem)
+
+The challenged assumption is named directly: "Model selection can be left to the agent's judgment or to free-form prompt instructions" is rejected as not robust enough; provider choice is a body-plane decision about cost, locality, resilience, and capability limits. The design "turns routing into inspectable runtime policy instead of prompt folklore," and every routed call leaves a receipt recording the decision, the reason set, the provider, and the model name. The kernel — not the model — chooses the model.
+
+---
+
+## 4. Where does cnos put the intelligence instead?
+
+In four homes the system owns: cells, packages, receipts, and repo state.
+
+**Cells — the workflow lives in the protocol.** The coherence-cell kernel is a five-step closed loop — `contract → matter → review → receipt → verdict → decision` — and it is **substrate-independent**: it names only roles (α, β, γ, δ, ε), the validator predicate V, and the artifacts it reasons over, with no tooling, platform, or model in the kernel sections ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Kernel). The validator V is executable as a binary (`cn cdd verify`), not a model judgment call (§Hard rule). A model produces matter; the cell decides whether matter passes. Swap the model and the workflow's shape, gates, and verdicts are unchanged.
+
+**Packages — the cognition arrives locally.** Doctrine, mindsets, and skills are distributed as versioned, installable packages so cognition is local, reproducible, and present at wake-up ([`THESIS.md`](../../THESIS.md) §12). Without packages, "skills become checkout-dependent" and "wake-up becomes nondeterministic." The intelligence an agent boots with is a property of its installed substrate, not of a vendor's hidden system prompt.
+
+**Receipts — the proof is reconstructable from files.** The runtime must not merely act; it must explain itself through receipts for every effect, with state reconstructable from files alone ([`THESIS.md`](../../THESIS.md) §11.5, §11.2). Every provider op and every model route emits a typed receipt ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §13; [`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §6). Auditability does not depend on the vendor logging anything.
+
+**Repo state — the identity and memory live in Git.** Identity is keys and signed commits; conversations are append-only thread logs; transport is forge-optional ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §0.0, §6, §8). Git is the lowest durable substrate — where coherence becomes cloneable, signed, diffable, and mergeable ([`THESIS.md`](../../THESIS.md) §13). The agent's memory is in a repo it can clone, not in a database it can lose.
+
+Together these four are what survives a model swap. The model touches all of them and owns none of them.
+
+---
+
+## 5. What does the model still do?
+
+Bounded execution — and at frontier scale, the hardest of it.
+
+This paper does not argue that models are weak or interchangeable in quality. cnos routes single-file, deterministic, low-context work to local models and escalates architecture, cross-package refactors, releases, and policy reconciliation to a frontier provider, because local models still fail too often on macro-coherence work ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §3). The model is often the most capable component in the loop.
+
+What the model does not do is hold authority. It does not decide its own permissions ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §10.1), does not choose which provider runs ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Authority relationships), does not emit the verdict that gates its own output ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Hard rule), and does not own the memory or identity it operates over. "Dumb" is precisely this: powerful at the task, mute on the authority. Capability sits inside the cell; authority sits around it.
+
+---
+
+## 6. What does convention-over-runtime buy?
+
+Four properties, each grounded in a boundary the system already enforces.
+
+- **Swappability.** A new model is a new provider behind an unchanged kernel and unchanged cells ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §3, §19.1). No application rewrite — the Rails property.
+- **Auditability.** Every effect and every route is a receipt; the verdict is an executable predicate, not a vendor's opaque judgment ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §13; [`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Hard rule).
+- **Durability.** Identity, memory, and workflow live in cloneable, signed Git state, so they survive a vendor outage, price change, or shutdown ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §3; [`THESIS.md`](../../THESIS.md) §13).
+- **Cost control.** Routing keeps the baseline local and reserves frontier spend for macro-coherence work, as inspectable policy rather than per-prompt habit ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Leverage).
+
+The common root: each property holds because the durable concern lives in a layer the system owns, not in the engine it rents.
+
+---
+
+## 7. How does this relate to the CN whitepaper and THESIS?
+
+Three papers, three governing questions, one boundary.
+
+| Paper | Governing question | Answer |
+|-------|--------------------|--------|
+| [`WHITEPAPER.md`](../protocol/WHITEPAPER.md) | Where do agents *coordinate*? | Git, with a thin CN convention layer. |
+| [`THESIS.md`](../../THESIS.md) | What *is* cnos? | A recurrent coherence system across all scales. |
+| This paper | Where should agent *intelligence* live? | Outside the vendor model — in cells, packages, receipts, and repo state. |
+
+The CN whitepaper is the **protocol** thesis: it owns the substrate and the wire format. THESIS is the **system** thesis: it owns the coherence principle that unifies every layer. This paper is the **placement** thesis: it owns the comparative argument, aimed at developers, for why intelligence belongs in the convention layer and not the runtime. The CN whitepaper and THESIS are canonical for their scopes; this paper depends on both and specifies neither.
+
+The three share one structural commitment: substrate and convention are owned; engines and projections are replaceable. CN draws that line under transport (forges are projections, the repo is the substrate). THESIS draws it under the whole stack (Git is the lowest durable articulation, not the source of coherence). This paper draws it under the model (the LLM is a provider the kernel governs, not an authority the system obeys).
+
+---
+
+## 8. Conclusion
+
+The default trajectory of agent systems pushes intelligence into the vendor runtime, where it is convenient, capable, and unreachable. Rails showed the alternative twenty years ago: own the conventions, rent the engine.
+
+cnos has already drawn the line in code. The model is a provider the kernel governs ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md)). Routing is inspectable policy, not prompt folklore ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md)). Workflow lives in a substrate-independent cell kernel ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md)). Cognition, proof, and identity live in packages, receipts, and signed Git state ([`THESIS.md`](../../THESIS.md), [`WHITEPAPER.md`](../protocol/WHITEPAPER.md)).
+
+Let the model be smart. Keep the authority in the cells.

--- a/docs/alpha/essays/DUMB-MODELS-SMART-CELLS.md
+++ b/docs/alpha/essays/DUMB-MODELS-SMART-CELLS.md
@@ -1,7 +1,7 @@
 ---
 title: "Dumb Models, Smart Cells"
 subtitle: "Convention over Vendor Runtime for Agent Systems"
-version: v0.1.0
+version: v0.2.0
 status: DRAFT
 author: usurobor (aka Axiom) (human & AI)
 date: 2026-06-22
@@ -10,129 +10,288 @@ date: 2026-06-22
 # Dumb Models, Smart Cells
 ## Convention over Vendor Runtime for Agent Systems
 
-**Status:** v0.1.0 (DRAFT — position paper)
+**Status:** v0.2.0 (DRAFT — position paper)
 **Author(s):** usurobor (aka Axiom) (human & AI)
 **Date:** 2026-06-22
 
-> **Scope:** This paper argues where agent-system intelligence should live. It does not specify the CN wire format (see [`WHITEPAPER.md`](../protocol/WHITEPAPER.md)) or the full cnos architecture (see [`THESIS.md`](../../THESIS.md)). It is a companion to both.
+> **Scope:** This paper explains why cnos treats language models as replaceable executors, not as the home of workflow, memory, identity, or authority. It complements the CN protocol whitepaper, which explains Git as the communication substrate, and `THESIS.md`, which explains cnos as a recurrent coherence system.
 
 ---
 
-## 0. Abstract
+## 0. The claim
 
-**Governing question: where should agent-system intelligence live — inside a proprietary LLM runtime, or inside open conventions, cells, packages, receipts, and repo state?**
+Most developers have seen this trade before.
 
-cnos answers: outside the model. The language model is a powerful but **replaceable executor**. Workflow, memory, identity, and proof live in the convention layer the system owns, not in the vendor runtime it rents.
+In the early Rails era, the database was the powerful engine. It stored the data, ran queries, enforced constraints, and offered its own language for procedures, triggers, and vendor-specific behavior.
 
-"Dumb" here means **non-authoritative**, not low-capability. cnos routes hard, high-context work to frontier models on purpose ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §3). The model can be the smartest component in the system and still hold no durable authority over workflow, state, or trust. Capability is rented; authority is owned.
+One camp put more logic in the database.
+The other camp wanted application logic in code, behind conventions the framework owned.
 
-The argument is an analogy developers already know. Rails treated the database as a powerful but replaceable engine behind conventions — ActiveRecord, migrations, convention over configuration — so application logic lived in the framework, not in vendor-specific stored procedures. cnos treats the LLM the same way: a powerful but replaceable engine behind cells, packages, receipts, and dispatch conventions, so agent logic lives in the repo, not in the vendor runtime.
+Rails made the second bet. Active Record and migrations did not make the database weak. They made the database replaceable enough. The engine stayed powerful. The durable shape moved into the application framework.
 
-This paper shows the boundary is not aspirational. It is already drawn in the provider contract ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §21: *Package distributes. Extension declares. Provider executes. Kernel decides.*).
+cnos makes the same bet for agent systems.
 
----
+The LLM can be very smart inside a task. It can write code, inspect files, draft plans, summarize evidence, and explain tradeoffs.
 
-## 1. Where does intelligence drift by default?
+It still should not own the work.
 
-Into the vendor runtime.
+Workflow, memory, identity, evidence, permissions, receipts, and release authority belong outside the model.
 
-The dominant framing of AI systems says the LLM is the intelligence, tools make it useful, memory makes it durable, and orchestration makes it autonomous ([`THESIS.md`](../../THESIS.md) §1). Followed to its conclusion, that framing pushes every durable concern *into the vendor*: the vendor stores the memory, the vendor runs the agent loop, the vendor defines the threads, the vendor holds the keys.
-
-The cost is structural, not cosmetic. A system organized this way is stateless in essence, fragile in operation, hard to audit, and dependent on a centralized service for its own correctness ([`THESIS.md`](../../THESIS.md) §1). The Moltbook incident is the concrete case: identity lived in a vendor database, one key leak compromised every agent, and write access broke the moment the vendor changed auth ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §1). When identity depends on a platform, losing the platform means losing agency.
-
-The drift is the default because it is the path of least resistance. Each vendor feature — managed memory, an assistants API, a hosted agent loop — is individually convenient and collectively a lock-in surface. The question is not whether vendor runtimes are capable. It is whether the things a system must keep should live where the system cannot reach them.
+Capability is rented.
+Authority is owned.
 
 ---
 
-## 2. What did Rails teach about replaceable engines?
+## 1. The old fork: database engine or application convention?
 
-That conventions outlast engines.
+Relational databases were not dumb in 2004. They were mature, fast, and full of features.
 
-Relational databases in 2004 were powerful, mature, and mutually incompatible. The naive design put application logic where the engine was strongest: stored procedures, vendor SQL dialects, database-specific triggers. That logic was fast and unportable. Switching engines meant rewriting the application.
+That was the temptation.
 
-Rails inverted the dependency. ActiveRecord, migrations, and convention over configuration treated the database as an engine *behind* a convention the framework owned. The database stayed powerful — it still indexed, joined, and enforced constraints — but it stopped being the home of application logic. You could run the same app on Postgres, MySQL, or SQLite because the durable shape lived in the framework, not the engine.
+If the database already had stored procedures, custom functions, triggers, indexes, views, and dialect-specific behavior, why not put more application logic there?
 
-The lesson generalizes: **put the durable, portable intelligence in the convention layer, and treat the powerful component as a replaceable engine behind it.** A convention you own survives an engine you swap.
+Sometimes that was the right local move. The database was close to the data. The vendor had optimized the engine. Teams did not switch databases every week.
 
----
+But the cost was real. The application became harder to move, harder to test from ordinary code, and harder for developers to reason about as one body. Logic split across code and vendor-specific database surfaces.
 
-## 3. How does cnos make the model a replaceable engine?
+Rails gave developers another path: follow the conventions and let the framework map objects to tables, migrations to schema changes, and application code to database operations. The official Rails guide describes Active Record as an ORM layer and names convention over configuration as the way models and tables are mapped.
 
-By defining it as a provider the kernel governs, not an authority the system obeys.
+The database still mattered.
+It just stopped being the place where the application lived.
 
-The provider contract is explicit about the boundary ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md)):
+That is the part worth remembering.
 
-> **Package distributes. Extension declares. Provider executes. Kernel decides.** (§21)
-
-An LLM backend is a provider — `cnos.llm.local`, `cnos.llm.anthropic` — sitting in the same execution slot as `cnos.net.http` or `cnos.transport.git` (§2.1). It declares what it implements and what it needs; the kernel decides whether it is enabled, which ops it owns, what permissions and limits apply, and whether it is invoked at all (§12). A provider may not widen its own permission envelope (§10). Multiple providers can implement the same capability family without changing the kernel (§3, §19.1). That is the replaceable-engine property, made a runtime invariant.
-
-Model selection is the second half of the move. cnos puts routing in the body/runtime policy layer, not in a skill or a prompt:
-
-> The runtime has no explicit, inspectable policy for when a task should stay local and when it should escalate to a remote frontier model. ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Problem)
-
-The challenged assumption is named directly: "Model selection can be left to the agent's judgment or to free-form prompt instructions" is rejected as not robust enough; provider choice is a body-plane decision about cost, locality, resilience, and capability limits. The design "turns routing into inspectable runtime policy instead of prompt folklore," and every routed call leaves a receipt recording the decision, the reason set, the provider, and the model name. The kernel — not the model — chooses the model.
+A powerful engine can sit behind a convention. The convention is what the developer keeps.
 
 ---
 
-## 4. Where does cnos put the intelligence instead?
+## 2. The same fork is happening with LLMs
 
-In four homes the system owns: cells, packages, receipts, and repo state.
+LLM vendors are following the same product gravity.
 
-**Cells — the workflow lives in the protocol.** The coherence-cell kernel is a five-step closed loop — `contract → matter → review → receipt → verdict → decision` — and it is **substrate-independent**: it names only roles (α, β, γ, δ, ε), the validator predicate V, and the artifacts it reasons over, with no tooling, platform, or model in the kernel sections ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Kernel). The validator V is executable as a binary (`cn cdd verify`), not a model judgment call (§Hard rule). A model produces matter; the cell decides whether matter passes. Swap the model and the workflow's shape, gates, and verdicts are unchanged.
+A prompt becomes a thread.
+A thread gets memory.
+Memory gets files.
+Files get tools.
+Tools get workflows.
+Workflows get hosted agents.
+Hosted agents get logs, permissions, background jobs, connectors, deployment surfaces, and team features.
 
-**Packages — the cognition arrives locally.** Doctrine, mindsets, and skills are distributed as versioned, installable packages so cognition is local, reproducible, and present at wake-up ([`THESIS.md`](../../THESIS.md) §12). Without packages, "skills become checkout-dependent" and "wake-up becomes nondeterministic." The intelligence an agent boots with is a property of its installed substrate, not of a vendor's hidden system prompt.
+Each feature is useful by itself.
+Together they turn the vendor runtime into the place where work lives.
 
-**Receipts — the proof is reconstructable from files.** The runtime must not merely act; it must explain itself through receipts for every effect, with state reconstructable from files alone ([`THESIS.md`](../../THESIS.md) §11.5, §11.2). Every provider op and every model route emits a typed receipt ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §13; [`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §6). Auditability does not depend on the vendor logging anything.
+That is not a conspiracy. It is the natural shape of a commercial product. If the vendor owns the engine, the easiest product path is to wrap the engine with more workflow until customers live there.
 
-**Repo state — the identity and memory live in Git.** Identity is keys and signed commits; conversations are append-only thread logs; transport is forge-optional ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §0.0, §6, §8). Git is the lowest durable substrate — where coherence becomes cloneable, signed, diffable, and mergeable ([`THESIS.md`](../../THESIS.md) §13). The agent's memory is in a repo it can clone, not in a database it can lose.
+For application developers, that creates the same old fork.
 
-Together these four are what survives a model swap. The model touches all of them and owns none of them.
+Do you build your system inside the vendor runtime?
+Or do you keep the durable shape in an open convention layer and treat the LLM as one engine behind it?
 
----
-
-## 5. What does the model still do?
-
-Bounded execution — and at frontier scale, the hardest of it.
-
-This paper does not argue that models are weak or interchangeable in quality. cnos routes single-file, deterministic, low-context work to local models and escalates architecture, cross-package refactors, releases, and policy reconciliation to a frontier provider, because local models still fail too often on macro-coherence work ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md) §3). The model is often the most capable component in the loop.
-
-What the model does not do is hold authority. It does not decide its own permissions ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §10.1), does not choose which provider runs ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Authority relationships), does not emit the verdict that gates its own output ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Hard rule), and does not own the memory or identity it operates over. "Dumb" is precisely this: powerful at the task, mute on the authority. Capability sits inside the cell; authority sits around it.
-
----
-
-## 6. What does convention-over-runtime buy?
-
-Four properties, each grounded in a boundary the system already enforces.
-
-- **Swappability.** A new model is a new provider behind an unchanged kernel and unchanged cells ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §3, §19.1). No application rewrite — the Rails property.
-- **Auditability.** Every effect and every route is a receipt; the verdict is an executable predicate, not a vendor's opaque judgment ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md) §13; [`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md), §Hard rule).
-- **Durability.** Identity, memory, and workflow live in cloneable, signed Git state, so they survive a vendor outage, price change, or shutdown ([`WHITEPAPER.md`](../protocol/WHITEPAPER.md) §3; [`THESIS.md`](../../THESIS.md) §13).
-- **Cost control.** Routing keeps the baseline local and reserves frontier spend for macro-coherence work, as inspectable policy rather than per-prompt habit ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md), Leverage).
-
-The common root: each property holds because the durable concern lives in a layer the system owns, not in the engine it rents.
+cnos chooses the second path.
 
 ---
 
-## 7. How does this relate to the CN whitepaper and THESIS?
+## 3. "Dumb" means non-authoritative
 
-Three papers, three governing questions, one boundary.
+"Dumb model" does not mean weak model.
+It means bounded model.
 
-| Paper | Governing question | Answer |
-|-------|--------------------|--------|
-| [`WHITEPAPER.md`](../protocol/WHITEPAPER.md) | Where do agents *coordinate*? | Git, with a thin CN convention layer. |
-| [`THESIS.md`](../../THESIS.md) | What *is* cnos? | A recurrent coherence system across all scales. |
-| This paper | Where should agent *intelligence* live? | Outside the vendor model — in cells, packages, receipts, and repo state. |
+A bounded model can still do hard work. cnos can route low-context work to a local model and escalate architecture, cross-package refactors, release work, and policy reconciliation to a frontier model when the task needs macro-coherence.
 
-The CN whitepaper is the **protocol** thesis: it owns the substrate and the wire format. THESIS is the **system** thesis: it owns the coherence principle that unifies every layer. This paper is the **placement** thesis: it owns the comparative argument, aimed at developers, for why intelligence belongs in the convention layer and not the runtime. The CN whitepaper and THESIS are canonical for their scopes; this paper depends on both and specifies neither.
+The boundary is authority.
 
-The three share one structural commitment: substrate and convention are owned; engines and projections are replaceable. CN draws that line under transport (forges are projections, the repo is the substrate). THESIS draws it under the whole stack (Git is the lowest durable articulation, not the source of coherence). This paper draws it under the model (the LLM is a provider the kernel governs, not an authority the system obeys).
+The model may produce matter.
+The model may propose changes.
+The model may summarize evidence.
+The model may recommend a next move.
+
+But the model does not decide its own permissions. It does not choose its own provider route. It does not validate its own receipt. It does not own identity, memory, or the definition of done.
+
+That is the difference between a smart product and a smart system.
+
+In a smart product, the model runtime absorbs authority.
+In a smart system, the model performs a move inside a boundary the system owns.
 
 ---
 
-## 8. Conclusion
+## 4. The cnos boundary
 
-The default trajectory of agent systems pushes intelligence into the vendor runtime, where it is convenient, capable, and unreachable. Rails showed the alternative twenty years ago: own the conventions, rent the engine.
+cnos draws the boundary in the provider contract.
 
-cnos has already drawn the line in code. The model is a provider the kernel governs ([`PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md)). Routing is inspectable policy, not prompt folklore ([`HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md)). Workflow lives in a substrate-independent cell kernel ([`CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md)). Cognition, proof, and identity live in packages, receipts, and signed Git state ([`THESIS.md`](../../THESIS.md), [`WHITEPAPER.md`](../protocol/WHITEPAPER.md)).
+A provider is an executable capability endpoint. It may be `cnos.llm.local`, `cnos.llm.anthropic`, `cnos.net.http`, or `cnos.transport.git`. The shape is the same: the provider declares what it can do; the kernel decides whether and how it may act.
 
-Let the model be smart. Keep the authority in the cells.
+The provider contract states the rule directly:
+
+> Package distributes. Extension declares. Provider executes. Kernel decides.
+
+That line is the replaceable-engine property.
+
+An LLM backend is not special because it sounds intelligent. It sits in the provider slot. It receives a typed operation, effective permissions, limits, and context. It returns a typed result, artifacts, timing, or an error.
+
+The provider may be powerful.
+The provider is not sovereign.
+
+Routing follows the same rule. Model choice belongs in runtime policy, not in prompt folklore. A skill may shape the task. A command may declare a hint. But the runtime decides which provider runs.
+
+Every routed model call must leave a receipt: route decision, reason set, provider, model name, fallback status, latency, token estimate, and validation signal when available.
+
+That gives cnos the Rails property for models.
+
+Change the engine.
+Keep the application shape.
+
+---
+
+## 5. Where the work lives
+
+If the model does not own the work, something else must.
+
+In cnos, durable work lives in four places: cells, packages, receipts, and repo state.
+
+### Cells own the workflow
+
+A cell is a bounded unit of work. The CDD kernel names the generic loop:
+
+`contract → matter → review → receipt → verdict → decision`
+
+The kernel is substrate-independent. It names roles, artifacts, validator `V`, evidence, verdicts, and decisions. It does not name GitHub, Claude, prompts, CI, branches, or any other invocation surface.
+
+That matters.
+
+A model can produce matter for a cell. But the cell gives the work its shape. The model can change. The cell loop remains.
+
+### Packages own local cognition
+
+Skills, doctrine, runtime adapters, and domain rules arrive as packages.
+
+That means an agent does not depend on a vendor's hidden system prompt to know how this repo works. It wakes into a local body of installed cognition.
+
+The package can be versioned.
+The package can be reviewed.
+The package can be replaced.
+
+### Receipts own evidence
+
+A receipt is the durable close-out artifact.
+
+It records what happened, what evidence was bound, what decision was made, and what can cross the boundary.
+
+The receipt is not a chat summary.
+It is the artifact another human, agent, validator, or release step can inspect later.
+
+### Repo state owns continuity
+
+The repo is the durable software body.
+
+CN uses Git because Git already gives history, signatures, diffs, branches, tags, merges, clones, and offline operation.
+
+Git is not the source of coherence. It is the lowest durable surface where coherence becomes inspectable.
+
+The agent's memory should not disappear when a chat ends.
+The repo remembers.
+
+---
+
+## 6. Why this is an open-source shape
+
+Open source cannot win by copying every vendor feature one at a time.
+
+That game favors the vendor. The vendor can integrate faster, polish harder, subsidize usage, and collapse more of the stack into one product.
+
+Open source wins where Unix and Rails won: small parts, strong conventions, stable interfaces, inspectable state, and community extension.
+
+For agent systems, that means:
+
+> the repo owns state,
+> the runtime owns effects,
+> the protocol owns handoff,
+> the cell owns workflow,
+> the receipt owns evidence,
+> the package owns local cognition,
+> the model owns only the bounded move it was asked to make.
+
+That is the architecture cnos is trying to make normal.
+
+A community can add a package.
+A team can swap a model.
+A domain can define its own evidence.
+A validator can check a receipt.
+A future agent can continue from repo state instead of guessing from chat history.
+
+The model is replaceable because the work has a body outside the model.
+
+---
+
+## 7. What convention-over-runtime buys
+
+This design buys four things.
+
+**Swappability.** A new LLM backend is a new provider behind the same kernel, cells, packages, and receipts. The system does not need to rewrite its workflow when the engine changes.
+
+**Auditability.** Effects and model routes leave receipts. The validator checks artifacts the system owns, not logs hidden inside a vendor product.
+
+**Durability.** Identity, memory, workflow, release notes, tags, and closeout artifacts live in signed repo state. They survive a vendor outage, price change, API change, or product shutdown.
+
+**Cost control.** The runtime can keep simple work local and reserve frontier spend for tasks that need macro-coherence. The decision is policy, not habit.
+
+The common point is simple: keep durable concerns where the system can reach them.
+
+---
+
+## 8. Relationship to the CN whitepaper and THESIS
+
+The CN whitepaper answers a substrate question:
+
+> Where do agents coordinate?
+
+Answer: Git, with a thin CN convention layer.
+
+`THESIS.md` answers the system question:
+
+> What is cnos?
+
+Answer: a recurrent coherence system whose articulations include doctrine, documents, packages, runtime modules, repos, traces, releases, and agents.
+
+This paper answers a placement question:
+
+> Which parts of agent work must not live inside the vendor model?
+
+Answer: workflow, memory, identity, evidence, permissions, receipts, and release authority.
+
+The three papers draw the same boundary at different layers.
+
+CN draws it under transport: forges are projections; the repo is the substrate.
+`THESIS.md` draws it under the whole system: Git is the lowest durable articulation, not the source of coherence.
+This paper draws it under the model: the LLM is a provider the kernel governs, not an authority the system obeys.
+
+---
+
+## 9. Conclusion
+
+Rails did not win by pretending databases were weak.
+It won by putting a strong convention in front of powerful engines.
+
+cnos makes the same move for agent systems.
+
+Let the model be smart.
+Keep memory, workflow, identity, evidence, receipts, and release authority outside it.
+
+Dumb models.
+Smart cells.
+Durable state.
+Governed effects.
+Receipts over vibes.
+
+The model should be smart enough to move the work forward.
+It should be dumb enough not to own the work.
+
+---
+
+## References
+
+- [Rails Guides: Active Record Basics](https://guides.rubyonrails.org/active_record_basics.html)
+- [`docs/alpha/protocol/WHITEPAPER.md`](../protocol/WHITEPAPER.md)
+- [`docs/THESIS.md`](../../THESIS.md)
+- [`docs/alpha/agent-runtime/PROVIDER-CONTRACT-v1.md`](../agent-runtime/PROVIDER-CONTRACT-v1.md)
+- [`docs/alpha/agent-runtime/HYBRID-LLM-ROUTING.md`](../agent-runtime/HYBRID-LLM-ROUTING.md)
+- [`src/packages/cnos.cdd/skills/cdd/CDD.md`](../../../src/packages/cnos.cdd/skills/cdd/CDD.md)

--- a/docs/alpha/essays/README.md
+++ b/docs/alpha/essays/README.md
@@ -9,3 +9,4 @@ Position papers and architectural notes. These predate the doctrine cycle patter
 - [SHIPPING-SOFTWARE-AFTER-AI](SHIPPING-SOFTWARE-AFTER-AI.md) — from H2M to a human triad
 - [AGENT-CONTINUITY](AGENT-CONTINUITY.md) — what persists across runners as the agent
 - [ACTIVATION-NOT-DEPLOYMENT](ACTIVATION-NOT-DEPLOYMENT.md) — activation versus deployment, MCP, memory, runtimes
+- [DUMB-MODELS-SMART-CELLS](DUMB-MODELS-SMART-CELLS.md) — where agent intelligence should live: convention over vendor runtime


### PR DESCRIPTION
Companion position paper to the CN whitepaper and THESIS. Governing
question: where should agent-system intelligence live -- inside a
proprietary LLM runtime, or inside open conventions, cells, packages,
receipts, and repo state? Answer: outside the model.

Grounds the replaceable-executor thesis in boundaries cnos already
enforces -- provider contract (Kernel decides), hybrid LLM routing
(inspectable policy, not prompt folklore), the substrate-independent
CCNF cell kernel, CAR/packages, receipts, and signed Git state. Uses
the Rails/ActiveRecord analogy: own the conventions, rent the engine.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf