### PR TITLE
repo hygiene H2: collapse tools/ → scripts/ci/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,10 +254,10 @@ jobs:
           version: v0.13.2
 
       - name: Schema self-test (positive + negative fixtures)
-        run: ./tools/validate-skill-frontmatter.sh --self-test
+        run: ./scripts/ci/validate-skill-frontmatter.sh --self-test
 
       - name: Validate every SKILL.md frontmatter
-        run: ./tools/validate-skill-frontmatter.sh
+        run: ./scripts/ci/validate-skill-frontmatter.sh
 
   cdd-artifact-check:
     name: CDD artifact ledger validation (I6)

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -9,7 +9,7 @@
 // The module path `cnos.dev/cnos` is a canonical-style placeholder identifier
 // (not a real domain). CUE only requires the path to be stable and unique
 // within the build; resolution is filesystem-relative under `cue.mod/`. The
-// existing `schemas/skill.cue` (used by tools/validate-skill-frontmatter.sh)
+// existing `schemas/skill.cue` (used by scripts/ci/validate-skill-frontmatter.sh)
 // is unaffected — it is invoked directly by path, not by import.
 
 module: "cnos.dev/cnos"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -48,7 +48,7 @@ The validation has two surfaces with one rule each:
 - **`schemas/skill.cue`** — owns shape, type, and enum constraints. CUE
   fails any frontmatter whose fields drift from this declaration. Pure;
   no filesystem I/O.
-- **`tools/validate-skill-frontmatter.sh`** — owns file discovery,
+- **`scripts/ci/validate-skill-frontmatter.sh`** — owns file discovery,
   frontmatter extraction, exception handling, and `calls`
   filesystem-existence checks. This is shell logic that wraps
   `cue vet` per skill.
@@ -123,13 +123,13 @@ You need [CUE](https://cuelang.org/) and `jq` on your `PATH`. Then:
 
 ```bash
 # Validate every src/packages/**/SKILL.md against schema + exceptions.
-./tools/validate-skill-frontmatter.sh
+./scripts/ci/validate-skill-frontmatter.sh
 
 # Run the positive/negative fixture suite (#301 AC8).
-./tools/validate-skill-frontmatter.sh --self-test
+./scripts/ci/validate-skill-frontmatter.sh --self-test
 
 # Validate a single skill file (useful while editing).
-./tools/validate-skill-frontmatter.sh --file src/packages/.../SKILL.md
+./scripts/ci/validate-skill-frontmatter.sh --file src/packages/.../SKILL.md
 ```
 
 `NO_COLOR=1` suppresses color. Findings are emitted one per line in the
@@ -164,7 +164,7 @@ When [LANGUAGE-SPEC.md](../docs/reference/ctb/LANGUAGE-SPEC.md) changes:
      stratification table above. Expect mass exception-list churn.
    - Adding a spec-required-but-exception-backed field: add a `?`
      field in CUE and add it to `SPEC_REQUIRED_EXCEPTION_BACKED` in
-     `tools/validate-skill-frontmatter.sh`.
+     `scripts/ci/validate-skill-frontmatter.sh`.
    - Adding a reserved field validated only if present: add a `?` field
      in CUE; no script change.
    - Tightening an enum: update the disjunction in CUE; expect to amend
@@ -172,7 +172,7 @@ When [LANGUAGE-SPEC.md](../docs/reference/ctb/LANGUAGE-SPEC.md) changes:
 3. Update fixtures in `schemas/fixtures/skill-frontmatter/`:
    - At least one positive fixture must use the new field.
    - At least one negative fixture must violate the new constraint.
-4. Re-run `./tools/validate-skill-frontmatter.sh --self-test` and the
+4. Re-run `./scripts/ci/validate-skill-frontmatter.sh --self-test` and the
    full validation; resolve any new findings before commit.
 
 ## Related issues and specs

--- a/schemas/cdd/README.md
+++ b/schemas/cdd/README.md
@@ -114,7 +114,7 @@ specific keys in the map. This is rejected for the reasons below.
 - A repo-level CUE module file (`cue.mod/module.cue`) is required so
   `schemas/cds/` and `schemas/cdr/` can `import "cnos.dev/cnos/schemas/cdd"`.
   Mitigated: a 2-line file; does not affect the existing
-  `tools/validate-skill-frontmatter.sh` invocations.
+  `scripts/ci/validate-skill-frontmatter.sh` invocations.
 - Phase 3's V acquires a small dispatch layer reading `protocol_id`.
   Mitigated: one switch statement; the alternative (field-shape
   inference) is structurally worse.

--- a/schemas/fixtures/skill-frontmatter/valid/full/SKILL.md
+++ b/schemas/fixtures/skill-frontmatter/valid/full/SKILL.md
@@ -32,7 +32,7 @@ parent: full-fixture
 
 # Full fixture
 
-Used by `tools/validate-skill-frontmatter.sh --self-test` (#301 AC8) to
+Used by `scripts/ci/validate-skill-frontmatter.sh --self-test` (#301 AC8) to
 prove the schema accepts every reserved field, an unknown package-local
 key (`parent:`), and a `calls` target whose existence is checked relative
 to the package skill root.

--- a/schemas/fixtures/skill-frontmatter/valid/minimal/SKILL.md
+++ b/schemas/fixtures/skill-frontmatter/valid/minimal/SKILL.md
@@ -15,5 +15,5 @@ outputs:
 
 # Minimal fixture
 
-Used by `tools/validate-skill-frontmatter.sh --self-test` (#301 AC8) to
+Used by `scripts/ci/validate-skill-frontmatter.sh --self-test` (#301 AC8) to
 prove the schema accepts a skill with only the hard-gate fields.

--- a/schemas/skill.cue
+++ b/schemas/skill.cue
@@ -1,6 +1,6 @@
 // schemas/skill.cue — CUE schema for SKILL.md frontmatter (CTB v0.1).
 //
-// Validated by tools/validate-skill-frontmatter.sh as the I5 coherence-CI
+// Validated by scripts/ci/validate-skill-frontmatter.sh as the I5 coherence-CI
 // job. Field shape, type, and enum constraints live here; file discovery,
 // frontmatter extraction, exception handling, and filesystem path checks
 // are owned by the script (#301 AC2 surface boundary).

--- a/scripts/ci/validate-skill-frontmatter.sh
+++ b/scripts/ci/validate-skill-frontmatter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tools/validate-skill-frontmatter.sh — validate every SKILL.md frontmatter
+# scripts/ci/validate-skill-frontmatter.sh — validate every SKILL.md frontmatter
 # against schemas/skill.cue (#301, I5 coherence-CI job).
 #
 # The CUE schema owns shape / type / enum constraints. This script owns
@@ -13,14 +13,14 @@
 #   2  prerequisite missing (cue, jq) — not a validation failure
 #
 # Usage:
-#   ./tools/validate-skill-frontmatter.sh
+#   ./scripts/ci/validate-skill-frontmatter.sh
 #       Validate all SKILL.md under src/packages/.
-#   ./tools/validate-skill-frontmatter.sh --root <dir>
+#   ./scripts/ci/validate-skill-frontmatter.sh --root <dir>
 #       Validate every SKILL.md under <dir> instead of src/packages/.
-#   ./tools/validate-skill-frontmatter.sh --self-test
+#   ./scripts/ci/validate-skill-frontmatter.sh --self-test
 #       Run schemas/fixtures/skill-frontmatter/{valid,invalid}/ as the
 #       built-in positive/negative regression suite (#301 AC8).
-#   ./tools/validate-skill-frontmatter.sh --file <path>
+#   ./scripts/ci/validate-skill-frontmatter.sh --file <path>
 #       Validate a single SKILL.md path. Used by --self-test internally.
 #
 # Honors NO_COLOR. Diagnostics are machine-readable: one finding per line,


### PR DESCRIPTION
Removes the one-file `tools/` root directory by moving its single CI validator under `scripts/ci/`.

## Changes
- `git mv tools/validate-skill-frontmatter.sh` → **`scripts/ci/validate-skill-frontmatter.sh`** (executable bit preserved; the script resolves paths via `git rev-parse --show-toplevel`, so it runs identically from the new location).
- `.github/workflows/build.yml`: the **I5** `skill-frontmatter-check` job invokes `./scripts/ci/validate-skill-frontmatter.sh` (×2 — `--self-test` + full run). **Path-only.**
- Path-citation repairs (no semantic/schema change): script header comment, `cue.mod/module.cue`, `schemas/README.md`, `schemas/cdd/README.md`, `schemas/skill.cue` comment, and the two self-test fixture SKILL.md **bodies** (frontmatter untouched).
- **`tools/` removed from root.**

CHANGELOG + frozen PRA snapshots keep the old path as history (not edited).

## Notes
- I5 runs **identically** from the new path (it was already an inherited red at ~56 frontmatter findings; this is a relocation, not a fix — the job should produce the same findings, not a script-not-found error). I'll confirm from the I5 log that it still runs.
- No source/package/schema semantics changed.

## Merge posture
Manual δ; **draft until CI confirms** Go/I1/I2/Package/Binary green and I5 runs at its inherited baseline (not a new break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_