### PR TITLE
cycle/524: wake-as-skill W0 design document

### DIFF
--- a/.cdd/unreleased/524/alpha-closeout.md
+++ b/.cdd/unreleased/524/alpha-closeout.md
@@ -1,0 +1,117 @@
+---
+cycle: 524
+role: alpha
+verdict: converge
+date: 2026-06-30 (UTC)
+authored_by: α@cdd.cnos (R0 closeout)
+parent_issue: cnos#524
+round: R0
+beta_verdict: converge
+---
+
+# α-closeout — cnos#524 R0: wake-as-skill W0 design document
+
+## What was implemented
+
+This cycle delivered a single primary artifact: `.cdd/unreleased/524/w0-design.md`, a standalone W0 design document formalizing the wake-as-skill contract. No source code, schema, workflow, or golden file was touched.
+
+The design document is a structured extraction and formal presentation of the design already present in cnos#524 (the `## W0 design (locked)` section and the operator W0-calls comment). It introduces no new design. It covers nine sections (§A through §I):
+
+- §A: Problem statement and invariant (two-system problem; one-system resolution)
+- §B: Complete `wake:` block schema with role-shaped output disjunction and field-by-field cross-reference to both `wake-provider.json` manifests
+- §C: The 5 operator design decisions (nesting, artifact_class, scope, CUE/renderer boundary, body-as-prompt)
+- §D: CUE ↔ renderer responsibility boundary table (15 concerns, cleanly partitioned)
+- §E: Body-as-prompt rule and byte-identity oracle
+- §F: W1→W4 migration plan (4 phases, oracle at each phase boundary)
+- §G: W1 acceptance criteria (AC1–AC7, each with invariant and oracle)
+- §H: Friction notes FN-1 through FN-8 for the W1 implementer
+- §I: Explicit non-goals (8 items)
+
+CDD support artifacts produced: `self-coherence.md §R0` and `beta-review.md §R0`.
+
+Field coverage: all 35 fields from `agent-admin/wake-provider.json` and all 36 fields from `cds-dispatch/wake-provider.json` are accounted for in `w0-design.md §B`. Zero missing.
+
+---
+
+## What worked well
+
+**Scope discipline.** The operator directive restricting this cycle to W0 design only was unambiguous, and the γ scaffold encoded it mechanically in §5 and §7. There was no temptation to begin W1 implementation — the hard scope list made it clear what was out of bounds and why. The scope guardrail confirmation in `self-coherence.md §1` was a clean pass.
+
+**Extraction from a locked design.** Because the W0 design was already operator-ratified in the issue body, α's task was formalization, not invention. This made the work more verifiable and less prone to drift. The field-by-field cross-reference table (§B.3) was the most mechanical part of the work and produced the highest-confidence output — every row is traceable to a specific JSON key in one or both manifests.
+
+**Role-shaped disjunction clarity.** Separating the admin output shape from the dispatch output shape as two distinct YAML blocks in §B.2 (rather than a flat union with optional fields) made the CUE design intent unambiguous. β's internal coherence walk confirmed the two shapes are fully disjoint.
+
+**Nine-section structure from γ scaffold.** The γ scaffold prescribing the exact nine sections (§A–§I) in order eliminated structural ambiguity. β's section-by-section review confirmed all nine sections GREEN without requiring iteration.
+
+**Friction notes as first-class content.** Including FN-1 through FN-8 verbatim in §H, rather than just citing them by reference, means the W1 implementer reads one document and gets the full friction picture without needing to trace back to prior γ scaffolds.
+
+---
+
+## What was challenging
+
+**Naming precision at the CUE/renderer boundary (§D).** The 15-row boundary table required careful judgment on each row: is this a static shape concern (CUE) or a runtime/substrate concern (renderer)? The FN-6 attach-incompatibility refusal was the least clear-cut entry — it is a cross-field runtime condition the renderer enforces, but its trigger condition is not fully documented in the W0 source material. It was correctly assigned to the renderer column, but the exact trigger condition is deferred to the W1 implementer (see FN-6).
+
+**Body authoring precision requirement (§E / AC2).** The body-as-prompt rule is stated clearly but its implementation involves a subtle constraint: the SKILL.md body must equal `prompt.md` verbatim, with verbose prose fields appended after — but the ordering of the appended prose is unspecified. β's Observation 2 correctly flags this as something the byte-identity oracle will enforce rather than the W0 design specifying. The ambiguity is acceptable at W0 but the W1 implementer should be aware.
+
+**Distinguishing `triggers:` (skill-level) from `wake.input.triggers` (substrate-level) (Gap-4).** These two fields share a name stem but serve entirely different purposes. The standard SKILL.md `triggers:` field is the I5/discovery invocation trigger; `wake.input.triggers` carries the GitHub Actions `on:` event set for the renderer. Both must appear on a wake SKILL.md. The W0 design notes the distinction (§B.4), but the potential for W1 authoring confusion is real — this is Gap-4.
+
+---
+
+## Lessons for the W1 implementer
+
+The following eight friction notes (FN-1 through FN-8) from the γ scaffold and `w0-design.md §H` are the primary guidance. Key points amplified here:
+
+**FN-1 (observer role):** Before finalizing `#Wake` in `schemas/skill.cue`, audit `cn-install-wake` for any `observer` role handling. The W0 schema defines `admin | dispatch` only. If `observer` exists in the renderer and live wakes, add it to the enum before the I5 gate validates anything. Do not assume the enum is complete.
+
+**FN-2 (`cue vet` with multi-doc frontmatter):** The I5 extractor must strip the SKILL.md body (everything after the second `---`) before running `cue vet`. Confirm this explicitly — do not rely on `cue vet` tolerating Markdown in the YAML stream.
+
+**FN-3 (`agent_variable.default: null`):** The admin wake's `agent_variable.default` is `null` (operator-required; no default). YAML `null` must round-trip through the frontmatter extractor and through `cue vet` as CUE `null`, not as the empty string or absent. Test this explicitly with a fixture before claiming AC1.
+
+**FN-4 (long `surfaces` arrays):** The `allowed_surfaces` and `disallowed_surfaces` arrays are 8–9 entries each. The CUE schema should use `[...string]` (no length constraint). Confirm the frontmatter extractor handles multi-line YAML arrays of this size without truncation.
+
+**FN-5 (body verbatim constraint):** Do not paraphrase, reformat, or summarize `prompt.md` when authoring the SKILL.md body. Every trailing newline matters for the byte-identity oracle. If `prompt.md` has a trailing newline, the body must too.
+
+**FN-6 (attach-incompatibility refusal):** Before W3 (renderer flip), confirm the exact trigger condition for this refusal from `cn-install-wake` source. AC6 requires it to fire from SKILL.md source. Author a synthetic mis-declared wake SKILL.md fixture to validate it.
+
+**FN-7 (dual-source parity gate):** Design the W2 parity gate before implementing it. Options: a `--source=skill` flag on `cn install-wake`, a temporary parallel render path, or a CI-only comparison step. The gate must not break the existing `install-wake golden` CI check.
+
+**FN-8 (deletion sequencing):** W4 must delete `wake-provider.json` and `prompt.md` in a single commit after byte-identical proof holds in CI — not across multiple commits. If the renderer uses a `SKILL.md then JSON fallback` pattern, the deletion is safe in a single commit. If the fallback path is removed separately, the commit sequence must be designed carefully to avoid a state where neither source is complete.
+
+**Gap-4 reminder:** On each wake SKILL.md, author BOTH `triggers:` (standard skill-level field, describing skill invocation) AND `wake.input.triggers` (renderer-consumed field, encoding the GitHub Actions `on:` event set). They are different fields with different consumers.
+
+---
+
+## The four known gaps (non-blocking)
+
+These gaps were identified in `self-coherence.md §6` and confirmed non-blocking by β. They are recorded here for the W1 implementer.
+
+**Gap-1 — `observer` role:** The W0 `#Wake` schema defines `wake.role: "admin" | "dispatch"`. The renderer may accept an `observer` role internally. The W1 implementer must audit `cn-install-wake` to determine whether `observer` belongs in the `#Wake` CUE enum or remains renderer-internal. This must be resolved before the I5 gate validates the first wake SKILL.md.
+
+**Gap-2 — `defer_path.*` string lengths:** The `defer_path.*` values in the current manifests are long prose strings (multiple sentences). The W0 schema types them as `string` with no length constraint. The W1 implementer must confirm these strings pass `cue vet` cleanly and that the renderer does not parse their content structurally (i.e., they are opaque strings to both CUE and the renderer's structural parser).
+
+**Gap-3 — `governing_question` authorship:** The W0 design does not specify the `governing_question` text for either wake SKILL.md. This is standard skill-authoring work for W1, per the skill-authoring discipline. No design decision is needed; the W1 implementer authors these.
+
+**Gap-4 — `triggers:` (standard) vs `wake.input.triggers` (renderer):** The standard SKILL.md `triggers:` field (skill-level invocation trigger, consumed by the I5/discovery pipeline) is distinct from `wake.input.triggers` (substrate event triggers encoded into the GitHub Actions `on:` block by the renderer). Both fields must appear on each wake SKILL.md. The W1 implementer must author both correctly for each wake.
+
+All four gaps are scoped as W1 implementation concerns. None is a W0 design gap.
+
+---
+
+## Scope violation confirmation
+
+No scope violations. The only diffs on `cycle/524` relative to main that belong to this cycle are under `.cdd/unreleased/524/`. The following files were explicitly NOT touched:
+
+- `schemas/skill.cue`
+- `src/packages/cnos.core/commands/install-wake/cn-install-wake` (renderer)
+- `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json`
+- `src/packages/cnos.core/orchestrators/agent-admin/prompt.md`
+- `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json`
+- `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md`
+- `.github/workflows/*.yml`
+- `*.golden.yml`
+
+No W1, W2, W3, or W4 implementation artifacts were created. β's scope compliance walk confirmed all six scope constraints PASS.
+
+---
+
+_Authored by α@cdd.cnos (R0 closeout), 2026-06-30 (UTC). R0 β-verdict: CONVERGE. Cycle/524 W0 design phase complete; W1→W4 build phases not yet scheduled._

--- a/.cdd/unreleased/524/beta-closeout.md
+++ b/.cdd/unreleased/524/beta-closeout.md
@@ -1,0 +1,67 @@
+---
+cycle: 524
+role: beta
+verdict: converge
+date: 2026-06-30 (UTC)
+authored_by: β@cdd.cnos (R0 closeout)
+parent_review: .cdd/unreleased/524/beta-review.md §R0
+---
+
+# β-closeout — cnos#524 R0
+
+## Review process summary
+
+This was a design-only dispatch. The scope contract was narrow and explicit: α's only permitted writable outputs were `.cdd/unreleased/524/w0-design.md` and the `self-coherence.md §R0` record. No source, schema, workflow, or golden files were in scope.
+
+The review ran in three passes.
+
+**Pass 1 — Scope compliance.** Before opening `w0-design.md`, I walked the branch diff against main. The diff contained exactly four paths: `gamma-scaffold.md` (γ output, pre-existing), `w0-design.md` (α output), `self-coherence.md` (α output), and `.cn-sigma/logs/20260630.md` (heartbeat log, CDD-external). None of the seven constrained paths appeared — `schemas/skill.cue`, `cn-install-wake`, `.github/workflows/*.yml`, `*.golden.yml`, `wake-provider.json` (either wake), `prompt.md` (either wake) — all confirmed absent from the diff. Scope compliance check passed before any content review began.
+
+**Pass 2 — Field coverage walk.** I read both `wake-provider.json` manifests independently and walked every field against `w0-design.md §B.3`. The admin manifest had 35 fields; the dispatch manifest had 36 fields. All 71 field entries resolved cleanly — each mapped to either a `wake.*` frontmatter key, a standard SKILL.md field (`name:`, `description:`), a "not carried / superseded" disposition (`schema`, `prompt_template`), or "→ body" (prose fields per Decision 5). Zero missing fields. The field coverage walk was load-bearing: a missing field here would have been an iterate condition regardless of section completeness.
+
+**Pass 3 — Internal coherence.** Four coherence threads checked: (a) role-shaped output disjunction in §B.2 — admin and dispatch shapes are disjoint and both complete; (b) §F migration plan alignment with the §B schema shape — all four phases are consistent with the field map; (c) §G ACs against §D CUE↔renderer boundary — no AC assigns a runtime refusal to CUE, no AC assigns a static shape constraint to the renderer; (d) §C Decision 5 (body-as-prompt) cross-checked against §E and the §B.3 "→ body" dispositions — all three sections mutually consistent, no field appears in both frontmatter and body disposition.
+
+---
+
+## Verdict rationale
+
+**CONVERGE, not iterate.**
+
+The iterate threshold for a design-only dispatch has three triggers: scope violation (any constrained file touched), section absence (any of §A–§I missing), or field gap (any `wake-provider.json` field unaccounted for in §B). None of these triggered.
+
+The converge case is strong, not marginal:
+
+- Scope: clean by diff inspection.
+- Sections: all nine present and substantive. No section is a placeholder or stub — each has the content structure the γ scaffold specified (e.g., §C has Decision + Rationale + W1 implication for all five decisions; §F has What + Oracle + State-after for all four phases).
+- Field coverage: 71/71 fields covered across both manifests, including edge cases (the `schema` and `prompt_template` fields that are explicitly dropped, the `agent_variable.default: null` encoding noted in FN-3, the long `allowed_surfaces`/`disallowed_surfaces` arrays noted in FN-4).
+- Internal coherence: the CUE↔renderer boundary in §D is respected throughout §C, §F, and §G with no contradiction. The byte-identity oracle in §E is formally stated and cited at each W1→W4 phase boundary.
+
+The only material uncertainty at W0 close is FN-1 (`observer` role in the renderer), which is correctly scoped as a W1 pre-flight check — it is not a W0 design gap because the W0 design makes no claim about the renderer's internal role handling beyond the two documented wakes. The design is complete for what it can know at W0.
+
+---
+
+## Non-blocking observations for the W1 implementer
+
+**OB-1 — FN-1 observer-role pre-flight (renderer enum vs CUE enum).** The `#Wake` schema defines `wake.role: "admin" | "dispatch"`. Before W1 finalizes the CUE definition, the implementer must grep `cn-install-wake` for any `observer` branch and confirm whether it corresponds to a live wake manifest or is dead code. If `observer` appears in any live `wake-provider.json` (beyond the two in scope), the enum must be extended before the CUE vet oracle in AC1 is meaningful. If it is dead code, it can be removed from the renderer in W2 without affecting AC1. This check should be the first action of W1 before any CUE schema is written.
+
+**OB-2 — AC2 body prose ordering (appended fields sequence).** The design (§C Decision 5, §E) specifies that the SKILL.md body equals verbatim `prompt.md` content plus appended prose from the fields moving out of `wake-provider.json`. The ordering of the appended prose block is unspecified. In practice, the ordering matters for human readability and for long-term authoring discipline, but not for the byte-identity oracle (which compares rendered prompt output, not body structure). The W1 implementer should establish a canonical ordering — e.g., `responsibilities` → `cross_references` → notes fields in the order they appear in `wake-provider.json` — and apply it consistently across both SKILL.md bodies. An inconsistent ordering between the two wakes will not break any AC, but will create a maintenance divergence that is harder to reason about during W2–W4.
+
+**OB-3 — Gap-4 triggers distinction (authoring discipline).** `w0-design.md §B.4` correctly names the distinction between `triggers:` (standard SKILL.md field, consumed by the I5/discovery pipeline as skill-level invocation triggers) and `wake.input.triggers` (substrate event triggers, consumed by the renderer and encoded as GitHub Actions `on:` events). These two fields coexist on the same SKILL.md. The authoring risk is conflating them: writing GitHub Actions event names (e.g. `schedule`, `issues_opened_title_match`) into the standard `triggers:` field, or writing skill invocation patterns into `wake.input.triggers`. The byte-identity oracle (AC4) will not catch this conflation — a wake SKILL.md with swapped trigger fields may still render correctly if the renderer reads only `wake.input.triggers` and ignores `triggers:`. The W1 implementer should add an explicit authoring note to the SKILL.md body (or to a W1 implementation note) that distinguishes these two fields by example for each wake before authoring.
+
+---
+
+## Process lessons for future β reviews of design-only dispatches
+
+**1. Scope compliance check before content review — always, and mechanically.** For design-only dispatches the scope check is the highest-leverage step. A scope violation (any constrained file in the diff) is an automatic iterate regardless of content quality. Running `git diff main..cycle/<N> --name-only` before opening any α artifact takes seconds and immediately eliminates the worst failure mode. This review ran the check first; future β reviews of design-only dispatches should make this the documented first step in the review record.
+
+**2. Field coverage walk requires independent manifest reads.** The β review cannot simply trust α's §B.3 cross-reference table — the value of the walk is that β reads the source manifests independently and compares. In this review, reading both `wake-provider.json` files directly (not via α's table) and then cross-checking α's table produced confidence that the coverage was genuine, not just a self-referential claim. For future design-only dispatches that have an authoritative source artifact (a JSON manifest, a schema file, an issue body section), β should read the source independently before checking α's coverage claim.
+
+**3. The "not carried" disposition requires explicit rationale.** Two fields — `schema` and `prompt_template` — were disposed as "not carried" rather than mapped to a frontmatter key or body placement. In this review, the rationale for each was present in the design document (artifact class signals schema version; body IS the prompt). For future design-only reviews, any "not carried" or "dropped" disposition in a field coverage table should be checked against a stated rationale in the document — an unrationalized drop is a potential load-bearing gap.
+
+**4. Internal coherence checks should follow the dependency graph of the document, not the section order.** §A→§I is the reading order, but the coherence threads run across non-adjacent sections: §C Decision 5 ↔ §E ↔ §B.3; §D ↔ §G ACs; §B schema shape ↔ §F migration phases. Walking coherence in section order risks missing cross-section contradictions. Future β reviews should enumerate the coherence threads explicitly (as done here) and walk each thread independently, not as a sequential section pass.
+
+**5. Non-blocking observations should be written at review time, not deferred to closeout.** The three observations in this closeout (OB-1, OB-2, OB-3) were identified during the review and noted in `beta-review.md §R0 Findings`. Writing them there (not only here) ensured they were visible to any reader of the review record before the closeout was written. Future β reviews should record non-blocking observations in the review artifact itself, and the closeout should reference or restate them — not introduce new observations post-verdict.
+
+---
+
+_Filed by β@cdd.cnos, 2026-06-30 (UTC). Cycle/524 R0 closed: CONVERGE. W0 design document complete, scope-clean, field-complete, internally coherent. Handoff to W1 implementer._

--- a/.cdd/unreleased/524/beta-review.md
+++ b/.cdd/unreleased/524/beta-review.md
@@ -1,0 +1,196 @@
+---
+cycle: 524
+parent_issue: cnos#524
+document_class: beta-review
+round: R0
+authored_by: β@cdd.cnos (R0)
+date: 2026-06-30 (UTC)
+base_sha: d7d2244cb4cb95b94e28569ac8ef090d49876c89
+alpha_commit_shas:
+  - 43b1c140016048fe0a1a0843b61e7a69a171eb81  # α-524 W0: w0 design document
+  - ada5f9fa3169698b13f7eb407d4d35733f7f2013  # α-524 R0: self-coherence §R0
+beta_review_timestamp: 2026-06-30T00:00:00Z
+verdict: converge
+---
+
+# β-review — cnos#524 R0
+
+## §R0 Verdict
+
+**CONVERGE**
+
+Scope compliance is clean. All 9 design document sections (§A–§I) are present and complete. Every field from both `wake-provider.json` manifests is accounted for in `w0-design.md §B`. Internal coherence holds across §B, §D, §F, and §G. No W1→W4 implementation artifacts on the branch.
+
+---
+
+## §R0 Scope Compliance Walk
+
+| Constraint | Result | Observation |
+|---|---|---|
+| No changes to `schemas/skill.cue` | PASS | Not in `git diff main..cycle/524 --name-only`; confirmed absent |
+| No changes to `cn-install-wake` or any renderer file | PASS | No `src/packages/cnos.core/commands/install-wake/` path in diff |
+| No changes to `.github/workflows/*.yml` | PASS | No workflow files in diff |
+| No changes to `*.golden.yml` | PASS | No golden files in diff |
+| `wake-provider.json` untouched (both wakes) | PASS | `agent-admin/wake-provider.json` and `cds-dispatch/wake-provider.json` both absent from diff |
+| `prompt.md` untouched (both wakes) | PASS | Neither `agent-admin/prompt.md` nor `cds-dispatch/prompt.md` in diff |
+| No W1→W4 implementation code on the branch | PASS | Diff contains only `.cdd/unreleased/524/gamma-scaffold.md`, `.cdd/unreleased/524/w0-design.md`, `.cdd/unreleased/524/self-coherence.md`, and `.cn-sigma/logs/20260630.md` (heartbeat log; CDD-external) |
+
+**Scope compliance: CLEAN.** The only writable outputs on the branch beyond the γ scaffold are the two α artifacts and the σ heartbeat log.
+
+---
+
+## §R0 Section Table (§A–§I)
+
+| Section | Status | Observation |
+|---|---|---|
+| §A — Problem statement and invariant | GREEN | Two-sentence problem accurately names the two-system problem (JSON+prompt vs SKILL.md). Invariant stated verbatim: "A wake is a typed SKILL.md module whose body is the prompt and whose frontmatter compiles to workflow substrate." Matches γ-scaffold §4.§A requirement. |
+| §B — `wake:` block schema | GREEN | Complete field listing with types, optionality, and notes. §B.1 shows the full `wake:` YAML block. §B.2 presents the role-shaped output disjunction (admin shape vs dispatch shape) as separate YAML blocks. §B.3 is a full cross-reference table mapping every `wake-provider.json` field to its SKILL.md placement (frontmatter key or "→ body"). §B.4 names the standard SKILL.md fields that carry wake data outside the `wake:` block. Field coverage verified independently below. |
+| §C — 5 operator design decisions | GREEN | All 5 decisions present in order: (1) `wake:` nesting, (2) `artifact_class: wake`, (3) `scope: global` / role in `wake.role`, (4) CUE owns typed contract / renderer owns substrate + runtime refusals, (5) prose fields → body. Each decision has a clearly labeled Decision, Rationale, and W1 implication paragraph. |
+| §D — CUE↔renderer boundary table | GREEN | 15-row table. Static shape, enums, role-shaped disjunction, selector shape, concurrency shape, permission_intent array shape, static required-field presence → CUE. Runtime refusals (exit 3 / exit 4 / FN-6), body extraction, install-time substitution, GitHub Actions encoding, bot identity, prompt delivery, pre-W4 JSON presence → renderer. No concern appears in both columns. Consistent with §C Decision 4. |
+| §E — Body-as-prompt rule | GREEN | Frontmatter/body split defined. Rule stated clearly: body (after second `---`) IS the prompt, extracted verbatim. Byte-identity oracle named and formalized: `render(SKILL.md source) == render(wake-provider.json + prompt.md source)`. `install-wake golden` CI check cited as the substrate encoding of the oracle. |
+| §F — W1→W4 migration plan | GREEN | 4 phases present (W1–W4) in order. Each phase: What / Oracle / State-after. W1: author SKILL.md + extend CUE; oracle = I5 count 91→93 + cue vet pass/fail. W2: dual-source parity gate; oracle = `cmp render(SKILL) render(JSON)`. W3: flip renderer source; oracle = `install-wake golden` CI green + re-render diff clean. W4: delete JSON + prompt; oracle = files absent + byte-identical goldens from SKILL.md only + I5 count 93. Byte-identity oracle present at each phase boundary. |
+| §G — W1 ACs (AC1–AC7) | GREEN | All 7 ACs from issue #524 body present. Each AC has Invariant and Oracle sub-sections. AC1: `#Wake` CUE schema. AC2: SKILL.md files authored. AC3: renderer reads SKILL.md. AC4: byte-identical goldens. AC5: JSON + prompt deleted. AC6: renderer refusals preserved (exit 3 / exit 4 / FN-6). AC7: all CI gates green. |
+| §H — Friction notes | GREEN | FN-1 through FN-8 present and carried from prior γ scaffolds (commit `f148a1fd`, updated scaffold at `9a10781d`). All 8 notes named (observer role collision, cue vet multi-doc, null encoding, array length, body verbatim constraint, FN-6 attach-incompatibility, dual-source parity gate implementation, deletion sequencing). Material for W1 implementer. |
+| §I — Non-goals | GREEN | 8 explicit non-goals listed: no rendered-workflow output change, no wake runtime-behavior change, no renderer substrate-encoding change, no new wake names, no Demo 0, no `.cdd/releases/` work, no per-package bot identities, no change to CUE validator script. Consistent with issue body non-goals. |
+
+**All 9 sections: GREEN.**
+
+---
+
+## §R0 Field Coverage Walk
+
+### `agent-admin/wake-provider.json` fields → §B coverage
+
+| JSON field | §B disposition | Status |
+|---|---|---|
+| `schema` | Not carried; artifact class signals schema version | PRESENT |
+| `name` | SKILL.md `name:` (standard skill field) | PRESENT |
+| `package` | `wake.package` | PRESENT |
+| `role` | `wake.role` | PRESENT |
+| `admin_only` | `wake.admin_only` | PRESENT |
+| `activation_log_writer` | `wake.activation_log_writer` | PRESENT |
+| `description` | SKILL.md `description:` (standard skill field) | PRESENT |
+| `responsibilities` | → body | PRESENT |
+| `input_contract.triggers` | `wake.input.triggers` | PRESENT |
+| `input_contract.issues_opened_title_pattern` | `wake.input.issues_opened_title_pattern` | PRESENT |
+| `input_contract.trigger_descriptions` | → body | PRESENT |
+| `input_contract.inbound` | → body | PRESENT |
+| `output_contract.channel_log_convention` | `wake.output.channel_log_convention` | PRESENT |
+| `output_contract.writer_surface` | `wake.output.writer_surface` | PRESENT |
+| `output_contract.class_taxonomy` | `wake.output.class_taxonomy` | PRESENT |
+| `output_contract.class_taxonomy_notes` | → body | PRESENT |
+| `output_contract.cursor_advance` | `wake.output.cursor_advance` | PRESENT |
+| `output_contract.cursor_field` | `wake.output.cursor_field` | PRESENT |
+| `allowed_surfaces` | `wake.surfaces.allowed` | PRESENT |
+| `disallowed_surfaces` | `wake.surfaces.disallowed` | PRESENT |
+| `defer_path.cell_shaped_directive` | `wake.defer_path.cell_shaped_directive` | PRESENT |
+| `defer_path.off_role_directive` | `wake.defer_path.off_role_directive` | PRESENT |
+| `defer_path.ambiguous_directive` | `wake.defer_path.ambiguous_directive` | PRESENT |
+| `prompt_template` | Not carried; body IS the prompt (§E) | PRESENT |
+| `agent_variable.name` | `wake.agent_variable.name` | PRESENT |
+| `agent_variable.default` | `wake.agent_variable.default` | PRESENT |
+| `agent_variable.description` | → body | PRESENT |
+| `permission_intent` | `wake.permission_intent` | PRESENT |
+| `permission_intent_notes` | → body | PRESENT |
+| `concurrency_intent.serialize` | `wake.concurrency.serialize` | PRESENT |
+| `concurrency_intent.group` | `wake.concurrency.group` | PRESENT |
+| `concurrency_intent.notes` | → body | PRESENT |
+| `superseded_substrate_artifact` | → body | PRESENT |
+| `relationship_to_substrate` | → body | PRESENT |
+| `cross_references` | → body | PRESENT |
+
+**agent-admin coverage: 35/35 fields — all PRESENT.**
+
+### `cds-dispatch/wake-provider.json` fields → §B coverage
+
+| JSON field | §B disposition | Status |
+|---|---|---|
+| `schema` | Not carried; artifact class signals schema version | PRESENT |
+| `name` | SKILL.md `name:` (standard skill field) | PRESENT |
+| `package` | `wake.package` | PRESENT |
+| `role` | `wake.role` | PRESENT |
+| `admin_only` | `wake.admin_only` | PRESENT |
+| `activation_log_writer` | `wake.activation_log_writer` | PRESENT |
+| `activation_state` | `wake.activation_state` | PRESENT |
+| `activation_state_notes` | → body | PRESENT |
+| `protocol` | `wake.protocol` | PRESENT |
+| `selector.include` | `wake.selector.include` | PRESENT |
+| `selector.exclude` | `wake.selector.exclude` | PRESENT |
+| `description` | SKILL.md `description:` (standard skill field) | PRESENT |
+| `responsibilities` | → body | PRESENT |
+| `input_contract.triggers` | `wake.input.triggers` | PRESENT |
+| `input_contract.trigger_descriptions` | → body | PRESENT |
+| `input_contract.inbound` | → body | PRESENT |
+| `output_contract.cycle_artifact_root` | `wake.output.cycle_artifact_root` | PRESENT |
+| `output_contract.artifact_class_taxonomy` | `wake.output.artifact_class_taxonomy` | PRESENT |
+| `output_contract.artifact_class_notes` | → body | PRESENT |
+| `output_contract.cell_runtime` | `wake.output.cell_runtime` | PRESENT |
+| `output_contract.cell_runtime_notes` | → body | PRESENT |
+| `allowed_surfaces` | `wake.surfaces.allowed` | PRESENT |
+| `disallowed_surfaces` | `wake.surfaces.disallowed` | PRESENT |
+| `defer_path.cell_shaped_directive` | `wake.defer_path.cell_shaped_directive` | PRESENT |
+| `defer_path.off_role_directive` | `wake.defer_path.off_role_directive` | PRESENT |
+| `defer_path.ambiguous_directive` | `wake.defer_path.ambiguous_directive` | PRESENT |
+| `prompt_template` | Not carried; body IS the prompt (§E) | PRESENT |
+| `agent_variable.name` | `wake.agent_variable.name` | PRESENT |
+| `agent_variable.default` | `wake.agent_variable.default` | PRESENT |
+| `agent_variable.description` | → body | PRESENT |
+| `permission_intent` | `wake.permission_intent` | PRESENT |
+| `permission_intent_notes` | → body | PRESENT |
+| `concurrency_intent.serialize` | `wake.concurrency.serialize` | PRESENT |
+| `concurrency_intent.group` | `wake.concurrency.group` | PRESENT |
+| `concurrency_intent.notes` | → body | PRESENT |
+| `cross_references` | → body | PRESENT |
+
+**cds-dispatch coverage: 36/36 fields — all PRESENT.**
+
+**Field coverage verdict: COMPLETE. Zero missing fields across both manifests.**
+
+---
+
+## §R0 Internal Coherence Walk
+
+### Role-shaped output disjunction (§B.2): admin shape ≠ dispatch shape; both present?
+
+**PASS.** §B.2 presents two distinct named YAML blocks:
+- Admin shape (`wake.role == "admin"`): `channel_log_convention`, `writer_surface`, `class_taxonomy`, `cursor_advance`, `cursor_field` — all sourced from `agent-admin/wake-provider.json output_contract`. All 5 admin-specific output fields present.
+- Dispatch shape (`wake.role == "dispatch"`): `cycle_artifact_root`, `artifact_class_taxonomy`, `cell_runtime` — all sourced from `cds-dispatch/wake-provider.json output_contract`. All 3 dispatch-specific output fields present.
+The two shapes are disjoint: no field appears in both. The disjunction is correctly role-gated and will require CUE to enforce field presence based on `wake.role` value.
+
+### §F migration plan consistent with §B schema shape?
+
+**PASS.** W1 authors SKILL.md with the `wake:` block per §B — consistent. W2 extends the renderer to read `wake:` frontmatter (§D renderer column fields) and body — consistent with §B field map. W3 flips source; the §B schema shape is unchanged — consistent. W4 deletes JSON + prompt; only the §B schema shape survives — consistent. The I5 count progression (91 → 93) matches §C Decision 2 (two wake SKILL.md files added to the `artifact_class: wake` discovery).
+
+### §G ACs consistent with §D CUE↔renderer boundary?
+
+**PASS.**
+- AC1 (`#Wake` CUE schema): covers static shape, enums (`wake.role`, `wake.activation_state`, `wake.permission_intent` values), role-shaped output disjunction, `selector` shape, `concurrency` shape, `permission_intent` array — these are precisely the CUE column entries in §D. No AC1 item crosses into the renderer column.
+- AC3 (renderer reads SKILL.md): body extraction, install-time substitution — renderer column in §D. No CUE involvement.
+- AC6 (refusals preserved): `activation_state` gating (exit 3), `activation_log_writer` mis-declaration (exit 4), FN-6 attach-incompatibility — all renderer column in §D. No CUE involvement. AC6 correctly cites the existing cycle/496 mis-declaration smoke as the oracle.
+- No AC asks CUE to enforce a runtime refusal; no AC asks the renderer to enforce static shape. Boundary is respected throughout.
+
+### §C Decision 5 (body-as-prompt) consistent with §E and §B.3 disposition map?
+
+**PASS.** §C Decision 5 names the specific verbose fields that move to body: `responsibilities`, `*_notes`, `cross_references`, `trigger_descriptions`, `relationship_to_substrate`, `superseded_substrate_artifact`, `agent_variable.description`. §B.3 marks each of these "→ body". §E states the body IS the prompt (verbatim `prompt.md` + moved prose). All three sections are mutually consistent — no field appears as both "→ body" and as a `wake.*` frontmatter key.
+
+### Self-coherence artifact consistency?
+
+**PASS.** α's `self-coherence.md §R0` performs the same field-coverage walk independently and reaches the same verdict (all fields covered, zero missing). The section walk in self-coherence aligns with the actual content of `w0-design.md`. The known gaps (FN-1 `observer` role, Gap-2 `defer_path` string lengths, Gap-3 `governing_question` authorship, Gap-4 `triggers:` vs `wake.input.triggers` distinction) are appropriately scoped as W1 implementation concerns, not W0 design gaps.
+
+---
+
+## §R0 Findings
+
+No blocking findings. No iterate conditions triggered.
+
+**Observations (non-blocking; for W1 implementer context):**
+
+1. **FN-1 observer role (carried forward):** The W0 `#Wake` schema defines `wake.role: "admin" | "dispatch"` only. If the renderer internally supports an `observer` role, this must be resolved before W1 finalizes the `#Wake` enum. α's Gap-1 correctly flags this; it is a W1 pre-flight check, not a W0 design gap.
+
+2. **AC2 body authoring precision:** §E and §C Decision 5 require the SKILL.md body to equal `prompt.md` verbatim plus appended prose from moved fields. The ordering of appended prose (which notes fields appear in which sequence) is left to the W1 implementer. The byte-identity oracle (AC4) will catch any divergence from the rendered prompt.
+
+3. **Gap-4 (triggers: vs wake.input.triggers):** The design correctly distinguishes standard SKILL.md `triggers:` (skill-level invocation triggers for the I5/discovery pipeline) from `wake.input.triggers` (substrate event triggers encoded by the renderer). §B.4 names this distinction. The W1 implementer must author both fields correctly on each wake SKILL.md.
+
+---
+
+_Reviewed by β@cdd.cnos (R0), 2026-06-30 (UTC). Verdict: CONVERGE. No iterate conditions. α's W0 design document is complete, field-complete, scope-clean, and internally coherent._

--- a/.cdd/unreleased/524/gamma-closeout.md
+++ b/.cdd/unreleased/524/gamma-closeout.md
@@ -1,0 +1,100 @@
+---
+cycle: 524
+verdict: converge
+base_sha: d7d2244cb4cb95b94e28569ac8ef090d49876c89
+head_sha_at_closeout: fc27cad16792b20c0fdd6b6248c1667ef35d2956
+date: 2026-06-30 (UTC)
+authored_by: γ@cdd.cnos (R0 closeout)
+round: R0
+---
+
+# γ-closeout — cnos#524 R0
+
+## §1. Cycle outcome
+
+**Verdict: CONVERGE.** R0 delivered the W0 design document for the wake-as-skill migration (cnos#524) and closed clean. β found no blocking findings; no iterate was triggered; the γ→α→β→γ routing ran to completion in a single round.
+
+**Calibrated success claim:** cycle/524 R0 produced a complete, field-complete, scope-clean, internally coherent W0 design document (`w0-design.md`) that formalizes the operator-ratified design from issue #524 body and the first @usurobor comment. The document is independently readable, names each of the 5 operator design decisions with rationale and W1 implication, provides a full field-to-placement mapping for both `wake-provider.json` manifests (35/35 agent-admin fields, 36/36 cds-dispatch fields, zero missing), and specifies the W1→W4 migration plan with byte-identity oracle at each phase boundary. No source, schema, workflow, or golden files were touched. The only diff on `cycle/524` relative to `main` is under `.cdd/unreleased/524/` (plus the σ heartbeat log entry at `.cn-sigma/logs/20260630.md`).
+
+---
+
+## §2. Process-gap audit
+
+### §2.1 Did the cycle process work as intended?
+
+Yes, with one structural note below. The scope override (operator DISPATCH DIRECTIVE) was propagated cleanly: the γ-scaffold named the scope constraint explicitly (§1 and §7), the α dispatch prompt restated the hard constraints, and α produced only the permitted outputs. β's scope compliance walk confirmed all 6 scope constraints PASS. No cell touched a guarded file.
+
+The γ-scaffold was updated once during the cycle (commit `9a10781d`) to tighten the W0-only framing after the base scaffold (`f148a1fd`) was written against the broader W1→W4 scope. This mid-cycle scaffold update was appropriate and worked correctly — α read the updated scaffold and operated against the W0-only constraints. There was no confusion or scope drift.
+
+### §2.2 Friction in γ→α→β routing
+
+**No routing friction.** The γ→α→β chain ran in correct sequence. No re-routing, no mid-cycle escalation, no round-trip required. α's self-coherence artifact was well-formed and made β's review straightforward — β could confirm α's field-coverage walk against the actual documents rather than re-deriving it from scratch.
+
+**Minor observation — two γ scaffold commits:** The cycle has two γ scaffold commits (`f148a1fd`, `9a10781d`) on the branch. This is because the initial scaffold pre-dated the operator DISPATCH DIRECTIVE comment and had to be re-scoped. This is not a process failure — the operator directive was posted after the initial scaffold — but it adds a minor artifact: anyone reading the commit log sees the W1→W4 scaffold commit before the W0-only correction. For future cycles, if an operator directive is known at dispatch time, the scope override should be baked into the first scaffold commit.
+
+### §2.3 Friction notes from β review needing follow-up issues
+
+β identified three non-blocking observations. None triggered iterate. All three are material for the W1 implementer's pre-flight checklist:
+
+**Obs-1 (FN-1 observer role) — needs W1 pre-flight check:**
+The W0 `#Wake` schema defines `wake.role: "admin" | "dispatch"` only. If the renderer internally supports an `observer` role, this must be resolved before the `#Wake` CUE enum is finalized in W1 (AC1). The W1 implementer must audit `cn-install-wake` for the `observer` path before locking the enum.
+
+No new issue needed: this is already FN-1 in `w0-design.md §H` and flagged as Gap-1 in `self-coherence.md §R0`. The W1 γ-scaffold should surface this as a required pre-flight step.
+
+**Obs-2 (AC2 body authoring precision) — implementation detail for W1:**
+The ordering of prose fields appended to the SKILL.md body (after the verbatim `prompt.md` content) is unspecified in the W0 design. The byte-identity oracle (AC4) will catch any divergence from the rendered prompt. The W1 implementer has latitude on ordering as long as the rendered body equals the prompt.md content exactly (the appended notes/cross_references are not consumed by the renderer structurally, so their ordering does not affect the byte-identity oracle).
+
+No new issue needed: this is an implementation-time authoring decision. Noted here for the W1 γ-scaffold.
+
+**Obs-3 (Gap-4 triggers: vs wake.input.triggers) — naming precision for W1:**
+The design correctly distinguishes standard SKILL.md `triggers:` (skill-level invocation triggers for the I5 discovery pipeline) from `wake.input.triggers` (substrate event triggers encoded by the renderer into the GitHub Actions `on:` block). The W1 implementer must author both correctly. §B.4 of `w0-design.md` names this distinction.
+
+No new issue needed: captured in `self-coherence.md §R0` Gap-4. The W1 γ-scaffold should call this out explicitly in the α dispatch prompt.
+
+---
+
+## §3. Carryforward items for future cycles
+
+All items below are non-blocking W1 implementation concerns. None unblocked R0. Carried forward to the W1 cycle γ-scaffold.
+
+| ID | Item | Source | Disposition for W1 |
+|---|---|---|---|
+| CF-1 | FN-1: `observer` role audit in renderer | `w0-design.md §H` / β Obs-1 | W1 pre-flight: audit `cn-install-wake` before locking `#Wake` role enum in `schemas/skill.cue` |
+| CF-2 | FN-2: `cue vet` multi-doc frontmatter handling | `w0-design.md §H` | W1 pre-flight: confirm I5 extractor strips body before `cue vet`; test with both wake SKILL.md files |
+| CF-3 | FN-3: `agent_variable.default: null` round-trip | `w0-design.md §H` | W1 pre-flight: test `null` through frontmatter extractor and `cue vet`; confirm CUE schema encodes `null` correctly |
+| CF-4 | FN-4: `surfaces.allowed` / `surfaces.disallowed` array length | `w0-design.md §H` | W1 pre-flight: confirm extractor handles 8–9 entry YAML arrays without truncation |
+| CF-5 | FN-5: Body verbatim constraint (trailing newline) | `w0-design.md §H` | W1 authoring discipline: preserve `prompt.md` trailing newline exactly; byte-identity oracle will catch divergence |
+| CF-6 | FN-6: attach-incompatibility refusal trigger condition | `w0-design.md §H` | W1 pre-flight: confirm exact trigger condition from `cn-install-wake` source before W3 renderer flip; include synthetic SKILL.md fixture for AC6 smoke |
+| CF-7 | FN-7: Dual-source parity gate implementation design | `w0-design.md §H` | W1 implementer decision: design the parity gate mechanism (flag, parallel render path, or CI-only comparison) before W2 work begins |
+| CF-8 | FN-8: Deletion sequencing (W4) | `w0-design.md §H` | W1 implementer discipline: W4 deletion in a single commit after byte-identical proof holds in CI |
+| CF-9 | Gap-3: `governing_question` authorship | `self-coherence.md §R0` | W1 authoring task: author `governing_question` for both wake SKILL.md files per skill-authoring discipline |
+| CF-10 | Gap-4: `triggers:` vs `wake.input.triggers` distinction | `self-coherence.md §R0` / β Obs-3 | W1 authoring task: author standard `triggers:` and `wake.input.triggers` correctly on each wake SKILL.md; γ-scaffold should call this out explicitly |
+| CF-11 | AC2 body ordering | β Obs-2 | W1 implementer latitude: ordering of appended prose after verbatim `prompt.md` content; byte-identity oracle governs correctness |
+
+---
+
+## §4. Scope guardrail confirmation (γ view)
+
+The PR branch (`cycle/524`) diff against `main` contains only:
+- `.cdd/unreleased/524/gamma-scaffold.md` (γ artifact, two commits)
+- `.cdd/unreleased/524/w0-design.md` (α artifact)
+- `.cdd/unreleased/524/self-coherence.md` (α artifact)
+- `.cdd/unreleased/524/beta-review.md` (β artifact)
+- `.cdd/unreleased/524/gamma-closeout.md` (this document)
+- `.cn-sigma/logs/20260630.md` (σ heartbeat log; CDD-external)
+
+No source, schema, workflow, or golden file is in the diff. Scope guardrails: CLEAN.
+
+---
+
+## §5. Next step
+
+The W0 design is locked. The next cycle for cnos#524 is the W1 implementation cycle (AC1–AC7). The W1 cycle γ-scaffold should:
+1. Set scope to W1 only (not W2–W4) if the operator applies a phased directive, or W1→W4 if the operator opens the full build scope.
+2. Surface CF-1 through CF-10 as pre-flight checks in the α dispatch prompt.
+3. Reference `w0-design.md` as the authoritative design source (not the issue body directly).
+4. Specify the exact `#Wake` CUE definition α must author, derived from `w0-design.md §B`.
+
+---
+
+_Filed by γ@cdd.cnos (R0 closeout), 2026-06-30 (UTC). Cycle/524 R0: CONVERGE. W0 design delivered and ratified. W1 cycle pending operator dispatch._

--- a/.cdd/unreleased/524/gamma-scaffold.md
+++ b/.cdd/unreleased/524/gamma-scaffold.md
@@ -3,8 +3,8 @@ cycle: 524
 parent_issue: cnos#524
 protocol: cds
 cycle_branch: cycle/524
-base_main_sha: 667388ce30d58a335e44dbf98217eb52eb789d9b
-head_sha_at_scaffold: (filled by scaffold-landing commit)
+base_main_sha: d7d2244cb4cb95b94e28569ac8ef090d49876c89
+head_sha_at_scaffold: d7d2244cb4cb95b94e28569ac8ef090d49876c89
 mode: MCA
 role: γ
 authored_by: γ@cdd.cnos (wake-invoked δ dispatch)
@@ -225,7 +225,7 @@ cn install-wake cds-dispatch  # exit 0; golden unchanged
 | Axis | Value |
 |---|---|
 | **Branch** | `cycle/524` |
-| **Base SHA** | `667388ce30d58a335e44dbf98217eb52eb789d9b` |
+| **Base SHA** | `d7d2244cb4cb95b94e28569ac8ef090d49876c89` |
 | **Issue** | cnos#524 |
 | **Mode** | MCA — W0 operator-ratified; α executes W1→W4 sequence |
 | **AC set** | AC1–AC7 (all) |
@@ -238,7 +238,7 @@ cn install-wake cds-dispatch  # exit 0; golden unchanged
 ```text
 You are α@cdd.cnos, running as the implementer for cycle/524.
 
-Branch: cycle/524 (at base main SHA 667388ce30d58a335e44dbf98217eb52eb789d9b).
+Branch: cycle/524 (at base main SHA d7d2244cb4cb95b94e28569ac8ef090d49876c89).
 Parent issue: cnos#524 ("wake-as-skill: migrate wakes to typed SKILL.md modules").
 Scaffold: .cdd/unreleased/524/gamma-scaffold.md (READ THIS FIRST in full before any edits).
 
@@ -258,7 +258,7 @@ Load these skills in order:
 | Axis | Value |
 |---|---|
 | Branch | cycle/524 |
-| Base SHA | 667388ce30d58a335e44dbf98217eb52eb789d9b |
+| Base SHA | d7d2244cb4cb95b94e28569ac8ef090d49876c89 |
 | Issue | cnos#524 |
 | Mode | MCA — execute known W1→W4 sequence; W0 is locked |
 | AC set | AC1–AC7 (all) |

--- a/.cdd/unreleased/524/gamma-scaffold.md
+++ b/.cdd/unreleased/524/gamma-scaffold.md
@@ -10,712 +10,252 @@ role: γ
 authored_by: γ@cdd.cnos (wake-invoked δ dispatch)
 date: 2026-06-30 (UTC)
 output_contract: γ-scaffold + α prompt + β prompt
-ac_set: cnos#524 body ACs 1–7
+dispatch_scope: W0-design-only
+scope_override_reason: operator-directive-2026-06-30
+ac_set: W0 design document (not issue AC1–AC7; those are W1→W4 scope)
 w0_locked: true
 ---
 
-# γ-scaffold — cnos#524: wake-as-skill migration W1→W4
+# γ-scaffold — cnos#524: wake-as-skill W0 design document
 
-## §1. Issue framing
+## §1. Scope
 
-**The problem.** Wakes today use two artifact systems in parallel: `wake-provider.json` (machine-readable manifest) + `prompt.md` (prompt body), compiled by `cn install-wake` into `.github/workflows/cnos-<wake>.yml`. The SKILL.md contract system (frontmatter + body + CUE validation by I5) runs beside this — not over it. Two contract systems means two maintenance surfaces, two validation pipelines, and no single source of truth for what a wake is.
+**This dispatch is W0 design only.** The W1→W4 build ACs (AC1–AC7) in the issue body are explicitly NOT in scope for this run. The operator DISPATCH DIRECTIVE (issue #524 comment "⛳ DISPATCH DIRECTIVE") governs this cycle.
 
-**The goal.** One contract system. A wake becomes a typed SKILL.md module: `artifact_class: wake`, a `wake:` frontmatter block validated by CUE carrying exactly what `wake-provider.json` carries today, and a body that IS `prompt.md` verbatim. The renderer reads SKILL.md; JSON + prompt are deleted after byte-identical proof.
+**Scope override reason:** The operator directive restricts this dispatch to W0 design work:
+> "This is W0 design only. Do not start W1. Do not change renderer code. Do not change CUE schema. Do not change workflows. Do not change goldens. Do not delete wake-provider.json or prompt.md."
 
-**Migration shape.** Four phases (W0 operator-ratified and locked):
+**What this cycle delivers:**
+- `.cdd/unreleased/524/w0-design.md` — a standalone W0 design document formalizing the wake-as-skill contract
+- Normal CDD closeout records (`self-coherence.md`, `beta-review.md`, closeouts)
+- A PR containing ONLY the design artifact and CDD artifacts (no source/schema/workflow changes)
 
-- **W1:** Author both SKILL.md files beside existing JSON/prompt (body = prompt.md verbatim). Add `#Wake` + `artifact_class: wake` to `skill.cue`. Renderer still reads JSON → goldens unchanged.
-- **W2:** Teach `cn-install-wake` to read SKILL.md; dual-source parity gate: render(SKILL) byte-identical to render(JSON).
-- **W3:** Flip renderer source to SKILL.md; re-render (no-op if byte-identical).
-- **W4:** Delete `wake-provider.json` + `prompt.md` for both wakes after byte-identical proof; I5 now covers 91→93 modules.
+**What this cycle explicitly does NOT deliver:**
+- Any changes to `schemas/skill.cue`
+- Any changes to `src/.../cn-install-wake`
+- Any `.github/workflows/*.yml` changes
+- Any `*.golden.yml` changes
+- Deletion or editing of `wake-provider.json` or `prompt.md`
 
-**Byte-identity is the migration oracle at every step.**
+## §2. W0 design context (what α will formalize)
 
-## §2. Source-of-truth table
+The W0 design is already complete and operator-ratified. It lives in two places:
+1. **Issue body** (`cnos#524 §"W0 design (locked)")** — the locked design block with the `wake:` block shape, CUE↔renderer boundary, and W1→W4 migration plan
+2. **Operator W0 calls comment** (issue #524, first comment by @usurobor) — the 5 design decisions
 
-| Surface | Path |
-|---|---|
-| CUE schema | `schemas/skill.cue` |
-| I5 validator | `scripts/ci/validate-skill-frontmatter.sh` |
-| Renderer | `src/packages/cnos.core/commands/install-wake/cn-install-wake` |
-| Golden CI | `.github/workflows/install-wake-golden.yml` |
-| agent-admin manifest | `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` |
-| agent-admin prompt | `src/packages/cnos.core/orchestrators/agent-admin/prompt.md` |
-| agent-admin golden | `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` |
-| cds-dispatch manifest | `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` |
-| cds-dispatch prompt | `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md` |
-| cds-dispatch golden | `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` |
-| Live admin workflow | `.github/workflows/cnos-agent-admin.yml` |
-| Live dispatch workflow | `.github/workflows/cnos-cds-dispatch.yml` |
-| agent-admin SKILL.md (to create) | `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` |
-| cds-dispatch SKILL.md (to create) | `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` |
+The W0 design document α authors is a FORMAL EXTRACTION and PRESENTATION of this design, not a new design. α reads the issue body and the operator W0 calls comment, then structures them into a design document that:
+- Can be read and reviewed independently of the issue
+- Names each design decision explicitly with its rationale
+- Defines the schema precisely enough for a future W1 implementer
+- Is internally coherent (no drift between the schema shape and the migration plan)
 
-## §3. Surfaces α will touch
+## §3. Source-of-truth table
 
-### Files to READ (source inputs):
-1. `schemas/skill.cue` — current `#Skill` definition; where to graft `#Wake` and extend `artifact_class`
-2. `src/packages/cnos.core/commands/install-wake/cn-install-wake` — every field consumed from `wake-provider.json` (lines 283–376); every renderer validation path
-3. `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` — agent-admin manifest data
-4. `src/packages/cnos.core/orchestrators/agent-admin/prompt.md` — agent-admin prompt body (verbatim into SKILL.md body)
-5. `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` — cds-dispatch manifest data
-6. `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md` — cds-dispatch prompt body (verbatim into SKILL.md body)
-7. `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` — current golden (byte-identity anchor)
-8. `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` — current golden (byte-identity anchor)
-9. `.github/workflows/install-wake-golden.yml` — CI oracle; where to add dual-source parity gate and W4 deletion proof
-10. `scripts/ci/validate-skill-frontmatter.sh` — I5 validator; confirms discovery pattern (`find src/packages -name SKILL.md`) picks up orchestrator SKILL.mds automatically
-11. `schemas/skill-exceptions.json` — check if any exception entries affect the new SKILL.mds
-12. An existing SKILL.md with a full field set (e.g., `src/packages/cnos.cds/skills/cds/SKILL.md`) for format reference
-
-### Files to MODIFY:
-1. `schemas/skill.cue` — add `"wake"` to `artifact_class` enum; add `#Wake` definition
-2. `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` — **CREATE** (W1 deliverable)
-3. `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` — **CREATE** (W1 deliverable)
-4. `src/packages/cnos.core/commands/install-wake/cn-install-wake` — W2: SKILL.md reader path; W2: dual-source parity; W3: flip source; W4: operate from SKILL.md only
-5. `.github/workflows/install-wake-golden.yml` — add: dual-source parity step (W2), SKILL.md-source render verification (W3), deletion-proof step (W4), I5 count step (91→93)
-6. `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` — W3 re-render (no-op expected if byte-identical); W4 confirm unchanged
-7. `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` — W3 re-render (no-op expected); W4 confirm unchanged
-8. `.github/workflows/cnos-agent-admin.yml` — W3/W4 re-render for live substrate (no-op expected)
-9. `.github/workflows/cnos-cds-dispatch.yml` — W3/W4 re-render for live substrate (no-op expected)
-
-### Files to DELETE (W4 only, after byte-identical proof):
-1. `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json`
-2. `src/packages/cnos.core/orchestrators/agent-admin/prompt.md`
-3. `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json`
-4. `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md`
-
-## §4. AC oracle table
-
-### AC1 — `#Wake` schema in CUE
-
-**Oracle:** `cue vet -d '#Wake' schemas/skill.cue <wake-frontmatter.yaml>` passes for a conformant wake SKILL.md frontmatter; fails with a diagnostic naming the bad field for a manifest with a bad enum or missing required field.
-
-**Testable boundary:** `schemas/skill.cue` adds:
-- `"wake"` to the `artifact_class` enum in `#Skill`
-- A new `#Wake` definition with the W0-locked shape (role enum; bool fields; enums; nested objects per §W0 design block)
-
-**Filesystem check:**
-```sh
-grep -c '"wake"' schemas/skill.cue  # must return >= 1
-cue vet -d '#Wake' schemas/skill.cue /tmp/conformant-wake.yaml  # exit 0
-cue vet -d '#Wake' schemas/skill.cue /tmp/bad-enum-wake.yaml    # exit nonzero + diagnostic
-```
-
-**Key `#Wake` fields (from W0 design + renderer field consumption at lines 283–523 of cn-install-wake):**
-
-| Field | Type | Notes |
+| Surface | Path | Role |
 |---|---|---|
-| `wake.role` | `"admin" \| "dispatch"` | renderer line 342: enum check; cross-field invariants |
-| `wake.package` | `string` | renderer line 281 schema check |
-| `wake.admin_only` | `bool` | renderer line 309/353 |
-| `wake.activation_log_writer` | `bool` | renderer line 452 |
-| `wake.activation_state` | optional `"live" \| "declaration-only"` | renderer line 386 |
-| `wake.protocol` | optional `string` | required when `role == "dispatch"` per renderer line 367 |
-| `wake.selector` | optional `{include: [...string], exclude: [...string]}` | required when `role == "dispatch"` per renderer lines 369-372 |
-| `wake.input.triggers` | `[...string]` | renderer line 338 |
-| `wake.output` | role-shaped disjunction | admin: `{channel_log_convention: string}`; dispatch: `{cycle_artifact_root: string, artifact_class_taxonomy: [...string], cell_runtime: string}` |
-| `wake.permission_intent` | `[...string]` | renderer lines 614-628 |
-| `wake.concurrency` | `{serialize: bool, group: string}` | renderer lines 493-495 |
-| `wake.agent_variable` | `{name: string, default: string \| null}` | renderer lines 85-89 |
+| Issue body (W0 design section) | GitHub issue #524 body | Primary source; contains locked W0 design |
+| Operator W0 calls comment | First @usurobor comment on #524 | The 5 operator decisions |
+| w0-design.md (to create) | `.cdd/unreleased/524/w0-design.md` | α's output artifact |
+| Current wake manifests (read-only) | `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json`<br>`src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` | Reference: what the `wake:` block must capture |
+| Current skill CUE schema (read-only) | `schemas/skill.cue` | Reference: what `#Skill` looks like; where `#Wake` will extend it |
 
-**Non-goal:** `#Wake` does NOT carry `responsibilities`, `*_notes`, `cross_references` — those move to body per W0 call #5.
+## §4. W0 design document structure (α deliverable)
 
-### AC2 — Wake SKILL.md modules authored
+The `w0-design.md` α produces MUST contain these sections in order:
 
-**Oracle:** `scripts/ci/validate-skill-frontmatter.sh` validates both new SKILL.md files — total count advances from 91 to 93; self-test green.
+### §A. Problem statement and invariant
+- Two-sentence problem: two contract systems, should be one
+- The invariant: "A wake is a typed SKILL.md module whose body is the prompt and whose frontmatter compiles to workflow substrate"
 
-**Testable boundary:**
-- `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` exists with `scope: global`, `artifact_class: wake`, `wake:` block carrying exact current `wake-provider.json` data; body = current `prompt.md` verbatim.
-- `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` exists with same shape; dispatch-specific `wake:` fields.
-- Verbose fields (`responsibilities`, `*_notes`, `cross_references`) are in the body, not frontmatter.
+### §B. The `wake:` block schema (the `#Wake` CUE definition)
+- Complete field listing with types, enums, optionality, and notes
+- Source: issue body `## W0 design → wake: block` + operator W0 calls comment
+- Must include ALL fields the renderer currently reads from `wake-provider.json` (cross-referenced against the source manifests)
+- Must show the role-shaped output disjunction (admin vs dispatch shapes)
 
-**Filesystem check:**
-```sh
-ls src/packages/cnos.core/orchestrators/agent-admin/SKILL.md  # exists
-ls src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md  # exists
-./scripts/ci/validate-skill-frontmatter.sh 2>&1 | grep 'SKILL.md validated'  # shows 93
-./scripts/ci/validate-skill-frontmatter.sh --self-test  # exits 0
-```
+### §C. The 5 operator design decisions
+1. `wake:` nesting (single block, not flattened)
+2. `artifact_class: wake` (reuse SKILL.md discovery + CUE pipeline)
+3. `scope: global` (role in `wake.role`)
+4. CUE owns typed contract; renderer owns substrate compilation + runtime refusals
+5. `responsibilities`/`*_notes`/`cross_references` → body, not frontmatter
 
-**I5 discovery note:** `validate-skill-frontmatter.sh` runs `find src/packages -name SKILL.md`. Both orchestrator dirs are under `src/packages/`; SKILL.md files placed there are discovered automatically — no exception-list changes needed.
+Each decision: state the decision, the rationale, and the implication for W1 implementation.
 
-### AC3 — Renderer reads SKILL.md
+### §D. CUE ↔ renderer responsibility boundary
+Concrete table:
+| Boundary | CUE owns | Renderer owns |
+- Static shape, field types, enums, role-output disjunction → CUE
+- Cross-field refusals (activation_log_writer mis-declaration, activation_state gating) → renderer
+- Substrate encoding (GitHub Actions YAML, secrets, cron slots, bot identity table) → renderer
+- Body extraction (second `---` delimiter; prompt substitution) → renderer
+- Install-time substitution (`{agent}` → `$agent`) → renderer
 
-**Oracle:** `cn install-wake <name>` when given a SKILL.md-bearing directory (W2 dual-source) produces output byte-identical to the JSON-sourced render; after W3 flip, renders from SKILL.md only.
+### §E. Body-as-prompt rule
+- Frontmatter = contract (machine-readable fields only)
+- Body = prompt/role doctrine (verbatim prompt.md content + verbose reference data from wake-provider.json)
+- The byte-identity oracle proves correctness: renderer extracting body → same output as reading prompt.md
 
-**Testable boundary:** renderer code path in `cn-install-wake`:
-- W2: add `--source skill-md` or auto-detect SKILL.md beside manifest; render from SKILL.md; compare bytes to render-from-JSON
-- W3: flip the default source to SKILL.md; the JSON path becomes a fallback or is removed
+### §F. W1→W4 migration plan (the 4 phases)
+- W1: Author both SKILL.md beside JSON/prompt; add `#Wake` to skill.cue; goldens unchanged
+- W2: Teach renderer to read SKILL.md; dual-source parity gate
+- W3: Flip renderer source to SKILL.md; re-render (no-op expected)
+- W4: Delete JSON + prompt after byte-identical proof; I5 count 91 → 93
+- Byte-identity oracle at each step
 
-**Filesystem check:**
-```sh
-# W2 parity (before JSON deletion):
-cn install-wake agent-admin --source skill-md --out /tmp/from-skill.yml
-cn install-wake agent-admin --source json      --out /tmp/from-json.yml
-cmp /tmp/from-skill.yml /tmp/from-json.yml     # must exit 0
+### §G. W1 acceptance criteria (scoped)
+The 7 ACs from the issue body, restated as the acceptance criteria for W1 specifically:
+- AC1: `#Wake` schema in `schemas/skill.cue`
+- AC2: Both wake SKILL.md files authored at the orchestrator paths
+- AC3: Renderer reads SKILL.md
+- AC4: Byte-identical goldens
+- AC5: JSON + prompt deleted
+- AC6: Renderer refusals preserved
+- AC7: All CI gates green
 
-# W3 (after flip):
-cn install-wake agent-admin --out /tmp/from-default.yml
-cmp /tmp/from-default.yml src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
-```
+### §H. Friction notes carried forward (for W1 implementer)
+The 8 friction notes (FN-1 through FN-8) from the prior γ scaffold are material for the W1 implementer. α includes the key ones here.
 
-### AC4 — Byte-identical goldens
+### §I. Non-goals
+Explicit non-goals: no rendered-workflow output change; no runtime-behavior change; no new wake names; no Demo 0.
 
-**Oracle:** `install-wake golden` CI green: re-render diff clean + sha256 golden==live + idempotence; one-shot dual-source parity check `render(SKILL) cmp render(JSON)` passes before deletion.
-
-**Testable boundary:**
-- Both goldens render byte-identically from SKILL.md versus from JSON
-- sha256 of live `.github/workflows/cnos-*.yml` equals sha256 of the package golden
-- Second render is a no-op (idempotence)
-
-**Filesystem check:**
-```sh
-sha256sum src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
-sha256sum .github/workflows/cnos-agent-admin.yml
-# must match
-
-sha256sum src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
-sha256sum .github/workflows/cnos-cds-dispatch.yml
-# must match
-```
-
-### AC5 — JSON + prompt deleted
-
-**Oracle:** `wake-provider.json` and `prompt.md` absent for both wakes; `cn install-wake` still renders byte-identical goldens.
-
-**Testable boundary:** files absent + renderer still produces correct output from SKILL.md only.
-
-**Filesystem check:**
-```sh
-ls src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json  # must NOT exist
-ls src/packages/cnos.core/orchestrators/agent-admin/prompt.md            # must NOT exist
-ls src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json   # must NOT exist
-ls src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md            # must NOT exist
-cn install-wake agent-admin   # exit 0; golden unchanged
-cn install-wake cds-dispatch  # exit 0; golden unchanged
-```
-
-### AC6 — Renderer refusals preserved
-
-**Oracle:** existing cycle/496 mis-declaration smoke in `install-wake-golden.yml` still passes; a synthetic mis-declared wake SKILL.md → exit 4.
-
-**Testable boundary:** after W3/W4, the renderer reads the `wake:` block from SKILL.md and applies the same refusal logic previously applied against JSON fields:
-- `activation_state != "live"` → exit 3
-- `role:dispatch + admin_only:false + activation_log_writer:true` → exit 4
-- `activation_log_writer:false + attach in cross_references` → exit 4 (FN-6 defense-in-depth)
-
-**Filesystem check:**
-```sh
-# Existing AC4/AC5 smoke in install-wake-golden.yml must still pass:
-# Step "AC4 (cycle/496) — renderer refusal on mis-declaration" exits 4.
-# Step "AC5 — declaration-only refusal" exits 3.
-# If synthetic fixture JSONs are deleted (or kept alongside), verify the smoke
-# is wired to SKILL.md-sourced equivalents post-W4.
-```
-
-### AC7 — All gates green
-
-**Oracle:** I1/I2/I4/I5/I6/`install-wake golden`/`dispatch-repair-preflight`/Go/Package/Binary all green on the cell's PR.
-
-**Testable boundary:** no inherited-cap failures; no new red gates.
-
-**Filesystem check:** CI run on the PR passes all jobs.
-
-## §5. Implementation contract (for α dispatch prompt)
-
-| Axis | Value |
-|---|---|
-| **Branch** | `cycle/524` |
-| **Base SHA** | `d7d2244cb4cb95b94e28569ac8ef090d49876c89` |
-| **Issue** | cnos#524 |
-| **Mode** | MCA — W0 operator-ratified; α executes W1→W4 sequence |
-| **AC set** | AC1–AC7 (all) |
-| **W0 non-goals** | No rendered-workflow output change; no runtime-behavior change; no renderer substrate-encoding change; no new wake names; no schema changes outside `schemas/skill.cue`; no I5 exception-list additions |
-| **Byte-identity oracle** | `cmp render(SKILL) render(JSON)` must pass at every intermediate step before deletion |
-| **Deletion gate** | W4 deletions ONLY after byte-identical proof holds in CI |
-
-## §6. α dispatch prompt
+## §5. α dispatch prompt
 
 ```text
-You are α@cdd.cnos, running as the implementer for cycle/524.
+You are α@cdd.cnos, running as the implementer for cycle/524 R0.
 
 Branch: cycle/524 (at base main SHA d7d2244cb4cb95b94e28569ac8ef090d49876c89).
 Parent issue: cnos#524 ("wake-as-skill: migrate wakes to typed SKILL.md modules").
-Scaffold: .cdd/unreleased/524/gamma-scaffold.md (READ THIS FIRST in full before any edits).
+Scaffold: .cdd/unreleased/524/gamma-scaffold.md (READ THIS FIRST in full before any work).
 
-## What you implement
+## Scope of this run (MANDATORY — read before any file write)
 
-Implement R0 of the W1→W4 migration per the operator-ratified W0 design (locked; no design reframing without operator approval). The 7 ACs are the acceptance surface. The byte-identity oracle is the migration correctness proof at every step.
+**This run is W0 DESIGN ONLY.**
+
+The operator DISPATCH DIRECTIVE (see issue #524 comments — "⛳ DISPATCH DIRECTIVE") overrides the full issue scope (W1→W4 ACs) for this run. Your task is to produce a standalone W0 design document — NOT to implement W1→W4.
+
+**Hard scope constraints (enforced by directive):**
+- Do NOT touch `schemas/skill.cue`
+- Do NOT touch `src/packages/.../cn-install-wake`
+- Do NOT touch any `.github/workflows/*.yml`
+- Do NOT touch any `*.golden.yml`
+- Do NOT delete or edit `wake-provider.json` or `prompt.md`
+- Do NOT start W1, W2, W3, or W4 implementation
+
+**Your ONLY writable outputs:**
+- `.cdd/unreleased/524/w0-design.md` — the W0 design document (see structure in γ-scaffold §4)
+- `.cdd/unreleased/524/self-coherence.md §R0` — your self-coherence artifact
+- Commits on `cycle/524` branch
+
+## What you produce
+
+Author `.cdd/unreleased/524/w0-design.md` per the structure in γ-scaffold §4 (§A through §I).
+
+This document FORMALIZES the W0 design already in the issue body. It does NOT design anything new. Read:
+1. Issue #524 body (especially `## W0 design (locked)` section)
+2. The operator W0 calls comment (first @usurobor comment on #524)
+3. `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` — REFERENCE ONLY (what `wake:` block must capture for admin wake)
+4. `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` — REFERENCE ONLY (what `wake:` block must capture for dispatch wake)
+5. `schemas/skill.cue` — REFERENCE ONLY (what `#Skill` looks like; where `#Wake` fits)
+
+Do NOT modify any of the reference files above.
 
 ## Skills to load before implementing
 
-Load these skills in order:
-1. `src/packages/cnos.cds/skills/cds/SKILL.md` — CDS protocol discipline
-2. `src/packages/cnos.cdd/skills/cdd/alpha/SKILL.md` — α role contract
-3. `src/packages/cnos.cdd/skills/cdd/SKILL.md` — cell-runtime framework
+1. `src/packages/cnos.cdd/skills/cdd/alpha/SKILL.md` — α role contract
+2. `src/packages/cnos.cdd/skills/cdd/SKILL.md` — cell-runtime framework
 
-## Implementation contract
+## Self-coherence (after w0-design.md is complete)
 
-| Axis | Value |
-|---|---|
-| Branch | cycle/524 |
-| Base SHA | d7d2244cb4cb95b94e28569ac8ef090d49876c89 |
-| Issue | cnos#524 |
-| Mode | MCA — execute known W1→W4 sequence; W0 is locked |
-| AC set | AC1–AC7 (all) |
-| W0 non-goals | No rendered-workflow output change; no runtime-behavior change; no new wake names; no schema changes outside schemas/skill.cue |
-| Byte-identity oracle | cmp render(SKILL) render(JSON) must pass at every step before deletion |
-| Deletion gate | W4 deletions ONLY after byte-identical proof CI-green |
+Write `.cdd/unreleased/524/self-coherence.md §R0`:
+- Confirm scope guardrails: which files were NOT touched
+- Walk the §4 structure sections (§A through §I): each section present? Internal coherence of `wake:` block fields?
+- Cross-reference check: does `w0-design.md §B` cover ALL fields from both `wake-provider.json` manifests?
+- Confirm: no W1→W4 implementation artifacts exist on the branch
 
-## Implementation order (W1 → W4; minimizes inter-step risk)
+## Commits
 
-### W1 — Schema + both SKILL.md files (AC1 + AC2)
-
-**Step 1: Extend `schemas/skill.cue` (AC1)**
-- Add `"wake"` to the `artifact_class` enum in `#Skill` (line 35).
-- Add `#Wake` definition after `#Skill`. The `#Wake` definition must type-check the `wake:` block per the W0 design (see γ-scaffold §4 AC1 field table and §5 for the complete W0 wake: block shape).
-- Key design constraints for `#Wake`:
-  - `wake.role: "admin" | "dispatch"` (not observer — the renderer's enum check at line 342 of cn-install-wake accepts admin/dispatch/observer but the W0 schema is admin|dispatch only)
-  - Role-shaped output disjunction: if `wake.role == "admin"` then `wake.output.channel_log_convention: string` required; if `wake.role == "dispatch"` then `wake.output.{cycle_artifact_root, artifact_class_taxonomy, cell_runtime}` required.
-  - `wake.selector` is required when `role == "dispatch"` (sub-fields: `include: [...string]`, `exclude: [...string]`).
-  - `wake.protocol` is optional string (required for dispatch semantically but CUE enforces it as optional to not break admin shapes).
-  - Keep `#Wake` open (`...`) per the LANGUAGE-SPEC §11 principle from `#Skill`.
-
-**Step 2: Author `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` (AC2)**
-
-Frontmatter:
-```yaml
----
-name: agent-admin
-description: "<from wake-provider.json description field>"
-governing_question: "How does the agent-admin wake orchestrate the admin role for a given agent installation?"
-triggers:
-  - "cn install-wake agent-admin --agent <agent>"
-  - "schedule (cron; substrate-encoded by renderer)"
-  - "issues:opened with title matching issues_opened_title_pattern"
-scope: global
-artifact_class: wake
-kata_surface: none
-inputs:
-  - "home thread (.cn-{agent}/threads/activations/{this-hub}/)"
-  - "open issues in this repo (read-only)"
-outputs:
-  - ".cn-{agent}/logs/YYYYMMDD.md (channel log entry)"
-  - ".cn-{agent}/state/ (cursor advancement)"
-wake:
-  role: admin
-  package: cnos.core
-  admin_only: true
-  activation_log_writer: true
-  input:
-    triggers:
-      - schedule
-      - issues_opened_title_match
-    issues_opened_title_pattern: claude-wake
-  output:
-    channel_log_convention: docs/reference/conventions/AGENT-ACTIVATION-LOG-v0.md
-  permission_intent:
-    - contents.write
-    - issues.write
-    - pull_requests.write
-    - id_token.write
-  concurrency:
-    serialize: true
-    group: agent-admin-{agent}
-  agent_variable:
-    name: agent
-    default: null
----
+1. Commit `.cdd/unreleased/524/w0-design.md` as: `α-524 W0: w0 design document`
+2. Commit `.cdd/unreleased/524/self-coherence.md` as: `α-524 R0: self-coherence §R0`
+3. Push all commits to `cycle/524`
 ```
 
-Body: the VERBATIM content of `src/packages/cnos.core/orchestrators/agent-admin/prompt.md`, followed (optionally, in a trailing `## Reference` section) by the verbose data from wake-provider.json that moves to body per W0 call #5: `responsibilities`, `*_notes`, `cross_references`, `allowed_surfaces`, `disallowed_surfaces`, `defer_path`, `relationship_to_substrate`.
-
-**Step 3: Author `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` (AC2)**
-
-Frontmatter:
-```yaml
----
-name: cds-dispatch
-description: "<from wake-provider.json description field>"
-governing_question: "How does the cds-dispatch wake claim and route CDS cells to the δ role contract?"
-triggers:
-  - "cn install-wake cds-dispatch --agent <agent>"
-  - "schedule (cron; substrate-encoded by renderer)"
-  - "issues:labeled with label in selector.include"
-scope: global
-artifact_class: wake
-kata_surface: none
-inputs:
-  - "open issues matching selector (dispatch:cell + protocol:cds + status:todo, minus exclude labels)"
-outputs:
-  - ".cdd/unreleased/{N}/ (cell artifact root via δ/γ/α/β)"
-  - "issue lifecycle labels on claimed cell"
-  - "pull request for claimed cell"
-wake:
-  role: dispatch
-  package: cnos.cds
-  admin_only: false
-  activation_log_writer: false
-  activation_state: live
-  protocol: cds
-  selector:
-    include:
-      - dispatch:cell
-      - protocol:cds
-      - status:todo
-    exclude:
-      - status:in-progress
-      - status:blocked
-      - status:review
-      - status:changes
-  input:
-    triggers:
-      - schedule
-      - issues_labeled_selector_match
-  output:
-    cycle_artifact_root: .cdd/unreleased/{N}/
-    artifact_class_taxonomy:
-      - gamma-scaffold
-      - self-coherence
-      - beta-review
-      - alpha-closeout
-      - beta-closeout
-      - gamma-closeout
-      - post-release-assessment
-    cell_runtime: cnos.cdd
-  permission_intent:
-    - contents.write
-    - issues.write
-    - pull_requests.write
-    - id_token.write
-  concurrency:
-    serialize: true
-    group: cds-dispatch-{agent}
-  agent_variable:
-    name: agent
-    default: sigma
----
-```
-
-Body: VERBATIM content of `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md`, followed by the verbose cross_references, responsibilities, *_notes, allowed/disallowed surfaces, and defer_path from wake-provider.json.
-
-**W1 verification (before proceeding to W2):**
-```sh
-cue vet -d '#Skill' schemas/skill.cue src/packages/cnos.core/orchestrators/agent-admin/SKILL.md
-cue vet -d '#Skill' schemas/skill.cue src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
-./scripts/ci/validate-skill-frontmatter.sh 2>&1 | grep 'SKILL.md validated'  # should show 93
-./scripts/ci/validate-skill-frontmatter.sh --self-test  # exit 0
-# Goldens UNCHANGED — renderer still reads JSON:
-cn install-wake agent-admin   # no diff to golden
-cn install-wake cds-dispatch  # no diff to golden
-```
-
-### W2 — Teach renderer to read SKILL.md; dual-source parity gate (AC3 + AC4)
-
-**Step 4: Extend `cn-install-wake` to parse SKILL.md**
-
-The renderer currently reads fields from `wake-provider.json` via `jq`. For W2, add a SKILL.md parsing path:
-- Detect `SKILL.md` beside the manifest path.
-- Extract the YAML frontmatter (between the two `---` delimiters).
-- Map `wake.*` frontmatter keys to the variables the renderer currently reads from JSON:
-  - `name` ← `name` (top-level in both)
-  - `package` ← `wake.package`
-  - `role` ← `wake.role`
-  - `admin_only` ← `wake.admin_only`
-  - `activation_log_writer` ← `wake.activation_log_writer`
-  - `activation_state` ← `wake.activation_state` (default: `"live"` when absent)
-  - `protocol` ← `wake.protocol`
-  - `selector` ← `wake.selector`
-  - `input_contract.triggers` ← `wake.input.triggers`
-  - `input_contract.issues_opened_title_pattern` ← `wake.input.issues_opened_title_pattern`
-  - `output_contract.*` ← `wake.output.*`
-  - `permission_intent` ← `wake.permission_intent`
-  - `concurrency_intent.serialize` ← `wake.concurrency.serialize`
-  - `concurrency_intent.group` ← `wake.concurrency.group`
-  - `agent_variable.default` ← `wake.agent_variable.default`
-  - **prompt body** ← SKILL.md body (everything after the second `---`)
-- Expose this as `--source skill-md` flag (or auto-detect: if SKILL.md present beside manifest, available as alternative source). Keep `--source json` (or default) path unchanged.
-
-**Step 5: Add dual-source parity gate to `install-wake-golden.yml` (AC4)**
-
-Add a new CI step after the existing "Re-render" steps:
-```yaml
-- name: W2 parity gate — render(SKILL) == render(JSON) for both wakes
-  run: |
-    set -euo pipefail
-    for wake in agent-admin cds-dispatch; do
-      ./src/packages/cnos.core/commands/install-wake/cn-install-wake "$wake" \
-        --source skill-md --out /tmp/${wake}-from-skill.yml
-      ./src/packages/cnos.core/commands/install-wake/cn-install-wake "$wake" \
-        --source json     --out /tmp/${wake}-from-json.yml
-      if ! cmp -s /tmp/${wake}-from-skill.yml /tmp/${wake}-from-json.yml; then
-        echo "::error::W2 parity FAILED for $wake: render(SKILL) != render(JSON)"
-        diff /tmp/${wake}-from-skill.yml /tmp/${wake}-from-json.yml || true
-        exit 1
-      fi
-      echo "W2 parity OK ($wake): render(SKILL) == render(JSON)"
-    done
-```
-
-### W3 — Flip renderer source to SKILL.md; re-render (AC3 + AC4)
-
-**Step 6: Flip default source in `cn-install-wake`**
-
-Change the resolver so that when SKILL.md is present, it is the primary source (not the JSON). The JSON fallback path remains for backward compatibility until W4.
-
-**Step 7: Re-render goldens and live workflows**
-
-```sh
-cn install-wake agent-admin   --out src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
-cn install-wake cds-dispatch  --out src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
-cn install-wake agent-admin   --out .github/workflows/cnos-agent-admin.yml
-cn install-wake cds-dispatch  --out .github/workflows/cnos-cds-dispatch.yml
-```
-
-These MUST produce zero diff if byte-identical — the oracle passes. If any diff appears: stop, file an FN, do NOT proceed to W4.
-
-### W4 — Delete JSON + prompt; I5 count confirms 93 (AC5 + AC7)
-
-**Step 8: Confirm byte-identity in CI, then delete source files**
-
-Only after W3 re-renders are verified byte-identical in CI:
-```sh
-rm src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json
-rm src/packages/cnos.core/orchestrators/agent-admin/prompt.md
-rm src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json
-rm src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md
-```
-
-**Step 9: Update renderer to remove JSON fallback path**
-
-After deletion, remove the JSON parsing path from `cn-install-wake` (the dead code for `wake-provider.json` lookup). The manifest path `--manifest <path>` flag still works but resolves against SKILL.md instead.
-
-**Step 10: Update `install-wake-golden.yml` for W4**
-
-- Remove or update the `--manifest` path comments that reference `wake-provider.json`.
-- Add an I5 count assertion step:
-  ```yaml
-  - name: I5 count check (93 SKILL.md post-W4)
-    run: |
-      n=$(find src/packages -name SKILL.md | wc -l)
-      if [ "$n" -ne 93 ]; then
-        echo "::error::Expected 93 SKILL.md files post-W4; found $n"
-        exit 1
-      fi
-      echo "I5 count OK: $n SKILL.md files"
-  ```
-- Add a W4 deletion-proof step confirming JSON + prompt absent for both wakes.
-- Verify `cn install-wake` still renders byte-identical goldens.
-
-## Commit message pattern
-
-```
-α-524 W1: <step name summary>
-α-524 W2: <step name summary>
-α-524 W3: <step name summary>
-α-524 W4: <step name summary>
-α-524 R0 signal: ready for β review
-```
-
-## Signaling β-readiness
-
-After all steps land + push, write `.cdd/unreleased/524/self-coherence.md` §R0, commit as `α-524 R0: self-coherence §R0`, push. Then add a signal commit `α-524 R0 signal: ready for β review` (zero file changes).
-
-## Scope guardrails (hard constraints)
-
-- **NO rendered-workflow output change** unless caused by a genuine field delta between JSON and SKILL.md (any such delta is an R0 blocker — stop, file FN, do not proceed to W3).
-- **NO runtime-behavior change** — the renderer's refusal logic (exits 2/3/4), the write-fence step, the permission encoding, the cron slots, the bot identity bindings — none of these change in this migration.
-- **NO renderer substrate-encoding change** — the YAML structure the renderer emits is unchanged; only the SOURCE it reads from changes.
-- **NO new wake names** — this migration covers agent-admin and cds-dispatch exactly.
-- **NO schema changes outside `schemas/skill.cue`** — do not modify I5 validator logic.
-- **NO I5 exception-list additions** — the new SKILL.mds must pass cue vet without exception entries.
-- **Byte-identity at every step** — if `cmp render(SKILL) render(JSON)` fails at any point in W2 or later, stop and file an FN before continuing.
-- **Deletion is W4-only** — do NOT delete JSON or prompt until CI confirms byte-identical goldens from SKILL.md source.
-
-## Re-iteration discipline
-
-If β R0 returns iterate:
-- Read β's review; do NOT re-derive ACs from scratch.
-- R[N] section in self-coherence.md per T-486-7 off-by-one prevention.
-- Apply δ-direct R1 pattern if the iterate is narrow + mechanical (single file/line fix without architectural reframing).
-
-## Hard do-not-cross lines
-
-- Do NOT pre-empt or modify any cycle outside cycle/524's scope.
-- Do NOT modify the test-fixtures at `src/packages/cnos.core/commands/install-wake/test-fixtures/` unless a new mis-declared SKILL.md fixture is needed for AC6 verification (in which case: file an FN naming the new fixture and why it's needed).
-- Do NOT touch `schemas/skill-exceptions.json` — new SKILL.mds must be clean.
-- Do NOT modify `.cn-sigma/logs/` — this cycle has no activation-log write scope.
-```
-
-## §7. β dispatch prompt
+## §6. β dispatch prompt
 
 ```text
 You are β@cdd.cnos, running as the reviewer for cycle/524 R0.
 
-Branch: cycle/524 (read α's R0 commits up to and including the "α-524 R0 signal" commit).
+Branch: cycle/524 (read α's R0 commits).
 Parent issue: cnos#524 ("wake-as-skill: migrate wakes to typed SKILL.md modules").
 Scaffold: .cdd/unreleased/524/gamma-scaffold.md (read in full).
 α self-coherence: .cdd/unreleased/524/self-coherence.md §R0 (read in full).
 
-## Your output
+## Scope reminder
 
-Write `.cdd/unreleased/524/beta-review.md` with §R0 review. Final verdict: **converge** OR **iterate**.
+This run is W0 design only. The ONLY artifact α should have produced is `.cdd/unreleased/524/w0-design.md` plus CDD records. If α touched any source/schema/workflow files, that is an immediate R0 iterate finding.
 
-## Pre-AC checklist (mechanical; walk every item in order)
+## Review checklist
 
-**AC1 — `#Wake` schema in CUE:**
-- `schemas/skill.cue` adds `"wake"` to `artifact_class` enum.
-- `#Wake` definition present with correct field types/enums per W0 design.
-- Run: `cue vet -d '#Wake' schemas/skill.cue /tmp/conformant-wake.yaml` → exit 0.
-- Run a bad-enum fixture → exit nonzero + diagnostic. Record both results.
+**Scope compliance (check first — iterate immediately on any failure):**
+- [ ] No changes to `schemas/skill.cue`
+- [ ] No changes to `cn-install-wake` or any renderer file
+- [ ] No changes to `.github/workflows/*.yml`
+- [ ] No changes to `*.golden.yml`
+- [ ] `wake-provider.json` and `prompt.md` untouched for both wakes
+- [ ] No W1→W4 implementation code on the branch
 
-**AC2 — Wake SKILL.md modules authored:**
-- Both SKILL.md files exist at the paths in §2 Source-of-truth table.
-- Frontmatter carries `scope: global`, `artifact_class: wake`, `wake:` block with exact manifest data.
-- Body contains prompt.md content verbatim (no paraphrase; no summary; literal copy).
-- Verbose fields (`responsibilities`, `*_notes`, `cross_references`) are in body ONLY, not frontmatter.
-- `./scripts/ci/validate-skill-frontmatter.sh` exits 0 and reports 93 SKILL.md.
+**`w0-design.md` completeness (walk each section):**
+- [ ] §A: Problem statement and invariant — accurate?
+- [ ] §B: `wake:` block schema — covers ALL fields from BOTH `wake-provider.json` manifests? Role-shaped output disjunction present?
+- [ ] §C: All 5 operator decisions present with decision + rationale + W1 implication?
+- [ ] §D: CUE↔renderer boundary table — complete? No mis-assignments?
+- [ ] §E: Body-as-prompt rule — clear? Byte-identity oracle cited?
+- [ ] §F: W1→W4 migration plan — 4 phases with oracle at each step?
+- [ ] §G: W1 ACs (AC1–AC7) present and accurate?
+- [ ] §H: Friction notes cited or included?
+- [ ] §I: Non-goals listed?
 
-**AC3 — Renderer reads SKILL.md:**
-- `cn-install-wake` has a SKILL.md parsing path.
-- The field mapping from `wake.*` to renderer variables is complete (no missing fields; see γ-scaffold §4 AC1 table).
-- After W3 flip: `cn install-wake agent-admin` uses SKILL.md as primary source.
+**Field completeness (load-bearing):**
+Read both `wake-provider.json` files. Walk every field. Is each field covered in `w0-design.md §B`?
+- `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json`
+- `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json`
 
-**AC4 — Byte-identical goldens:**
-- `cmp render(SKILL) render(JSON)` passes for BOTH wakes (record sha256 of each pair).
-- sha256(golden) == sha256(live workflow) for both wakes.
-- Second render is a no-op (idempotence: sha256 before == sha256 after).
-- The W2 parity CI step is present in `install-wake-golden.yml` and passes.
+**Internal coherence:**
+- Role-shaped output disjunction in §B: admin shape ≠ dispatch shape; both present?
+- §F migration plan consistent with §B schema shape?
+- §G ACs consistent with §D CUE↔renderer boundary?
 
-**AC5 — JSON + prompt deleted:**
-- All four deletion-target files are absent in the W4 commit.
-- `cn install-wake` still renders byte-identical goldens post-deletion.
-- `install-wake-golden.yml` W4 deletion-proof step present and passes.
+**Verdict:**
+- **converge** if: scope compliance clean; all 9 sections present and complete; all JSON fields covered in §B; internal coherence holds
+- **iterate** if: any scope compliance failure; any section absent; any load-bearing field missing from §B; internal incoherence
 
-**AC6 — Renderer refusals preserved:**
-- Existing cycle/496 refusal smoke in `install-wake-golden.yml` still passes: exit 4 + "activation_log_writer mis-declaration" in stderr; exit 3 on declaration-only fixture.
-- Refusal logic fires correctly whether source is JSON (W2) or SKILL.md (W3/W4).
-- If α created a synthetic mis-declared SKILL.md fixture: verify it exits 4.
-
-**AC7 — All gates green:**
-- No inherited-cap failures; no new red gates on the PR.
-- I5 count step in CI reports 93.
-
-## Independence requirement
-
-β must reach its verdict independently. Do NOT ask α to pre-certify; do NOT accept α's self-assessment as a substitute for β's own verification. Run the oracles yourself (or simulate them against the committed state).
-
-## Variable consistency walk (T-486-1 + T-487-1)
-
-Walk every variable that changed across: SKILL.md frontmatter → renderer field consumption → rendered workflow YAML → CI oracle → prompt body → PR body.
-
-Key variables to check:
-| Variable | SKILL.md `wake:` block | Renderer parsing | Rendered YAML | CI assertion | Body prose |
-|---|---|---|---|---|---|
-| `wake.role` | `admin` / `dispatch` | line ~342 enum check | implicit in shape | AC1 CUE vet | body mentions role |
-| `wake.activation_log_writer` | `true` / `false` | line ~452 mis-declaration check | write-fence step presence | AC6 refusal smoke | body names "non-writer" |
-| `wake.concurrency.group` | `agent-admin-{agent}` / `cds-dispatch-{agent}` | line ~498 substitution | `group:` in YAML | golden shape check | body mentions concurrency |
-| prompt body | verbatim in SKILL.md body | body extraction after `---` | `prompt: \|` block | sha256 parity | N/A (IS the body) |
-
-Flag any drift between columns.
-
-## Per-CI-step bash-e audit (cnos#478 mechanical-injection)
-
-For every new `run:` step α added to `install-wake-golden.yml`:
-- Verify `set -eu` / `set -euo pipefail` is in effect.
-- Verify no `grep -c ... | true` pipefail-trap class.
-- Verify fixture cleanup (no orphaned temp files after step).
-
-## Byte-identity audit (load-bearing)
-
-1. Record sha256 of both goldens from JSON source (pre-W3 baseline).
-2. Record sha256 of both goldens from SKILL.md source (W2 parity render).
-3. Verify all four sha256s match.
-4. Record sha256 of live workflows; verify they match goldens.
-5. After W4 deletion: re-verify goldens unchanged.
-
-If any pair mismatches: P0 blocker. Iterate immediately. Byte-identity is the migration oracle.
-
-## Output structure for `.cdd/unreleased/524/beta-review.md`
-
-- **§R0 frontmatter.** YAML with cycle, base SHA, α R0 signal commit SHA, β review timestamp.
-- **§R0 verdict.** `converge` OR `iterate` at the top, before narrative.
-- **§R0 AC table.** AC1–AC7 with per-AC green/red/ambiguous + oracle command + observation.
-- **§R0 variable consistency walk.** Every variable × every column.
-- **§R0 per-CI-step bash-e audit.** Every modified/added `run:` step + result.
-- **§R0 byte-identity audit.** sha256 pairs for all four files.
-- **§R0 friction notes (if any).** FN-β-N entries.
-
-## When to iterate vs converge
-
-- **Iterate** if: any byte-identity pair mismatches; any AC oracle returns red; SKILL.md body is NOT verbatim prompt.md (paraphrase = red); renderer skips a field from the `wake:` block; I5 count != 93; any existing refusal smoke breaks.
-- **Converge** if: byte-identical across all pairs; all AC oracles green; I5 count = 93; existing CI smokes all pass; variable consistency clean.
-
-## Hard constraints
-
-- **Do NOT iterate for taste** — β iterates only when an oracle returns red or a load-bearing invariant is violated.
-- **Do NOT modify any α-written file** — β reviews; does not implement.
-- **Honor T-486-12 (operator-final-read P1)** — β converge is not the cycle's final gate.
-- **Commit message:** `β-524 R0 review: <converge|iterate>`. Co-Authored-By trailer matches prior cycles.
+Write `.cdd/unreleased/524/beta-review.md §R0` with verdict.
+Commit as: `β-524 R0 review: <converge|iterate>`
+Push to `cycle/524`.
 ```
 
-## §8. Scope guardrails (W0 non-goals)
+## §7. Scope guardrails (mechanical — operator directive)
 
-These are hard guardrails α and β must both enforce:
+The cell MUST NOT touch any of:
+- `src/.../cn-install-wake` (renderer)
+- `schemas/skill.cue`
+- Any `.github/workflows/*.yml`
+- Any `*.golden.yml`
+- `wake-provider.json` or `prompt.md` (either wake)
 
-1. **No rendered-workflow output change.** The YAML emitted by `cn install-wake` for both wakes must be byte-identical before and after the migration. Any diff is an R0 blocker.
-2. **No runtime-behavior change.** The renderer's refusals (exits 2/3/4), the write-fence step logic, the permission block, the cron-slot encoding, the bot identity table — none change. This migration is a source-swap, not a behavior change.
-3. **No renderer substrate-encoding change.** The `gha_permission_line` function, the cron-slot list (`8 23 38 53`), the `anthropics/claude-code-action@v1` pinning, the `SIGMA_WORKFLOW_PAT` secret name, the `cancel-in-progress: false` policy — all unchanged.
-4. **No new wake names.** Migration scope is exactly: `agent-admin` (cnos.core) and `cds-dispatch` (cnos.cds).
-5. **No other schema changes.** `schemas/skill.cue` changes are limited to: adding `"wake"` to the `artifact_class` enum + adding the `#Wake` definition. No other field or constraint changes.
+The ONLY diff in the PR branch should be under `.cdd/unreleased/524/`.
 
-## §9. Friction notes (anticipated classes for α + β)
+## §8. Cross-references
 
-**FN-1: Frontmatter YAML quoting.** The wake-provider.json contains string values with characters that may require quoting in YAML frontmatter (colons in descriptions, curly braces in `{agent}` substitution tokens). `{agent}` tokens in strings like `"agent-admin-{agent}"` must be quoted in YAML to avoid being parsed as flow mappings. α must verify: `cue vet` passes with the actual frontmatter text, not a simplified version.
-
-**FN-2: Prompt body verbatim discipline.** The SKILL.md body must contain prompt.md content verbatim — not paraphrased, not reformatted, not summarized. The byte-identity oracle (AC4) is the enforcement mechanism: if the renderer's body-extraction produces a different string than the raw `prompt.md`, the rendered output will differ. Any transform applied to the body (e.g., indentation normalization, line-ending normalization) will break byte-identity. The renderer currently uses `sed "s/{agent}/${agent}/g" "$prompt_path"` — the SKILL.md body extraction path must apply the same substitution and the same trailing-whitespace strip (`sed 's/[[:space:]]*$//'`) to produce identical output.
-
-**FN-3: The renderer's `--manifest` flag interaction.** `cn-install-wake` accepts `--manifest <path>` to override the default JSON lookup. The manifest-override path resolves `prompt_path` relative to the manifest's directory (`manifest_dir`). When the source is SKILL.md, the body extraction replaces both: the `prompt_template` JSON field lookup AND the `$manifest_dir/$prompt_template_relpath` file read. The W2 SKILL.md path must handle `--manifest` correctly — if `--manifest` points to a SKILL.md (or if there's a SKILL.md beside a `--manifest`-specified JSON), the precedence is well-defined. α should document the flag interaction in the renderer comments.
-
-**FN-4: Renderer field name mapping (`input_contract` vs `wake.input`).** The JSON manifest uses `input_contract: {triggers: [...]}` while the W0 SKILL.md shape uses `wake: {input: {triggers: [...]}}`. The renderer currently reads `jq -r '.input_contract.triggers'`. The SKILL.md parser must read `wake.input.triggers` and expose it as `input_contract_triggers` (or however the renderer variable is named) to avoid duplication of the rendering logic. α must map ALL fields — including the less-obvious ones like `input_contract.issues_opened_title_pattern` ← `wake.input.issues_opened_title_pattern` and `output_contract.channel_log_convention` ← `wake.output.channel_log_convention` (admin shape) and `output_contract.{cycle_artifact_root,artifact_class_taxonomy,cell_runtime}` ← `wake.output.{...}` (dispatch shape).
-
-**FN-5: `cross_references.consumed_skills` FN-6 defense-in-depth check.** The renderer currently (at line 477-484) checks `cross_references.consumed_skills` from the JSON for the FN-6 attach-incompatibility refusal. After W3/W4, this data moves to the SKILL.md body (per W0 call #5: `cross_references` → body). The renderer must extract this from the SKILL.md body OR the `calls` / `requires` frontmatter field. Design choice: either (a) keep `cross_references.consumed_skills` in the SKILL.md frontmatter as a `requires:` list (LANGUAGE-SPEC §11 allows this), or (b) move the FN-6 check to a body-prose check (fragile). Option (a) is preferred. α must document this choice as a design fork and record the resolution in self-coherence.md.
-
-**FN-6: `activation_state_notes` field.** The renderer reads `activation_state_notes` from the JSON (line 387) for the exit-3 refusal message. The W0 `wake:` block shape does not include this field. α must decide: add `wake.activation_state_notes` as an optional string to `#Wake`, OR absorb the notes into the body. If absorbed into body, the renderer's exit-3 message will not include the notes content. This is a narrow behavioral change (refusal message text only; not the refusal itself). α should file an FN if the notes are dropped from the exit-3 message.
-
-**FN-7: I5 discovery path — are orchestrator/ dirs under `src/packages/`?** The I5 validator runs `find src/packages -name SKILL.md`. Both orchestrator dirs (`src/packages/cnos.core/orchestrators/agent-admin/` and `src/packages/cnos.cds/orchestrators/cds-dispatch/`) ARE under `src/packages/`. Discovery is automatic — confirmed. However, α should verify the `calls:` resolution in `validate_skill_file` for orchestrator SKILL.mds: `package_skill_root_of` uses the path's `.../packages/<pkg>/skills/` pattern to find the root. Orchestrator SKILL.mds are under `.../packages/<pkg>/orchestrators/`, not `.../packages/<pkg>/skills/`. The `package_skill_root_of` function falls back to `dirname "$file"` for out-of-pattern paths. This means `calls:` entries in orchestrator SKILL.mds resolve relative to the orchestrator dir, not the package skill root. If the new SKILL.mds use `calls:`, α must set them to avoid the path-resolution trap. Safest: use `requires:` instead of `calls:` for the cross_references.consumed_skills data.
-
-**FN-8: `cue export` vs `cue vet` for `#Wake`.** The I5 validator uses `cue export --out json -d '#Skill'` (line 176). When a SKILL.md has `artifact_class: wake`, the `cue export` call passes `-d '#Skill'`, not `-d '#Wake'`. The `#Skill` definition must include `artifact_class: "wake"` in its enum for the export to succeed. The `#Wake` definition is separate and used for the wake-specific type-check. These are two separate CUE operations: `cue vet -d '#Skill'` (general SKILL.md validation by I5) and `cue vet -d '#Wake'` (AC1 oracle). Both must pass for a wake SKILL.md. This is the correct architecture — the `#Skill` definition is the I5 gate; `#Wake` is the wake-contract gate. α must not conflate them.
-
-## §10. Cross-references + carryforwards
-
-| Carryforward | Source | How applied this cycle |
-|---|---|---|
-| T-486-1 (variable consistency table) | cycle/486 closeouts | α writes seed table in self-coherence.md; β walks every variable × every surface |
-| T-486-7 (R[N] off-by-one prevention) | cycle/486 closeouts | α's iteration discipline cited in §6 α prompt |
-| T-486-12 (operator-final-read defense-in-depth, P1) | cycle/486 + cycle/487 promotion | β explicitly defers "final gate" to operator-final-read |
-| T-487-1 (variable consistency table extended to ALL surfaces) | cycle/487 closeouts | β prompt §"Variable consistency walk" covers 5 columns including prompt body |
-| Byte-identity oracle | cycle/487 Sub 3 (cycle/476 pattern) | The migration oracle at every step; stricter than cycle/476 (which only verified within a single source) |
-| Wake-provider contract (AC4 refusal patterns) | cycle/496 | Renderer refusals PRESERVED post-migration; AC6 confirms they fire from SKILL.md source |
-| AC8/AC7 renderer-side authority audit | cycle/476 / cycle/485 | Not explicitly repeated here; the audit constraint is inherited: renderer must not encode role decisions. The migration does not change role decision encoding — it changes source format only. |
-
-## §11. Non-goals + out-of-scope
-
-- No new wake providers beyond agent-admin and cds-dispatch.
-- No changes to the rendered workflow structure (no new steps, no changed triggers, no permission changes).
-- No changes to the `cn wake install` operator-facing subcommand contract.
-- No migration of test-fixtures at `src/packages/cnos.core/commands/install-wake/test-fixtures/` to SKILL.md format (those fixtures are JSON-native synthetic cases; migrating them is a separate cycle if ever needed).
-- No schema changes to `wake-provider.json` format (the JSON is being replaced, not evolved).
-- No other orchestrator directories (future packages: cnos.cdr, cnos.cdw; those are out of scope for this cycle).
-- No admin dispatch-summary work (cnos#495 Sub 2; HELD).
-- No artifact-root rename (cnos#497; design-held).
-
-## §12. Cycle-shape forecast
-
-- **R0 converge target.** The migration is mechanical: author SKILL.md (body = verbatim prompt), extend CUE, teach renderer, verify byte-identity, delete source. Four phases but each phase has a clear oracle. R0 converge is achievable if α is rigorous about byte-identity at each step and FN-2 (verbatim body) + FN-4 (field mapping completeness) are handled cleanly.
-- **Most likely R0 iterate trigger.** FN-2 (prompt body not verbatim → byte-identity fails) or FN-4 (field mapping gap → renderer skips a field → wrong YAML output). Both are detectable by the W2 parity gate before proceeding to W3.
-- **Operator-final-read expectation.** Operator is likely to verify: (a) SKILL.md body is actually verbatim — not summarized; (b) `#Wake` CUE definition correctly types the role-output disjunction; (c) the W4 deletion proof CI step is load-bearing, not ceremonial.
-- **PR title forecast.** `cycle/524: wake-as-skill migration W1→W4 — typed SKILL.md modules replace JSON+prompt pair`.
+- Issue #524 body: `## W0 design (locked)` — the locked W0 design
+- Issue #524 comments: operator W0 calls (first @usurobor comment) — the 5 decisions
+- Issue #524 comments: ⛳ DISPATCH DIRECTIVE — scope override governing this run
+- `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` — admin wake manifest (reference only)
+- `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` — dispatch wake manifest (reference only)
+- `schemas/skill.cue` — current skill schema (reference only)
+- Prior γ scaffold (cycle/524 commit `f148a1fd`): FN-1 through FN-8 friction notes — material for W1 implementer
 
 ---
 
 Filed by γ@cdd.cnos (wake-invoked δ dispatch, cycle/524), 2026-06-30 (UTC).
+Scope override: operator DISPATCH DIRECTIVE (W0 design only; W1→W4 ACs not in scope for this run).

--- a/.cdd/unreleased/524/gamma-scaffold.md
+++ b/.cdd/unreleased/524/gamma-scaffold.md
@@ -1,0 +1,721 @@
+---
+cycle: 524
+parent_issue: cnos#524
+protocol: cds
+cycle_branch: cycle/524
+base_main_sha: 667388ce30d58a335e44dbf98217eb52eb789d9b
+head_sha_at_scaffold: (filled by scaffold-landing commit)
+mode: MCA
+role: γ
+authored_by: γ@cdd.cnos (wake-invoked δ dispatch)
+date: 2026-06-30 (UTC)
+output_contract: γ-scaffold + α prompt + β prompt
+ac_set: cnos#524 body ACs 1–7
+w0_locked: true
+---
+
+# γ-scaffold — cnos#524: wake-as-skill migration W1→W4
+
+## §1. Issue framing
+
+**The problem.** Wakes today use two artifact systems in parallel: `wake-provider.json` (machine-readable manifest) + `prompt.md` (prompt body), compiled by `cn install-wake` into `.github/workflows/cnos-<wake>.yml`. The SKILL.md contract system (frontmatter + body + CUE validation by I5) runs beside this — not over it. Two contract systems means two maintenance surfaces, two validation pipelines, and no single source of truth for what a wake is.
+
+**The goal.** One contract system. A wake becomes a typed SKILL.md module: `artifact_class: wake`, a `wake:` frontmatter block validated by CUE carrying exactly what `wake-provider.json` carries today, and a body that IS `prompt.md` verbatim. The renderer reads SKILL.md; JSON + prompt are deleted after byte-identical proof.
+
+**Migration shape.** Four phases (W0 operator-ratified and locked):
+
+- **W1:** Author both SKILL.md files beside existing JSON/prompt (body = prompt.md verbatim). Add `#Wake` + `artifact_class: wake` to `skill.cue`. Renderer still reads JSON → goldens unchanged.
+- **W2:** Teach `cn-install-wake` to read SKILL.md; dual-source parity gate: render(SKILL) byte-identical to render(JSON).
+- **W3:** Flip renderer source to SKILL.md; re-render (no-op if byte-identical).
+- **W4:** Delete `wake-provider.json` + `prompt.md` for both wakes after byte-identical proof; I5 now covers 91→93 modules.
+
+**Byte-identity is the migration oracle at every step.**
+
+## §2. Source-of-truth table
+
+| Surface | Path |
+|---|---|
+| CUE schema | `schemas/skill.cue` |
+| I5 validator | `scripts/ci/validate-skill-frontmatter.sh` |
+| Renderer | `src/packages/cnos.core/commands/install-wake/cn-install-wake` |
+| Golden CI | `.github/workflows/install-wake-golden.yml` |
+| agent-admin manifest | `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` |
+| agent-admin prompt | `src/packages/cnos.core/orchestrators/agent-admin/prompt.md` |
+| agent-admin golden | `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` |
+| cds-dispatch manifest | `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` |
+| cds-dispatch prompt | `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md` |
+| cds-dispatch golden | `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` |
+| Live admin workflow | `.github/workflows/cnos-agent-admin.yml` |
+| Live dispatch workflow | `.github/workflows/cnos-cds-dispatch.yml` |
+| agent-admin SKILL.md (to create) | `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` |
+| cds-dispatch SKILL.md (to create) | `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` |
+
+## §3. Surfaces α will touch
+
+### Files to READ (source inputs):
+1. `schemas/skill.cue` — current `#Skill` definition; where to graft `#Wake` and extend `artifact_class`
+2. `src/packages/cnos.core/commands/install-wake/cn-install-wake` — every field consumed from `wake-provider.json` (lines 283–376); every renderer validation path
+3. `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` — agent-admin manifest data
+4. `src/packages/cnos.core/orchestrators/agent-admin/prompt.md` — agent-admin prompt body (verbatim into SKILL.md body)
+5. `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` — cds-dispatch manifest data
+6. `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md` — cds-dispatch prompt body (verbatim into SKILL.md body)
+7. `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` — current golden (byte-identity anchor)
+8. `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` — current golden (byte-identity anchor)
+9. `.github/workflows/install-wake-golden.yml` — CI oracle; where to add dual-source parity gate and W4 deletion proof
+10. `scripts/ci/validate-skill-frontmatter.sh` — I5 validator; confirms discovery pattern (`find src/packages -name SKILL.md`) picks up orchestrator SKILL.mds automatically
+11. `schemas/skill-exceptions.json` — check if any exception entries affect the new SKILL.mds
+12. An existing SKILL.md with a full field set (e.g., `src/packages/cnos.cds/skills/cds/SKILL.md`) for format reference
+
+### Files to MODIFY:
+1. `schemas/skill.cue` — add `"wake"` to `artifact_class` enum; add `#Wake` definition
+2. `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` — **CREATE** (W1 deliverable)
+3. `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` — **CREATE** (W1 deliverable)
+4. `src/packages/cnos.core/commands/install-wake/cn-install-wake` — W2: SKILL.md reader path; W2: dual-source parity; W3: flip source; W4: operate from SKILL.md only
+5. `.github/workflows/install-wake-golden.yml` — add: dual-source parity step (W2), SKILL.md-source render verification (W3), deletion-proof step (W4), I5 count step (91→93)
+6. `src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml` — W3 re-render (no-op expected if byte-identical); W4 confirm unchanged
+7. `src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml` — W3 re-render (no-op expected); W4 confirm unchanged
+8. `.github/workflows/cnos-agent-admin.yml` — W3/W4 re-render for live substrate (no-op expected)
+9. `.github/workflows/cnos-cds-dispatch.yml` — W3/W4 re-render for live substrate (no-op expected)
+
+### Files to DELETE (W4 only, after byte-identical proof):
+1. `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json`
+2. `src/packages/cnos.core/orchestrators/agent-admin/prompt.md`
+3. `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json`
+4. `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md`
+
+## §4. AC oracle table
+
+### AC1 — `#Wake` schema in CUE
+
+**Oracle:** `cue vet -d '#Wake' schemas/skill.cue <wake-frontmatter.yaml>` passes for a conformant wake SKILL.md frontmatter; fails with a diagnostic naming the bad field for a manifest with a bad enum or missing required field.
+
+**Testable boundary:** `schemas/skill.cue` adds:
+- `"wake"` to the `artifact_class` enum in `#Skill`
+- A new `#Wake` definition with the W0-locked shape (role enum; bool fields; enums; nested objects per §W0 design block)
+
+**Filesystem check:**
+```sh
+grep -c '"wake"' schemas/skill.cue  # must return >= 1
+cue vet -d '#Wake' schemas/skill.cue /tmp/conformant-wake.yaml  # exit 0
+cue vet -d '#Wake' schemas/skill.cue /tmp/bad-enum-wake.yaml    # exit nonzero + diagnostic
+```
+
+**Key `#Wake` fields (from W0 design + renderer field consumption at lines 283–523 of cn-install-wake):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `wake.role` | `"admin" \| "dispatch"` | renderer line 342: enum check; cross-field invariants |
+| `wake.package` | `string` | renderer line 281 schema check |
+| `wake.admin_only` | `bool` | renderer line 309/353 |
+| `wake.activation_log_writer` | `bool` | renderer line 452 |
+| `wake.activation_state` | optional `"live" \| "declaration-only"` | renderer line 386 |
+| `wake.protocol` | optional `string` | required when `role == "dispatch"` per renderer line 367 |
+| `wake.selector` | optional `{include: [...string], exclude: [...string]}` | required when `role == "dispatch"` per renderer lines 369-372 |
+| `wake.input.triggers` | `[...string]` | renderer line 338 |
+| `wake.output` | role-shaped disjunction | admin: `{channel_log_convention: string}`; dispatch: `{cycle_artifact_root: string, artifact_class_taxonomy: [...string], cell_runtime: string}` |
+| `wake.permission_intent` | `[...string]` | renderer lines 614-628 |
+| `wake.concurrency` | `{serialize: bool, group: string}` | renderer lines 493-495 |
+| `wake.agent_variable` | `{name: string, default: string \| null}` | renderer lines 85-89 |
+
+**Non-goal:** `#Wake` does NOT carry `responsibilities`, `*_notes`, `cross_references` — those move to body per W0 call #5.
+
+### AC2 — Wake SKILL.md modules authored
+
+**Oracle:** `scripts/ci/validate-skill-frontmatter.sh` validates both new SKILL.md files — total count advances from 91 to 93; self-test green.
+
+**Testable boundary:**
+- `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` exists with `scope: global`, `artifact_class: wake`, `wake:` block carrying exact current `wake-provider.json` data; body = current `prompt.md` verbatim.
+- `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` exists with same shape; dispatch-specific `wake:` fields.
+- Verbose fields (`responsibilities`, `*_notes`, `cross_references`) are in the body, not frontmatter.
+
+**Filesystem check:**
+```sh
+ls src/packages/cnos.core/orchestrators/agent-admin/SKILL.md  # exists
+ls src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md  # exists
+./scripts/ci/validate-skill-frontmatter.sh 2>&1 | grep 'SKILL.md validated'  # shows 93
+./scripts/ci/validate-skill-frontmatter.sh --self-test  # exits 0
+```
+
+**I5 discovery note:** `validate-skill-frontmatter.sh` runs `find src/packages -name SKILL.md`. Both orchestrator dirs are under `src/packages/`; SKILL.md files placed there are discovered automatically — no exception-list changes needed.
+
+### AC3 — Renderer reads SKILL.md
+
+**Oracle:** `cn install-wake <name>` when given a SKILL.md-bearing directory (W2 dual-source) produces output byte-identical to the JSON-sourced render; after W3 flip, renders from SKILL.md only.
+
+**Testable boundary:** renderer code path in `cn-install-wake`:
+- W2: add `--source skill-md` or auto-detect SKILL.md beside manifest; render from SKILL.md; compare bytes to render-from-JSON
+- W3: flip the default source to SKILL.md; the JSON path becomes a fallback or is removed
+
+**Filesystem check:**
+```sh
+# W2 parity (before JSON deletion):
+cn install-wake agent-admin --source skill-md --out /tmp/from-skill.yml
+cn install-wake agent-admin --source json      --out /tmp/from-json.yml
+cmp /tmp/from-skill.yml /tmp/from-json.yml     # must exit 0
+
+# W3 (after flip):
+cn install-wake agent-admin --out /tmp/from-default.yml
+cmp /tmp/from-default.yml src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+```
+
+### AC4 — Byte-identical goldens
+
+**Oracle:** `install-wake golden` CI green: re-render diff clean + sha256 golden==live + idempotence; one-shot dual-source parity check `render(SKILL) cmp render(JSON)` passes before deletion.
+
+**Testable boundary:**
+- Both goldens render byte-identically from SKILL.md versus from JSON
+- sha256 of live `.github/workflows/cnos-*.yml` equals sha256 of the package golden
+- Second render is a no-op (idempotence)
+
+**Filesystem check:**
+```sh
+sha256sum src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+sha256sum .github/workflows/cnos-agent-admin.yml
+# must match
+
+sha256sum src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+sha256sum .github/workflows/cnos-cds-dispatch.yml
+# must match
+```
+
+### AC5 — JSON + prompt deleted
+
+**Oracle:** `wake-provider.json` and `prompt.md` absent for both wakes; `cn install-wake` still renders byte-identical goldens.
+
+**Testable boundary:** files absent + renderer still produces correct output from SKILL.md only.
+
+**Filesystem check:**
+```sh
+ls src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json  # must NOT exist
+ls src/packages/cnos.core/orchestrators/agent-admin/prompt.md            # must NOT exist
+ls src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json   # must NOT exist
+ls src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md            # must NOT exist
+cn install-wake agent-admin   # exit 0; golden unchanged
+cn install-wake cds-dispatch  # exit 0; golden unchanged
+```
+
+### AC6 — Renderer refusals preserved
+
+**Oracle:** existing cycle/496 mis-declaration smoke in `install-wake-golden.yml` still passes; a synthetic mis-declared wake SKILL.md → exit 4.
+
+**Testable boundary:** after W3/W4, the renderer reads the `wake:` block from SKILL.md and applies the same refusal logic previously applied against JSON fields:
+- `activation_state != "live"` → exit 3
+- `role:dispatch + admin_only:false + activation_log_writer:true` → exit 4
+- `activation_log_writer:false + attach in cross_references` → exit 4 (FN-6 defense-in-depth)
+
+**Filesystem check:**
+```sh
+# Existing AC4/AC5 smoke in install-wake-golden.yml must still pass:
+# Step "AC4 (cycle/496) — renderer refusal on mis-declaration" exits 4.
+# Step "AC5 — declaration-only refusal" exits 3.
+# If synthetic fixture JSONs are deleted (or kept alongside), verify the smoke
+# is wired to SKILL.md-sourced equivalents post-W4.
+```
+
+### AC7 — All gates green
+
+**Oracle:** I1/I2/I4/I5/I6/`install-wake golden`/`dispatch-repair-preflight`/Go/Package/Binary all green on the cell's PR.
+
+**Testable boundary:** no inherited-cap failures; no new red gates.
+
+**Filesystem check:** CI run on the PR passes all jobs.
+
+## §5. Implementation contract (for α dispatch prompt)
+
+| Axis | Value |
+|---|---|
+| **Branch** | `cycle/524` |
+| **Base SHA** | `667388ce30d58a335e44dbf98217eb52eb789d9b` |
+| **Issue** | cnos#524 |
+| **Mode** | MCA — W0 operator-ratified; α executes W1→W4 sequence |
+| **AC set** | AC1–AC7 (all) |
+| **W0 non-goals** | No rendered-workflow output change; no runtime-behavior change; no renderer substrate-encoding change; no new wake names; no schema changes outside `schemas/skill.cue`; no I5 exception-list additions |
+| **Byte-identity oracle** | `cmp render(SKILL) render(JSON)` must pass at every intermediate step before deletion |
+| **Deletion gate** | W4 deletions ONLY after byte-identical proof holds in CI |
+
+## §6. α dispatch prompt
+
+```text
+You are α@cdd.cnos, running as the implementer for cycle/524.
+
+Branch: cycle/524 (at base main SHA 667388ce30d58a335e44dbf98217eb52eb789d9b).
+Parent issue: cnos#524 ("wake-as-skill: migrate wakes to typed SKILL.md modules").
+Scaffold: .cdd/unreleased/524/gamma-scaffold.md (READ THIS FIRST in full before any edits).
+
+## What you implement
+
+Implement R0 of the W1→W4 migration per the operator-ratified W0 design (locked; no design reframing without operator approval). The 7 ACs are the acceptance surface. The byte-identity oracle is the migration correctness proof at every step.
+
+## Skills to load before implementing
+
+Load these skills in order:
+1. `src/packages/cnos.cds/skills/cds/SKILL.md` — CDS protocol discipline
+2. `src/packages/cnos.cdd/skills/cdd/alpha/SKILL.md` — α role contract
+3. `src/packages/cnos.cdd/skills/cdd/SKILL.md` — cell-runtime framework
+
+## Implementation contract
+
+| Axis | Value |
+|---|---|
+| Branch | cycle/524 |
+| Base SHA | 667388ce30d58a335e44dbf98217eb52eb789d9b |
+| Issue | cnos#524 |
+| Mode | MCA — execute known W1→W4 sequence; W0 is locked |
+| AC set | AC1–AC7 (all) |
+| W0 non-goals | No rendered-workflow output change; no runtime-behavior change; no new wake names; no schema changes outside schemas/skill.cue |
+| Byte-identity oracle | cmp render(SKILL) render(JSON) must pass at every step before deletion |
+| Deletion gate | W4 deletions ONLY after byte-identical proof CI-green |
+
+## Implementation order (W1 → W4; minimizes inter-step risk)
+
+### W1 — Schema + both SKILL.md files (AC1 + AC2)
+
+**Step 1: Extend `schemas/skill.cue` (AC1)**
+- Add `"wake"` to the `artifact_class` enum in `#Skill` (line 35).
+- Add `#Wake` definition after `#Skill`. The `#Wake` definition must type-check the `wake:` block per the W0 design (see γ-scaffold §4 AC1 field table and §5 for the complete W0 wake: block shape).
+- Key design constraints for `#Wake`:
+  - `wake.role: "admin" | "dispatch"` (not observer — the renderer's enum check at line 342 of cn-install-wake accepts admin/dispatch/observer but the W0 schema is admin|dispatch only)
+  - Role-shaped output disjunction: if `wake.role == "admin"` then `wake.output.channel_log_convention: string` required; if `wake.role == "dispatch"` then `wake.output.{cycle_artifact_root, artifact_class_taxonomy, cell_runtime}` required.
+  - `wake.selector` is required when `role == "dispatch"` (sub-fields: `include: [...string]`, `exclude: [...string]`).
+  - `wake.protocol` is optional string (required for dispatch semantically but CUE enforces it as optional to not break admin shapes).
+  - Keep `#Wake` open (`...`) per the LANGUAGE-SPEC §11 principle from `#Skill`.
+
+**Step 2: Author `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` (AC2)**
+
+Frontmatter:
+```yaml
+---
+name: agent-admin
+description: "<from wake-provider.json description field>"
+governing_question: "How does the agent-admin wake orchestrate the admin role for a given agent installation?"
+triggers:
+  - "cn install-wake agent-admin --agent <agent>"
+  - "schedule (cron; substrate-encoded by renderer)"
+  - "issues:opened with title matching issues_opened_title_pattern"
+scope: global
+artifact_class: wake
+kata_surface: none
+inputs:
+  - "home thread (.cn-{agent}/threads/activations/{this-hub}/)"
+  - "open issues in this repo (read-only)"
+outputs:
+  - ".cn-{agent}/logs/YYYYMMDD.md (channel log entry)"
+  - ".cn-{agent}/state/ (cursor advancement)"
+wake:
+  role: admin
+  package: cnos.core
+  admin_only: true
+  activation_log_writer: true
+  input:
+    triggers:
+      - schedule
+      - issues_opened_title_match
+    issues_opened_title_pattern: claude-wake
+  output:
+    channel_log_convention: docs/reference/conventions/AGENT-ACTIVATION-LOG-v0.md
+  permission_intent:
+    - contents.write
+    - issues.write
+    - pull_requests.write
+    - id_token.write
+  concurrency:
+    serialize: true
+    group: agent-admin-{agent}
+  agent_variable:
+    name: agent
+    default: null
+---
+```
+
+Body: the VERBATIM content of `src/packages/cnos.core/orchestrators/agent-admin/prompt.md`, followed (optionally, in a trailing `## Reference` section) by the verbose data from wake-provider.json that moves to body per W0 call #5: `responsibilities`, `*_notes`, `cross_references`, `allowed_surfaces`, `disallowed_surfaces`, `defer_path`, `relationship_to_substrate`.
+
+**Step 3: Author `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` (AC2)**
+
+Frontmatter:
+```yaml
+---
+name: cds-dispatch
+description: "<from wake-provider.json description field>"
+governing_question: "How does the cds-dispatch wake claim and route CDS cells to the δ role contract?"
+triggers:
+  - "cn install-wake cds-dispatch --agent <agent>"
+  - "schedule (cron; substrate-encoded by renderer)"
+  - "issues:labeled with label in selector.include"
+scope: global
+artifact_class: wake
+kata_surface: none
+inputs:
+  - "open issues matching selector (dispatch:cell + protocol:cds + status:todo, minus exclude labels)"
+outputs:
+  - ".cdd/unreleased/{N}/ (cell artifact root via δ/γ/α/β)"
+  - "issue lifecycle labels on claimed cell"
+  - "pull request for claimed cell"
+wake:
+  role: dispatch
+  package: cnos.cds
+  admin_only: false
+  activation_log_writer: false
+  activation_state: live
+  protocol: cds
+  selector:
+    include:
+      - dispatch:cell
+      - protocol:cds
+      - status:todo
+    exclude:
+      - status:in-progress
+      - status:blocked
+      - status:review
+      - status:changes
+  input:
+    triggers:
+      - schedule
+      - issues_labeled_selector_match
+  output:
+    cycle_artifact_root: .cdd/unreleased/{N}/
+    artifact_class_taxonomy:
+      - gamma-scaffold
+      - self-coherence
+      - beta-review
+      - alpha-closeout
+      - beta-closeout
+      - gamma-closeout
+      - post-release-assessment
+    cell_runtime: cnos.cdd
+  permission_intent:
+    - contents.write
+    - issues.write
+    - pull_requests.write
+    - id_token.write
+  concurrency:
+    serialize: true
+    group: cds-dispatch-{agent}
+  agent_variable:
+    name: agent
+    default: sigma
+---
+```
+
+Body: VERBATIM content of `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md`, followed by the verbose cross_references, responsibilities, *_notes, allowed/disallowed surfaces, and defer_path from wake-provider.json.
+
+**W1 verification (before proceeding to W2):**
+```sh
+cue vet -d '#Skill' schemas/skill.cue src/packages/cnos.core/orchestrators/agent-admin/SKILL.md
+cue vet -d '#Skill' schemas/skill.cue src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
+./scripts/ci/validate-skill-frontmatter.sh 2>&1 | grep 'SKILL.md validated'  # should show 93
+./scripts/ci/validate-skill-frontmatter.sh --self-test  # exit 0
+# Goldens UNCHANGED — renderer still reads JSON:
+cn install-wake agent-admin   # no diff to golden
+cn install-wake cds-dispatch  # no diff to golden
+```
+
+### W2 — Teach renderer to read SKILL.md; dual-source parity gate (AC3 + AC4)
+
+**Step 4: Extend `cn-install-wake` to parse SKILL.md**
+
+The renderer currently reads fields from `wake-provider.json` via `jq`. For W2, add a SKILL.md parsing path:
+- Detect `SKILL.md` beside the manifest path.
+- Extract the YAML frontmatter (between the two `---` delimiters).
+- Map `wake.*` frontmatter keys to the variables the renderer currently reads from JSON:
+  - `name` ← `name` (top-level in both)
+  - `package` ← `wake.package`
+  - `role` ← `wake.role`
+  - `admin_only` ← `wake.admin_only`
+  - `activation_log_writer` ← `wake.activation_log_writer`
+  - `activation_state` ← `wake.activation_state` (default: `"live"` when absent)
+  - `protocol` ← `wake.protocol`
+  - `selector` ← `wake.selector`
+  - `input_contract.triggers` ← `wake.input.triggers`
+  - `input_contract.issues_opened_title_pattern` ← `wake.input.issues_opened_title_pattern`
+  - `output_contract.*` ← `wake.output.*`
+  - `permission_intent` ← `wake.permission_intent`
+  - `concurrency_intent.serialize` ← `wake.concurrency.serialize`
+  - `concurrency_intent.group` ← `wake.concurrency.group`
+  - `agent_variable.default` ← `wake.agent_variable.default`
+  - **prompt body** ← SKILL.md body (everything after the second `---`)
+- Expose this as `--source skill-md` flag (or auto-detect: if SKILL.md present beside manifest, available as alternative source). Keep `--source json` (or default) path unchanged.
+
+**Step 5: Add dual-source parity gate to `install-wake-golden.yml` (AC4)**
+
+Add a new CI step after the existing "Re-render" steps:
+```yaml
+- name: W2 parity gate — render(SKILL) == render(JSON) for both wakes
+  run: |
+    set -euo pipefail
+    for wake in agent-admin cds-dispatch; do
+      ./src/packages/cnos.core/commands/install-wake/cn-install-wake "$wake" \
+        --source skill-md --out /tmp/${wake}-from-skill.yml
+      ./src/packages/cnos.core/commands/install-wake/cn-install-wake "$wake" \
+        --source json     --out /tmp/${wake}-from-json.yml
+      if ! cmp -s /tmp/${wake}-from-skill.yml /tmp/${wake}-from-json.yml; then
+        echo "::error::W2 parity FAILED for $wake: render(SKILL) != render(JSON)"
+        diff /tmp/${wake}-from-skill.yml /tmp/${wake}-from-json.yml || true
+        exit 1
+      fi
+      echo "W2 parity OK ($wake): render(SKILL) == render(JSON)"
+    done
+```
+
+### W3 — Flip renderer source to SKILL.md; re-render (AC3 + AC4)
+
+**Step 6: Flip default source in `cn-install-wake`**
+
+Change the resolver so that when SKILL.md is present, it is the primary source (not the JSON). The JSON fallback path remains for backward compatibility until W4.
+
+**Step 7: Re-render goldens and live workflows**
+
+```sh
+cn install-wake agent-admin   --out src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+cn install-wake cds-dispatch  --out src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+cn install-wake agent-admin   --out .github/workflows/cnos-agent-admin.yml
+cn install-wake cds-dispatch  --out .github/workflows/cnos-cds-dispatch.yml
+```
+
+These MUST produce zero diff if byte-identical — the oracle passes. If any diff appears: stop, file an FN, do NOT proceed to W4.
+
+### W4 — Delete JSON + prompt; I5 count confirms 93 (AC5 + AC7)
+
+**Step 8: Confirm byte-identity in CI, then delete source files**
+
+Only after W3 re-renders are verified byte-identical in CI:
+```sh
+rm src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json
+rm src/packages/cnos.core/orchestrators/agent-admin/prompt.md
+rm src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json
+rm src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md
+```
+
+**Step 9: Update renderer to remove JSON fallback path**
+
+After deletion, remove the JSON parsing path from `cn-install-wake` (the dead code for `wake-provider.json` lookup). The manifest path `--manifest <path>` flag still works but resolves against SKILL.md instead.
+
+**Step 10: Update `install-wake-golden.yml` for W4**
+
+- Remove or update the `--manifest` path comments that reference `wake-provider.json`.
+- Add an I5 count assertion step:
+  ```yaml
+  - name: I5 count check (93 SKILL.md post-W4)
+    run: |
+      n=$(find src/packages -name SKILL.md | wc -l)
+      if [ "$n" -ne 93 ]; then
+        echo "::error::Expected 93 SKILL.md files post-W4; found $n"
+        exit 1
+      fi
+      echo "I5 count OK: $n SKILL.md files"
+  ```
+- Add a W4 deletion-proof step confirming JSON + prompt absent for both wakes.
+- Verify `cn install-wake` still renders byte-identical goldens.
+
+## Commit message pattern
+
+```
+α-524 W1: <step name summary>
+α-524 W2: <step name summary>
+α-524 W3: <step name summary>
+α-524 W4: <step name summary>
+α-524 R0 signal: ready for β review
+```
+
+## Signaling β-readiness
+
+After all steps land + push, write `.cdd/unreleased/524/self-coherence.md` §R0, commit as `α-524 R0: self-coherence §R0`, push. Then add a signal commit `α-524 R0 signal: ready for β review` (zero file changes).
+
+## Scope guardrails (hard constraints)
+
+- **NO rendered-workflow output change** unless caused by a genuine field delta between JSON and SKILL.md (any such delta is an R0 blocker — stop, file FN, do not proceed to W3).
+- **NO runtime-behavior change** — the renderer's refusal logic (exits 2/3/4), the write-fence step, the permission encoding, the cron slots, the bot identity bindings — none of these change in this migration.
+- **NO renderer substrate-encoding change** — the YAML structure the renderer emits is unchanged; only the SOURCE it reads from changes.
+- **NO new wake names** — this migration covers agent-admin and cds-dispatch exactly.
+- **NO schema changes outside `schemas/skill.cue`** — do not modify I5 validator logic.
+- **NO I5 exception-list additions** — the new SKILL.mds must pass cue vet without exception entries.
+- **Byte-identity at every step** — if `cmp render(SKILL) render(JSON)` fails at any point in W2 or later, stop and file an FN before continuing.
+- **Deletion is W4-only** — do NOT delete JSON or prompt until CI confirms byte-identical goldens from SKILL.md source.
+
+## Re-iteration discipline
+
+If β R0 returns iterate:
+- Read β's review; do NOT re-derive ACs from scratch.
+- R[N] section in self-coherence.md per T-486-7 off-by-one prevention.
+- Apply δ-direct R1 pattern if the iterate is narrow + mechanical (single file/line fix without architectural reframing).
+
+## Hard do-not-cross lines
+
+- Do NOT pre-empt or modify any cycle outside cycle/524's scope.
+- Do NOT modify the test-fixtures at `src/packages/cnos.core/commands/install-wake/test-fixtures/` unless a new mis-declared SKILL.md fixture is needed for AC6 verification (in which case: file an FN naming the new fixture and why it's needed).
+- Do NOT touch `schemas/skill-exceptions.json` — new SKILL.mds must be clean.
+- Do NOT modify `.cn-sigma/logs/` — this cycle has no activation-log write scope.
+```
+
+## §7. β dispatch prompt
+
+```text
+You are β@cdd.cnos, running as the reviewer for cycle/524 R0.
+
+Branch: cycle/524 (read α's R0 commits up to and including the "α-524 R0 signal" commit).
+Parent issue: cnos#524 ("wake-as-skill: migrate wakes to typed SKILL.md modules").
+Scaffold: .cdd/unreleased/524/gamma-scaffold.md (read in full).
+α self-coherence: .cdd/unreleased/524/self-coherence.md §R0 (read in full).
+
+## Your output
+
+Write `.cdd/unreleased/524/beta-review.md` with §R0 review. Final verdict: **converge** OR **iterate**.
+
+## Pre-AC checklist (mechanical; walk every item in order)
+
+**AC1 — `#Wake` schema in CUE:**
+- `schemas/skill.cue` adds `"wake"` to `artifact_class` enum.
+- `#Wake` definition present with correct field types/enums per W0 design.
+- Run: `cue vet -d '#Wake' schemas/skill.cue /tmp/conformant-wake.yaml` → exit 0.
+- Run a bad-enum fixture → exit nonzero + diagnostic. Record both results.
+
+**AC2 — Wake SKILL.md modules authored:**
+- Both SKILL.md files exist at the paths in §2 Source-of-truth table.
+- Frontmatter carries `scope: global`, `artifact_class: wake`, `wake:` block with exact manifest data.
+- Body contains prompt.md content verbatim (no paraphrase; no summary; literal copy).
+- Verbose fields (`responsibilities`, `*_notes`, `cross_references`) are in body ONLY, not frontmatter.
+- `./scripts/ci/validate-skill-frontmatter.sh` exits 0 and reports 93 SKILL.md.
+
+**AC3 — Renderer reads SKILL.md:**
+- `cn-install-wake` has a SKILL.md parsing path.
+- The field mapping from `wake.*` to renderer variables is complete (no missing fields; see γ-scaffold §4 AC1 table).
+- After W3 flip: `cn install-wake agent-admin` uses SKILL.md as primary source.
+
+**AC4 — Byte-identical goldens:**
+- `cmp render(SKILL) render(JSON)` passes for BOTH wakes (record sha256 of each pair).
+- sha256(golden) == sha256(live workflow) for both wakes.
+- Second render is a no-op (idempotence: sha256 before == sha256 after).
+- The W2 parity CI step is present in `install-wake-golden.yml` and passes.
+
+**AC5 — JSON + prompt deleted:**
+- All four deletion-target files are absent in the W4 commit.
+- `cn install-wake` still renders byte-identical goldens post-deletion.
+- `install-wake-golden.yml` W4 deletion-proof step present and passes.
+
+**AC6 — Renderer refusals preserved:**
+- Existing cycle/496 refusal smoke in `install-wake-golden.yml` still passes: exit 4 + "activation_log_writer mis-declaration" in stderr; exit 3 on declaration-only fixture.
+- Refusal logic fires correctly whether source is JSON (W2) or SKILL.md (W3/W4).
+- If α created a synthetic mis-declared SKILL.md fixture: verify it exits 4.
+
+**AC7 — All gates green:**
+- No inherited-cap failures; no new red gates on the PR.
+- I5 count step in CI reports 93.
+
+## Independence requirement
+
+β must reach its verdict independently. Do NOT ask α to pre-certify; do NOT accept α's self-assessment as a substitute for β's own verification. Run the oracles yourself (or simulate them against the committed state).
+
+## Variable consistency walk (T-486-1 + T-487-1)
+
+Walk every variable that changed across: SKILL.md frontmatter → renderer field consumption → rendered workflow YAML → CI oracle → prompt body → PR body.
+
+Key variables to check:
+| Variable | SKILL.md `wake:` block | Renderer parsing | Rendered YAML | CI assertion | Body prose |
+|---|---|---|---|---|---|
+| `wake.role` | `admin` / `dispatch` | line ~342 enum check | implicit in shape | AC1 CUE vet | body mentions role |
+| `wake.activation_log_writer` | `true` / `false` | line ~452 mis-declaration check | write-fence step presence | AC6 refusal smoke | body names "non-writer" |
+| `wake.concurrency.group` | `agent-admin-{agent}` / `cds-dispatch-{agent}` | line ~498 substitution | `group:` in YAML | golden shape check | body mentions concurrency |
+| prompt body | verbatim in SKILL.md body | body extraction after `---` | `prompt: \|` block | sha256 parity | N/A (IS the body) |
+
+Flag any drift between columns.
+
+## Per-CI-step bash-e audit (cnos#478 mechanical-injection)
+
+For every new `run:` step α added to `install-wake-golden.yml`:
+- Verify `set -eu` / `set -euo pipefail` is in effect.
+- Verify no `grep -c ... | true` pipefail-trap class.
+- Verify fixture cleanup (no orphaned temp files after step).
+
+## Byte-identity audit (load-bearing)
+
+1. Record sha256 of both goldens from JSON source (pre-W3 baseline).
+2. Record sha256 of both goldens from SKILL.md source (W2 parity render).
+3. Verify all four sha256s match.
+4. Record sha256 of live workflows; verify they match goldens.
+5. After W4 deletion: re-verify goldens unchanged.
+
+If any pair mismatches: P0 blocker. Iterate immediately. Byte-identity is the migration oracle.
+
+## Output structure for `.cdd/unreleased/524/beta-review.md`
+
+- **§R0 frontmatter.** YAML with cycle, base SHA, α R0 signal commit SHA, β review timestamp.
+- **§R0 verdict.** `converge` OR `iterate` at the top, before narrative.
+- **§R0 AC table.** AC1–AC7 with per-AC green/red/ambiguous + oracle command + observation.
+- **§R0 variable consistency walk.** Every variable × every column.
+- **§R0 per-CI-step bash-e audit.** Every modified/added `run:` step + result.
+- **§R0 byte-identity audit.** sha256 pairs for all four files.
+- **§R0 friction notes (if any).** FN-β-N entries.
+
+## When to iterate vs converge
+
+- **Iterate** if: any byte-identity pair mismatches; any AC oracle returns red; SKILL.md body is NOT verbatim prompt.md (paraphrase = red); renderer skips a field from the `wake:` block; I5 count != 93; any existing refusal smoke breaks.
+- **Converge** if: byte-identical across all pairs; all AC oracles green; I5 count = 93; existing CI smokes all pass; variable consistency clean.
+
+## Hard constraints
+
+- **Do NOT iterate for taste** — β iterates only when an oracle returns red or a load-bearing invariant is violated.
+- **Do NOT modify any α-written file** — β reviews; does not implement.
+- **Honor T-486-12 (operator-final-read P1)** — β converge is not the cycle's final gate.
+- **Commit message:** `β-524 R0 review: <converge|iterate>`. Co-Authored-By trailer matches prior cycles.
+```
+
+## §8. Scope guardrails (W0 non-goals)
+
+These are hard guardrails α and β must both enforce:
+
+1. **No rendered-workflow output change.** The YAML emitted by `cn install-wake` for both wakes must be byte-identical before and after the migration. Any diff is an R0 blocker.
+2. **No runtime-behavior change.** The renderer's refusals (exits 2/3/4), the write-fence step logic, the permission block, the cron-slot encoding, the bot identity table — none change. This migration is a source-swap, not a behavior change.
+3. **No renderer substrate-encoding change.** The `gha_permission_line` function, the cron-slot list (`8 23 38 53`), the `anthropics/claude-code-action@v1` pinning, the `SIGMA_WORKFLOW_PAT` secret name, the `cancel-in-progress: false` policy — all unchanged.
+4. **No new wake names.** Migration scope is exactly: `agent-admin` (cnos.core) and `cds-dispatch` (cnos.cds).
+5. **No other schema changes.** `schemas/skill.cue` changes are limited to: adding `"wake"` to the `artifact_class` enum + adding the `#Wake` definition. No other field or constraint changes.
+
+## §9. Friction notes (anticipated classes for α + β)
+
+**FN-1: Frontmatter YAML quoting.** The wake-provider.json contains string values with characters that may require quoting in YAML frontmatter (colons in descriptions, curly braces in `{agent}` substitution tokens). `{agent}` tokens in strings like `"agent-admin-{agent}"` must be quoted in YAML to avoid being parsed as flow mappings. α must verify: `cue vet` passes with the actual frontmatter text, not a simplified version.
+
+**FN-2: Prompt body verbatim discipline.** The SKILL.md body must contain prompt.md content verbatim — not paraphrased, not reformatted, not summarized. The byte-identity oracle (AC4) is the enforcement mechanism: if the renderer's body-extraction produces a different string than the raw `prompt.md`, the rendered output will differ. Any transform applied to the body (e.g., indentation normalization, line-ending normalization) will break byte-identity. The renderer currently uses `sed "s/{agent}/${agent}/g" "$prompt_path"` — the SKILL.md body extraction path must apply the same substitution and the same trailing-whitespace strip (`sed 's/[[:space:]]*$//'`) to produce identical output.
+
+**FN-3: The renderer's `--manifest` flag interaction.** `cn-install-wake` accepts `--manifest <path>` to override the default JSON lookup. The manifest-override path resolves `prompt_path` relative to the manifest's directory (`manifest_dir`). When the source is SKILL.md, the body extraction replaces both: the `prompt_template` JSON field lookup AND the `$manifest_dir/$prompt_template_relpath` file read. The W2 SKILL.md path must handle `--manifest` correctly — if `--manifest` points to a SKILL.md (or if there's a SKILL.md beside a `--manifest`-specified JSON), the precedence is well-defined. α should document the flag interaction in the renderer comments.
+
+**FN-4: Renderer field name mapping (`input_contract` vs `wake.input`).** The JSON manifest uses `input_contract: {triggers: [...]}` while the W0 SKILL.md shape uses `wake: {input: {triggers: [...]}}`. The renderer currently reads `jq -r '.input_contract.triggers'`. The SKILL.md parser must read `wake.input.triggers` and expose it as `input_contract_triggers` (or however the renderer variable is named) to avoid duplication of the rendering logic. α must map ALL fields — including the less-obvious ones like `input_contract.issues_opened_title_pattern` ← `wake.input.issues_opened_title_pattern` and `output_contract.channel_log_convention` ← `wake.output.channel_log_convention` (admin shape) and `output_contract.{cycle_artifact_root,artifact_class_taxonomy,cell_runtime}` ← `wake.output.{...}` (dispatch shape).
+
+**FN-5: `cross_references.consumed_skills` FN-6 defense-in-depth check.** The renderer currently (at line 477-484) checks `cross_references.consumed_skills` from the JSON for the FN-6 attach-incompatibility refusal. After W3/W4, this data moves to the SKILL.md body (per W0 call #5: `cross_references` → body). The renderer must extract this from the SKILL.md body OR the `calls` / `requires` frontmatter field. Design choice: either (a) keep `cross_references.consumed_skills` in the SKILL.md frontmatter as a `requires:` list (LANGUAGE-SPEC §11 allows this), or (b) move the FN-6 check to a body-prose check (fragile). Option (a) is preferred. α must document this choice as a design fork and record the resolution in self-coherence.md.
+
+**FN-6: `activation_state_notes` field.** The renderer reads `activation_state_notes` from the JSON (line 387) for the exit-3 refusal message. The W0 `wake:` block shape does not include this field. α must decide: add `wake.activation_state_notes` as an optional string to `#Wake`, OR absorb the notes into the body. If absorbed into body, the renderer's exit-3 message will not include the notes content. This is a narrow behavioral change (refusal message text only; not the refusal itself). α should file an FN if the notes are dropped from the exit-3 message.
+
+**FN-7: I5 discovery path — are orchestrator/ dirs under `src/packages/`?** The I5 validator runs `find src/packages -name SKILL.md`. Both orchestrator dirs (`src/packages/cnos.core/orchestrators/agent-admin/` and `src/packages/cnos.cds/orchestrators/cds-dispatch/`) ARE under `src/packages/`. Discovery is automatic — confirmed. However, α should verify the `calls:` resolution in `validate_skill_file` for orchestrator SKILL.mds: `package_skill_root_of` uses the path's `.../packages/<pkg>/skills/` pattern to find the root. Orchestrator SKILL.mds are under `.../packages/<pkg>/orchestrators/`, not `.../packages/<pkg>/skills/`. The `package_skill_root_of` function falls back to `dirname "$file"` for out-of-pattern paths. This means `calls:` entries in orchestrator SKILL.mds resolve relative to the orchestrator dir, not the package skill root. If the new SKILL.mds use `calls:`, α must set them to avoid the path-resolution trap. Safest: use `requires:` instead of `calls:` for the cross_references.consumed_skills data.
+
+**FN-8: `cue export` vs `cue vet` for `#Wake`.** The I5 validator uses `cue export --out json -d '#Skill'` (line 176). When a SKILL.md has `artifact_class: wake`, the `cue export` call passes `-d '#Skill'`, not `-d '#Wake'`. The `#Skill` definition must include `artifact_class: "wake"` in its enum for the export to succeed. The `#Wake` definition is separate and used for the wake-specific type-check. These are two separate CUE operations: `cue vet -d '#Skill'` (general SKILL.md validation by I5) and `cue vet -d '#Wake'` (AC1 oracle). Both must pass for a wake SKILL.md. This is the correct architecture — the `#Skill` definition is the I5 gate; `#Wake` is the wake-contract gate. α must not conflate them.
+
+## §10. Cross-references + carryforwards
+
+| Carryforward | Source | How applied this cycle |
+|---|---|---|
+| T-486-1 (variable consistency table) | cycle/486 closeouts | α writes seed table in self-coherence.md; β walks every variable × every surface |
+| T-486-7 (R[N] off-by-one prevention) | cycle/486 closeouts | α's iteration discipline cited in §6 α prompt |
+| T-486-12 (operator-final-read defense-in-depth, P1) | cycle/486 + cycle/487 promotion | β explicitly defers "final gate" to operator-final-read |
+| T-487-1 (variable consistency table extended to ALL surfaces) | cycle/487 closeouts | β prompt §"Variable consistency walk" covers 5 columns including prompt body |
+| Byte-identity oracle | cycle/487 Sub 3 (cycle/476 pattern) | The migration oracle at every step; stricter than cycle/476 (which only verified within a single source) |
+| Wake-provider contract (AC4 refusal patterns) | cycle/496 | Renderer refusals PRESERVED post-migration; AC6 confirms they fire from SKILL.md source |
+| AC8/AC7 renderer-side authority audit | cycle/476 / cycle/485 | Not explicitly repeated here; the audit constraint is inherited: renderer must not encode role decisions. The migration does not change role decision encoding — it changes source format only. |
+
+## §11. Non-goals + out-of-scope
+
+- No new wake providers beyond agent-admin and cds-dispatch.
+- No changes to the rendered workflow structure (no new steps, no changed triggers, no permission changes).
+- No changes to the `cn wake install` operator-facing subcommand contract.
+- No migration of test-fixtures at `src/packages/cnos.core/commands/install-wake/test-fixtures/` to SKILL.md format (those fixtures are JSON-native synthetic cases; migrating them is a separate cycle if ever needed).
+- No schema changes to `wake-provider.json` format (the JSON is being replaced, not evolved).
+- No other orchestrator directories (future packages: cnos.cdr, cnos.cdw; those are out of scope for this cycle).
+- No admin dispatch-summary work (cnos#495 Sub 2; HELD).
+- No artifact-root rename (cnos#497; design-held).
+
+## §12. Cycle-shape forecast
+
+- **R0 converge target.** The migration is mechanical: author SKILL.md (body = verbatim prompt), extend CUE, teach renderer, verify byte-identity, delete source. Four phases but each phase has a clear oracle. R0 converge is achievable if α is rigorous about byte-identity at each step and FN-2 (verbatim body) + FN-4 (field mapping completeness) are handled cleanly.
+- **Most likely R0 iterate trigger.** FN-2 (prompt body not verbatim → byte-identity fails) or FN-4 (field mapping gap → renderer skips a field → wrong YAML output). Both are detectable by the W2 parity gate before proceeding to W3.
+- **Operator-final-read expectation.** Operator is likely to verify: (a) SKILL.md body is actually verbatim — not summarized; (b) `#Wake` CUE definition correctly types the role-output disjunction; (c) the W4 deletion proof CI step is load-bearing, not ceremonial.
+- **PR title forecast.** `cycle/524: wake-as-skill migration W1→W4 — typed SKILL.md modules replace JSON+prompt pair`.
+
+---
+
+Filed by γ@cdd.cnos (wake-invoked δ dispatch, cycle/524), 2026-06-30 (UTC).

--- a/.cdd/unreleased/524/self-coherence.md
+++ b/.cdd/unreleased/524/self-coherence.md
@@ -1,0 +1,172 @@
+---
+cycle: 524
+parent_issue: cnos#524
+document_class: self-coherence
+authored_by: α@cdd.cnos (R0)
+date: 2026-06-30 (UTC)
+---
+
+# Self-coherence — cnos#524 R0
+
+## §R0
+
+### 1. Scope guardrail confirmation
+
+Files NOT touched by this run (hard constraints per operator directive and γ-scaffold §7):
+
+| File / surface | Status |
+|---|---|
+| `schemas/skill.cue` | Not touched |
+| `src/packages/cnos.core/commands/install-wake/cn-install-wake` | Not touched |
+| `src/packages/cnos.core/orchestrators/agent-admin/wake-provider.json` | Not touched |
+| `src/packages/cnos.core/orchestrators/agent-admin/prompt.md` | Not touched |
+| `src/packages/cnos.cds/orchestrators/cds-dispatch/wake-provider.json` | Not touched |
+| `src/packages/cnos.cds/orchestrators/cds-dispatch/prompt.md` | Not touched |
+| `.github/workflows/*.yml` | Not touched |
+| `*.golden.yml` | Not touched |
+| Any W1→W4 implementation files | Not created |
+
+**Writable outputs produced:**
+- `.cdd/unreleased/524/w0-design.md` — the W0 design document (this run's primary output)
+- `.cdd/unreleased/524/self-coherence.md §R0` — this document
+
+### 2. §4 structure walk (§A through §I)
+
+| Section | Present | Internal coherence |
+|---|---|---|
+| §A — Problem statement and invariant | yes | Two-sentence problem (two contract systems, should be one); invariant stated verbatim from issue body |
+| §B — `wake:` block schema | yes | Complete field listing with types, optionality, role-shaped disjunction; field-by-field cross-reference table to both `wake-provider.json` files |
+| §C — 5 operator design decisions | yes | All 5 decisions present (nesting, artifact_class, scope, CUE/renderer boundary, body-as-prompt); each has decision + rationale + W1 implication |
+| §D — CUE ↔ renderer boundary table | yes | 15-row table; no concern appears in both columns; consistent with §C Decision 4 |
+| §E — Body-as-prompt rule | yes | Frontmatter/body split defined; byte-identity oracle named; `install-wake golden` cited as substrate oracle |
+| §F — W1→W4 migration plan | yes | 4 phases; oracle at each phase boundary; state after each phase described |
+| §G — W1 ACs (AC1–AC7) | yes | All 7 ACs from issue body present; oracle for each AC |
+| §H — Friction notes | yes | FN-1 through FN-8 present; material for W1 implementer |
+| §I — Non-goals | yes | 8 explicit non-goals; consistent with issue body non-goals section |
+
+### 3. Field completeness check — §B vs both `wake-provider.json` files
+
+**agent-admin `wake-provider.json` fields:**
+
+| Field | Covered in §B? | Disposition |
+|---|---|---|
+| `schema` | yes | → "Not carried; artifact class signals schema version" (table row) |
+| `name` | yes | → SKILL.md `name:` (standard skill field) |
+| `package` | yes | → `wake.package` |
+| `role` | yes | → `wake.role` |
+| `admin_only` | yes | → `wake.admin_only` |
+| `activation_log_writer` | yes | → `wake.activation_log_writer` |
+| `description` | yes | → SKILL.md `description:` |
+| `responsibilities` | yes | → body |
+| `input_contract.triggers` | yes | → `wake.input.triggers` |
+| `input_contract.issues_opened_title_pattern` | yes | → `wake.input.issues_opened_title_pattern` |
+| `input_contract.trigger_descriptions` | yes | → body |
+| `input_contract.inbound` | yes | → body |
+| `output_contract.channel_log_convention` | yes | → `wake.output.channel_log_convention` |
+| `output_contract.writer_surface` | yes | → `wake.output.writer_surface` |
+| `output_contract.class_taxonomy` | yes | → `wake.output.class_taxonomy` |
+| `output_contract.class_taxonomy_notes` | yes | → body |
+| `output_contract.cursor_advance` | yes | → `wake.output.cursor_advance` |
+| `output_contract.cursor_field` | yes | → `wake.output.cursor_field` |
+| `allowed_surfaces` | yes | → `wake.surfaces.allowed` |
+| `disallowed_surfaces` | yes | → `wake.surfaces.disallowed` |
+| `defer_path.cell_shaped_directive` | yes | → `wake.defer_path.cell_shaped_directive` |
+| `defer_path.off_role_directive` | yes | → `wake.defer_path.off_role_directive` |
+| `defer_path.ambiguous_directive` | yes | → `wake.defer_path.ambiguous_directive` |
+| `prompt_template` | yes | → "Not carried; body IS the prompt" |
+| `agent_variable.name` | yes | → `wake.agent_variable.name` |
+| `agent_variable.default` | yes | → `wake.agent_variable.default` |
+| `agent_variable.description` | yes | → body |
+| `permission_intent` | yes | → `wake.permission_intent` |
+| `permission_intent_notes` | yes | → body |
+| `concurrency_intent.serialize` | yes | → `wake.concurrency.serialize` |
+| `concurrency_intent.group` | yes | → `wake.concurrency.group` |
+| `concurrency_intent.notes` | yes | → body |
+| `superseded_substrate_artifact` | yes | → body |
+| `relationship_to_substrate` | yes | → body |
+| `cross_references` | yes | → body |
+
+**cds-dispatch `wake-provider.json` fields:**
+
+| Field | Covered in §B? | Disposition |
+|---|---|---|
+| `schema` | yes | → "Not carried" |
+| `name` | yes | → SKILL.md `name:` |
+| `package` | yes | → `wake.package` |
+| `role` | yes | → `wake.role` |
+| `admin_only` | yes | → `wake.admin_only` |
+| `activation_log_writer` | yes | → `wake.activation_log_writer` |
+| `activation_state` | yes | → `wake.activation_state` |
+| `activation_state_notes` | yes | → body |
+| `protocol` | yes | → `wake.protocol` |
+| `selector.include` | yes | → `wake.selector.include` |
+| `selector.exclude` | yes | → `wake.selector.exclude` |
+| `description` | yes | → SKILL.md `description:` |
+| `responsibilities` | yes | → body |
+| `input_contract.triggers` | yes | → `wake.input.triggers` |
+| `input_contract.trigger_descriptions` | yes | → body |
+| `input_contract.inbound` | yes | → body |
+| `output_contract.cycle_artifact_root` | yes | → `wake.output.cycle_artifact_root` |
+| `output_contract.artifact_class_taxonomy` | yes | → `wake.output.artifact_class_taxonomy` |
+| `output_contract.artifact_class_notes` | yes | → body |
+| `output_contract.cell_runtime` | yes | → `wake.output.cell_runtime` |
+| `output_contract.cell_runtime_notes` | yes | → body |
+| `allowed_surfaces` | yes | → `wake.surfaces.allowed` |
+| `disallowed_surfaces` | yes | → `wake.surfaces.disallowed` |
+| `defer_path.cell_shaped_directive` | yes | → `wake.defer_path.cell_shaped_directive` |
+| `defer_path.off_role_directive` | yes | → `wake.defer_path.off_role_directive` |
+| `defer_path.ambiguous_directive` | yes | → `wake.defer_path.ambiguous_directive` |
+| `prompt_template` | yes | → "Not carried; body IS the prompt" |
+| `agent_variable.name` | yes | → `wake.agent_variable.name` |
+| `agent_variable.default` | yes | → `wake.agent_variable.default` |
+| `agent_variable.description` | yes | → body |
+| `permission_intent` | yes | → `wake.permission_intent` |
+| `permission_intent_notes` | yes | → body |
+| `concurrency_intent.serialize` | yes | → `wake.concurrency.serialize` |
+| `concurrency_intent.group` | yes | → `wake.concurrency.group` |
+| `concurrency_intent.notes` | yes | → body |
+| `cross_references` | yes | → body |
+
+**Field completeness verdict:** All fields from both `wake-provider.json` files are covered in `w0-design.md §B`. Zero missing.
+
+### 4. Internal coherence checks
+
+**Role-shaped output disjunction (§B.2):**
+- Admin shape: `channel_log_convention`, `writer_surface`, `class_taxonomy`, `cursor_advance`, `cursor_field` — all sourced from `agent-admin/wake-provider.json` `output_contract`. Consistent.
+- Dispatch shape: `cycle_artifact_root`, `artifact_class_taxonomy`, `cell_runtime` — all sourced from `cds-dispatch/wake-provider.json` `output_contract`. Consistent.
+- The two shapes are disjoint (no overlap). Consistent with §C Decision 4 (CUE enforces role-shaped required fields).
+
+**§F migration plan consistent with §B schema shape:**
+- W1 authors SKILL.md with the `wake:` block as defined in §B. Consistent.
+- W2 teaches renderer to read `wake:` frontmatter and body. The fields the renderer reads (per §D) are a subset of the §B schema. Consistent.
+- W3 flips source; no schema change. Consistent.
+- W4 deletes `wake-provider.json` + `prompt.md`. After deletion, only the §B schema shape exists. Consistent.
+
+**§G ACs consistent with §D CUE↔renderer boundary:**
+- AC1 (`#Wake` CUE schema): scoped to static shape/enums/disjunction → CUE column in §D. Consistent.
+- AC3 (renderer reads SKILL.md): body extraction, install-time substitution → renderer column in §D. Consistent.
+- AC6 (refusals preserved): `activation_state`, `activation_log_writer` mis-declaration, FN-6 → renderer column in §D. Consistent.
+- No AC asks CUE to enforce a runtime refusal; no AC asks the renderer to enforce static shape. Consistent.
+
+**§C Decision 5 (body-as-prompt) consistent with §E:**
+- §C-5 states verbose notes/cross_references move to body. §E states the body IS the prompt (verbatim `prompt.md` + moved prose). §B table marks all notes/cross_references as "→ body". All three sections are consistent.
+
+### 5. No W1→W4 implementation artifacts
+
+Confirmed: no source files, schema files, workflow files, or golden files were created or modified in this run. The only new files on `cycle/524` after this run are:
+- `.cdd/unreleased/524/w0-design.md`
+- `.cdd/unreleased/524/self-coherence.md`
+
+No W1 code exists on the branch.
+
+### 6. Known gaps / open items
+
+**Gap-1: `observer` role.** The W0 schema defines `wake.role: "admin" | "dispatch"`. The renderer source may accept an `observer` role internally. The W1 implementer must audit the renderer to determine whether `observer` needs to be added to the `#Wake` role enum or remains renderer-internal only (see FN-1).
+
+**Gap-2: Verbose `defer_path` strings.** The `defer_path.*` values in the current `wake-provider.json` are long prose strings (several sentences each). The W0 schema types them as `string`. The W1 implementer must confirm these strings pass `cue vet` as plain strings — no length constraint — and confirm the renderer does not parse their content structurally.
+
+**Gap-3: `governing_question` authorship.** The W0 design does not specify the `governing_question` text for either wake SKILL.md. This is standard skill-authoring work for W1 (no design decision required). The W1 implementer authors these per the skill-authoring discipline.
+
+**Gap-4: `triggers:` (standard skill field) vs `wake.input.triggers` (renderer triggers).** The standard SKILL.md `triggers:` field captures skill-level invocation triggers (how a human/agent invokes the skill). The `wake.input.triggers` field captures the substrate event triggers the renderer encodes. These are distinct. The W1 implementer must author both correctly: `triggers:` describes install-time invocation; `wake.input.triggers` describes the GitHub Actions event trigger set.
+
+_Self-coherence verdict: PASS. All 9 sections present; all JSON fields covered; internal coherence holds; no W1→W4 artifacts on branch; scope guardrails clean._

--- a/.cdd/unreleased/524/w0-design.md
+++ b/.cdd/unreleased/524/w0-design.md
@@ -1,0 +1,373 @@
+---
+cycle: 524
+parent_issue: cnos#524
+document_class: w0-design
+status: locked
+authored_by: α@cdd.cnos (R0)
+date: 2026-06-30 (UTC)
+scope: W0 design only (operator directive); W1→W4 ACs not in scope for this document's cycle
+---
+
+# W0 design — cnos#524: wake-as-skill
+
+This document formalizes the converged, operator-ratified W0 design for the wake-as-skill migration. It is a structured extraction of the design already present in issue #524 body (`## W0 design (locked)`) and the operator W0-calls comment (first @usurobor comment). No new design is introduced here.
+
+---
+
+## §A. Problem statement and invariant
+
+**Problem:** A wake is currently two artifacts in a bespoke JSON+prompt contract system — `wake-provider.json` (the typed manifest) plus `prompt.md` (the prompt body) — compiled by `cn install-wake` into `.github/workflows/cnos-<wake>.yml`. This system runs **beside** the typed SKILL.md contract system (`SKILL.md` frontmatter + body, validated by `schemas/skill.cue` via the I5 gate). Two contract systems means: wake contracts escape CUE typing, every wake change touches two files in a non-standard format, and the discipline imposed by the skill pipeline does not apply to wakes.
+
+**What is expected:** one contract system. A wake is a typed `SKILL.md` module whose frontmatter carries a `wake:` contract block and whose body is the prompt, validated by CUE and compiled to a workflow by the renderer.
+
+**Invariant:** *A wake is a typed SKILL.md module whose body is the prompt and whose frontmatter compiles to workflow substrate. One SKILL.md+CUE contract system, not a second JSON+prompt system.*
+
+---
+
+## §B. The `wake:` block schema (the `#Wake` CUE definition)
+
+### B.1 Complete `wake:` block shape
+
+```yaml
+wake:
+  role: admin | dispatch                           # required; drives role-shaped output disjunction
+  package: string                                  # required; e.g. cnos.core, cnos.cds
+  admin_only: bool                                 # required; true for admin wake, false for dispatch
+  activation_log_writer: bool                      # required; whether this wake writes channel logs
+  activation_state?: live | declaration-only       # dispatch only; optional on admin
+  protocol?: string                                # dispatch only (e.g. "cds"); optional on admin
+  selector?:                                       # dispatch only; optional on admin
+    include: [...string]
+    exclude: [...string]
+  input:
+    triggers: [...string]                          # required; e.g. ["schedule", "issues_opened_title_match"]
+    issues_opened_title_pattern?: string           # optional; present on admin wake
+  output: <role-shaped disjunction; see §B.2>
+  permission_intent: [...string]                   # required; logical permissions
+  concurrency:
+    serialize: bool                                # required
+    group: string                                  # required; e.g. "agent-admin-{agent}"
+  agent_variable:
+    name: string                                   # required
+    default: string | null                         # required; null means operator-required
+  surfaces?:
+    allowed: [...string]
+    disallowed: [...string]
+  defer_path?:
+    cell_shaped_directive?: string
+    off_role_directive?: string
+    ambiguous_directive?: string
+```
+
+### B.2 Role-shaped output disjunction
+
+The `wake.output` field is role-shaped. The CUE `#Wake` definition MUST express a disjunction based on `wake.role`:
+
+**When `wake.role == "admin"` (agent-admin shape):**
+```yaml
+output:
+  channel_log_convention: string                   # e.g. docs/reference/conventions/AGENT-ACTIVATION-LOG-v0.md
+  writer_surface: string                           # e.g. ".cn-{agent}/logs/YYYYMMDD.md"
+  class_taxonomy: [...string]                      # entry class enum values
+  cursor_advance: bool
+  cursor_field: string
+```
+
+**When `wake.role == "dispatch"` (cds-dispatch shape):**
+```yaml
+output:
+  cycle_artifact_root: string                      # e.g. ".cdd/unreleased/{N}/"
+  artifact_class_taxonomy: [...string]             # CDD artifact class enum values
+  cell_runtime: string                             # e.g. "cnos.cdd"
+```
+
+### B.3 Field-by-field cross-reference to current `wake-provider.json` manifests
+
+The following table maps every field in the two current `wake-provider.json` files to its placement in the SKILL.md contract. Fields marked "→ body" are verbose prose that moves to the SKILL.md body per design decision §C-5; they are NOT frontmatter.
+
+| `wake-provider.json` field | Wake | Placement in SKILL.md |
+|---|---|---|
+| `schema` | both | Not carried; artifact class signals schema version |
+| `name` | both | SKILL.md `name:` field (standard skill field) |
+| `package` | both | `wake.package` |
+| `role` | both | `wake.role` |
+| `admin_only` | both | `wake.admin_only` |
+| `activation_log_writer` | both | `wake.activation_log_writer` |
+| `activation_state` | dispatch | `wake.activation_state` |
+| `activation_state_notes` | dispatch | → body |
+| `protocol` | dispatch | `wake.protocol` |
+| `selector.include` | dispatch | `wake.selector.include` |
+| `selector.exclude` | dispatch | `wake.selector.exclude` |
+| `description` | both | SKILL.md `description:` field (standard skill field) |
+| `responsibilities` | both | → body |
+| `input_contract.triggers` | both | `wake.input.triggers` |
+| `input_contract.issues_opened_title_pattern` | admin | `wake.input.issues_opened_title_pattern` |
+| `input_contract.trigger_descriptions` | both | → body |
+| `input_contract.inbound` | both | → body |
+| `output_contract.channel_log_convention` | admin | `wake.output.channel_log_convention` |
+| `output_contract.writer_surface` | admin | `wake.output.writer_surface` |
+| `output_contract.class_taxonomy` | admin | `wake.output.class_taxonomy` |
+| `output_contract.class_taxonomy_notes` | admin | → body |
+| `output_contract.cursor_advance` | admin | `wake.output.cursor_advance` |
+| `output_contract.cursor_field` | admin | `wake.output.cursor_field` |
+| `output_contract.cycle_artifact_root` | dispatch | `wake.output.cycle_artifact_root` |
+| `output_contract.artifact_class_taxonomy` | dispatch | `wake.output.artifact_class_taxonomy` |
+| `output_contract.artifact_class_notes` | dispatch | → body |
+| `output_contract.cell_runtime` | dispatch | `wake.output.cell_runtime` |
+| `output_contract.cell_runtime_notes` | dispatch | → body |
+| `allowed_surfaces` | both | `wake.surfaces.allowed` |
+| `disallowed_surfaces` | both | `wake.surfaces.disallowed` |
+| `defer_path.cell_shaped_directive` | both | `wake.defer_path.cell_shaped_directive` |
+| `defer_path.off_role_directive` | both | `wake.defer_path.off_role_directive` |
+| `defer_path.ambiguous_directive` | both | `wake.defer_path.ambiguous_directive` |
+| `prompt_template` | both | Not carried; body IS the prompt (§E) |
+| `agent_variable.name` | both | `wake.agent_variable.name` |
+| `agent_variable.default` | both | `wake.agent_variable.default` |
+| `agent_variable.description` | both | → body |
+| `permission_intent` | both | `wake.permission_intent` |
+| `permission_intent_notes` | both | → body |
+| `concurrency_intent.serialize` | both | `wake.concurrency.serialize` |
+| `concurrency_intent.group` | both | `wake.concurrency.group` |
+| `concurrency_intent.notes` | both | → body |
+| `superseded_substrate_artifact` | admin | → body |
+| `relationship_to_substrate` | admin | → body |
+| `cross_references` | both | → body |
+
+**Notes on field renaming:**
+- `input_contract` → `wake.input` (shorter, consistent with YAML block-key convention)
+- `output_contract` → `wake.output`
+- `concurrency_intent` → `wake.concurrency`
+- `allowed_surfaces` / `disallowed_surfaces` → `wake.surfaces.allowed` / `wake.surfaces.disallowed`
+- `defer_path.*` → `wake.defer_path.*` (unchanged keys, nested under `wake`)
+
+### B.4 Standard SKILL.md fields carried by the wake
+
+A wake SKILL.md uses the standard `#Skill` fields for the following (they do NOT move under `wake:`):
+- `name:` — the wake name (e.g. `agent-admin`, `cds-dispatch`)
+- `description:` — the short description (from `wake-provider.json` `description`)
+- `governing_question:` — authored per skill discipline
+- `triggers:` — install triggers (distinct from `wake.input.triggers` which are substrate event triggers; these are skill-level invocation triggers)
+- `scope: global` — per design decision §C-3
+- `artifact_class: wake` — per design decision §C-2
+- `kata_surface: none`
+- `inputs:` — logical inputs (human-readable)
+- `outputs:` — logical outputs (human-readable)
+
+---
+
+## §C. The 5 operator design decisions
+
+### Decision 1: Use `wake:` nesting (single block, not flattened)
+
+**Decision:** Wake-specific contract fields live under a single `wake:` block in frontmatter. Do not flatten into top-level keys like `wake_role:`, `wake_selector:`, etc.
+
+**Rationale:** The SKILL.md frontmatter stays readable and the wake contract has a clear boundary. Flattening would pollute the standard skill namespace with wake-specific keys, making it impossible for validators to distinguish wake fields from skill fields without special-casing.
+
+**W1 implication:** When authoring both wake SKILL.md files, all wake-specific fields go under `wake:`. The renderer reads from `wake.*` keys. The I5 validator type-checks the `wake:` block as the `#Wake` CUE definition.
+
+### Decision 2: Use `artifact_class: wake`
+
+**Decision:** A wake's `artifact_class` is `wake`, not `skill`, `runbook`, or `reference`. The SKILL.md discovery mechanism (which walks the repo for all `SKILL.md` files) discovers wakes automatically; the `artifact_class` tells tooling what kind of module it is.
+
+**Rationale:** Cleaner than pretending a wake is an ordinary `skill`. Cleaner than inventing a separate discovery pipeline. The I5 validator already discovers SKILL.md files; adding `wake` to the `artifact_class` enum reuses that pipeline without modification. The I5 count advances from 91 to 93 when the two wake SKILL.md files are validated.
+
+**W1 implication:** AC1 adds `"wake"` to the `artifact_class` enum in `schemas/skill.cue`. AC2 sets `artifact_class: wake` on both wake SKILL.md files. I5 must show 93 validated SKILL.md files (no findings) after W2.
+
+### Decision 3: Use existing `scope: global`; role is carried by `wake.role`
+
+**Decision:** A wake uses the existing `scope: global` vocabulary. The wake role (`admin`, `dispatch`) is carried by `wake.role`, not by a new `scope:` value.
+
+**Rationale:** A wake is repo/workflow-level, which maps exactly to `scope: global`. Adding new scope vocabulary (e.g. `scope: wake`) for a concept already captured by `artifact_class: wake` + `wake.role` would inflate the scope enum with no discriminating value.
+
+**W1 implication:** Both wake SKILL.md files set `scope: global`. No new scope vocabulary is added to `schemas/skill.cue`.
+
+### Decision 4: CUE owns typed contract; renderer owns substrate compilation + runtime refusals
+
+**Decision:** There is a strict boundary between what CUE validates at I5 time and what the renderer enforces at install/run time.
+
+**CUE (`schemas/skill.cue`) validates:**
+- `wake:` block shape and field types
+- Enums: `wake.role`, `wake.activation_state`, `wake.permission_intent` values
+- Role-shaped required fields (admin-output vs dispatch-output disjunction)
+- `wake.selector` shape (`include`/`exclude` arrays)
+- `wake.permission_intent` array
+- `wake.concurrency` shape
+
+**Renderer (`cn-install-wake`) enforces:**
+- `activation_state` refusal (exit 3 when `declaration-only`)
+- `activation_log_writer` mis-declaration refusal (exit 4 when `role: dispatch + admin_only: false` declares `activation_log_writer: true`)
+- The FN-6 `attach`-incompatibility refusal
+- Body extraction (second `---` delimiter; the body IS the prompt — see §E)
+- Install-time substitution (`{agent}` → operator-supplied value)
+- GitHub Actions YAML encoding (substrate-specific `permissions:`, `concurrency:`, `on:` triggers, cron slots)
+- Bot identity resolution (mapping `agent_variable.default` to a substrate bot identity)
+
+**Rationale:** CUE is a static shape validator; it cannot enforce cross-field runtime conditions (e.g. "if this wake is installed on substrate X, check activation_state"). The renderer is already the single enforcement surface for substrate concerns; keeping runtime refusals in the renderer avoids duplicating that logic in CUE and preserves the "package owns role behavior, renderer owns substrate encoding" split already documented in `cn-install-wake`.
+
+**W1 implication:** AC1 adds ONLY static shape/type/enum validation to `schemas/skill.cue`. AC6 verifies that the renderer's existing refusal smokes still fire from `SKILL.md`-sourced input after the renderer flip in W3.
+
+### Decision 5: `responsibilities` / `*_notes` / `cross_references` → body, not frontmatter
+
+**Decision:** Verbose prose fields from `wake-provider.json` — `responsibilities`, `*_notes` (e.g. `activation_state_notes`, `class_taxonomy_notes`, `cell_runtime_notes`, `permission_intent_notes`, `concurrency_intent.notes`), `cross_references`, `trigger_descriptions`, `relationship_to_substrate`, `superseded_substrate_artifact`, `agent_variable.description` — move to the SKILL.md body, not to frontmatter.
+
+**Rationale:** Frontmatter is contract (machine-readable fields consumed mechanically by the renderer or validator). Body is prompt/role doctrine (consumed by the agent executing the wake). Verbose prose that is neither type-checked by CUE nor consumed by the renderer belongs in the body where it informs the agent's execution.
+
+**W1 implication:** AC2 requires that the SKILL.md body for each wake equals `prompt.md` verbatim (the existing prose prompt) PLUS the verbose reference data that is moving from `wake-provider.json` into the body. The byte-identity oracle (§F) proves that the renderer extracting the body produces the same prompt the renderer previously read from `prompt.md`.
+
+---
+
+## §D. CUE ↔ renderer responsibility boundary
+
+| Concern | CUE owns | Renderer owns |
+|---|---|---|
+| `wake:` block field types and shapes | yes | no |
+| Enum validation (`wake.role`, `wake.activation_state`, `wake.permission_intent[*]`) | yes | no |
+| Role-shaped output disjunction (admin-output vs dispatch-output fields required) | yes | no |
+| `wake.selector` shape (`include`/`exclude` arrays) | yes | no |
+| `wake.concurrency` shape | yes | no |
+| `wake.permission_intent` array shape | yes | no |
+| Static presence of required fields | yes | no |
+| Cross-field runtime refusal: `activation_state == "declaration-only"` → exit 3 | no | yes |
+| Cross-field runtime refusal: `role:dispatch + admin_only:false + activation_log_writer:true` → exit 4 | no | yes |
+| FN-6 attach-incompatibility refusal | no | yes |
+| Body extraction from SKILL.md (second `---` delimiter rule) | no | yes |
+| Install-time substitution (`{agent}` → operator-supplied value) | no | yes |
+| GitHub Actions YAML encoding (`permissions:`, `concurrency:`, `on:` triggers, cron slots) | no | yes |
+| Bot identity resolution (`agent_variable.default` → substrate bot name/id) | no | yes |
+| Prompt text delivered to the agent (body of SKILL.md) | no | yes |
+| Existence of `wake-provider.json` or `prompt.md` (pre-W4) | no | yes |
+
+**Design note:** CUE asserts static shape; the renderer is the single enforcement surface for all substrate, runtime, and defense-in-depth concerns. This is the "package owns role behavior, renderer owns substrate encoding" split documented in `cn-install-wake`.
+
+---
+
+## §E. Body-as-prompt rule
+
+**Rule:** The SKILL.md body (everything after the second `---` frontmatter delimiter) IS the prompt. The renderer extracts the body verbatim and uses it as the prompt delivered to the agent executing the wake.
+
+**Implication:** `prompt.md` is the current source of truth for the prompt. When authoring the wake SKILL.md (W1), the body MUST equal the current `prompt.md` content verbatim — no paraphrase, no reformatting, no omissions. The body may additionally include the verbose reference data moving from `wake-provider.json` (responsibilities, cross_references, notes), appended after the verbatim `prompt.md` content.
+
+**Frontmatter / body split:**
+- Frontmatter (`---` … `---`): machine-readable contract fields only. Consumed by the renderer and the CUE validator. No prose.
+- Body: the agent's execution prompt + role doctrine + verbose reference data. Not consumed by the renderer structurally (extracted as a single text block). Not CUE-typed.
+
+**Byte-identity oracle:** The oracle that proves correctness at each W1→W4 step is:
+```
+render(SKILL.md source) == render(wake-provider.json + prompt.md source)
+```
+Equivalently: the renderer extracting the SKILL.md body produces output byte-identical to the renderer reading `prompt.md` directly. The `install-wake golden` CI check (sha256 golden == live, diff clean, idempotence) is the substrate encoding of this oracle.
+
+**Why this matters:** The body-as-prompt rule is what makes the migration a no-op for the rendered artifact. If the body is not verbatim `prompt.md`, the rendered workflow's prompt section will differ, breaking byte-identity. The rule is enforced by the oracle, not by a CUE constraint.
+
+---
+
+## §F. W1→W4 migration plan
+
+Each phase keeps both `install-wake golden` (byte-identical CI) and I5 (91→93 typed modules) green. The byte-identity oracle is checked at every phase boundary.
+
+### W1 — Author wake SKILL.md files; extend `schemas/skill.cue`
+
+**What:** Author both `agent-admin/SKILL.md` and `cds-dispatch/SKILL.md` beside their existing `wake-provider.json` and `prompt.md`. Add `#Wake` definition and `"wake"` to `artifact_class` in `schemas/skill.cue`.
+
+**Oracle:** I5 validates both new SKILL.md files (count: 91 → 93, no findings). `cue vet` passes on conformant wake SKILL.md; fails on a wake SKILL.md with a bad enum or missing role-required field. The renderer still reads from `wake-provider.json` + `prompt.md` — goldens are unchanged.
+
+**State after W1:** Three sources of truth coexist briefly: `wake-provider.json` (renderer reads this), `prompt.md` (renderer reads this), and the new `SKILL.md` (I5 validates this). No rendered output has changed.
+
+### W2 — Teach the renderer to read SKILL.md; dual-source parity gate
+
+**What:** Extend `cn-install-wake` to resolve its source from SKILL.md (frontmatter `wake:` block → the fields it currently reads from `wake-provider.json`; body → the prompt it currently reads from `prompt.md`). Run a dual-source parity gate: `render(SKILL.md)` must be byte-identical to `render(wake-provider.json + prompt.md)`.
+
+**Oracle:** `cmp render(SKILL) render(JSON)` passes for both wakes. The `install-wake golden` CI check remains green (renderer can still fall back to JSON, or the parity gate is run before the CI golden check).
+
+**State after W2:** The renderer can read from either source. Parity is proved. Goldens are still produced from whichever source is active (JSON by default, unless the renderer is already flipped).
+
+### W3 — Flip renderer source to SKILL.md; re-render
+
+**What:** Configure `cn-install-wake` to use SKILL.md as the primary source (not `wake-provider.json`). Re-render both wakes.
+
+**Oracle:** `install-wake golden` CI check green (rendered output byte-identical to committed goldens). The re-render is expected to be a no-op if W2 parity holds. If the re-render produces any diff, the diff is a bug — iterate to fix before proceeding.
+
+**State after W3:** Renderer reads only SKILL.md. `wake-provider.json` and `prompt.md` are still present but no longer consumed.
+
+### W4 — Delete `wake-provider.json` + `prompt.md`; verify I5 count
+
+**What:** After the W3 byte-identical proof holds in CI, delete `wake-provider.json` and `prompt.md` for both wakes. Verify the renderer still renders byte-identical goldens with no `wake-provider.json` or `prompt.md` present.
+
+**Oracle:** Files absent; `cn install-wake agent-admin` and `cn install-wake cds-dispatch` render byte-identical goldens from SKILL.md only. I5 count = 93 (91 pre-migration + 2 wake SKILL.md files). The migration is complete.
+
+**State after W4:** One contract system. Two typed `SKILL.md` modules in the skill pipeline. No `wake-provider.json` or `prompt.md`.
+
+---
+
+## §G. W1 acceptance criteria (AC1–AC7)
+
+These are the ACs from issue #524 body, restated as the acceptance surface for the W1→W4 build sequence. This cycle (R0) is W0 design only; these ACs govern the next cycle's implementation.
+
+### AC1 — `#Wake` schema in CUE
+**Invariant:** `schemas/skill.cue` adds `"wake"` to the `artifact_class` enum and a `#Wake` definition validating the `wake:` block. The definition covers: `role` enum (`admin | dispatch`); `admin_only` / `activation_log_writer` bool; `activation_state` optional enum (`live | declaration-only`); `protocol` optional string; `selector` optional with `include`/`exclude` arrays; `permission_intent` array; `concurrency` shape with `serialize` bool and `group` string; `input.triggers` array; `input.issues_opened_title_pattern` optional string; role-shaped `output` disjunction (admin shape vs dispatch shape).
+**Oracle:** `cue vet` a conformant wake SKILL.md → pass; a wake SKILL.md with a bad enum or missing role-required field → fail.
+
+### AC2 — Wake SKILL.md modules authored
+**Invariant:** `src/packages/cnos.core/orchestrators/agent-admin/SKILL.md` and `src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md` exist. Each has: `scope: global`, `artifact_class: wake`, a `wake:` block carrying the exact current manifest data (per §B field mapping), and a body equal to the current `prompt.md` verbatim. Verbose `responsibilities` / `*_notes` / `cross_references` move into the body; frontmatter is contract only.
+**Oracle:** I5 validator (`scripts/ci/validate-skill-frontmatter.sh`) validates both → "93 SKILL.md validated; no findings".
+
+### AC3 — Renderer reads SKILL.md
+**Invariant:** `cn-install-wake` resolves its source from SKILL.md (`wake:` frontmatter block → fields; body → prompt), preserving install-time `{agent}` / `cn-{agent}` substitution.
+**Oracle:** `cn install-wake <name>` renders from SKILL.md.
+
+### AC4 — Byte-identical goldens (the binding proof)
+**Invariant:** Rendering from SKILL.md produces output byte-identical to the committed goldens. During transition (W2), `render(SKILL)` byte-identical to `render(JSON)`.
+**Oracle:** `install-wake golden` CI green (re-render diff clean + sha256 golden == live + idempotence) for both wakes; one-shot dual-source parity check (`cmp render(SKILL) render(JSON)`) passes before deletion.
+
+### AC5 — JSON + prompt deleted
+**Invariant:** After AC4 holds, `wake-provider.json` and `prompt.md` are removed for both wakes. The renderer reads only SKILL.md.
+**Oracle:** Files absent; `cn install-wake` still renders byte-identical goldens with no `wake-provider.json` / `prompt.md` present.
+
+### AC6 — Renderer refusals preserved (defense-in-depth)
+**Invariant:** The renderer's runtime refusals still fire from SKILL.md source — `activation_log_writer` mis-declaration (exit 4), the FN-6 `attach`-incompatibility refusal, and `activation_state` gating (exit 3 on `declaration-only`).
+**Oracle:** Existing cycle/496 mis-declaration smoke in `install-wake-golden.yml` still passes against a wake SKILL.md; a synthetic mis-declared wake SKILL.md → exit 4.
+
+### AC7 — All CI gates green
+**Invariant:** No inherited-cap, no new red.
+**Oracle:** I1 / I2 / I4 / I5 / I6 / `install-wake golden` / `dispatch-repair-preflight (cnos#516)` / Go / Package / Binary all green on the cell's PR.
+
+---
+
+## §H. Friction notes for the W1 implementer
+
+These friction notes are carried from the prior γ scaffolds (original R0 scaffold at commit `f148a1fd`, updated W0-scope scaffold at commit `9a10781d`). They are material for the W1 implementer.
+
+**FN-1: Renderer role-enum collision.** The renderer (`cn-install-wake`) currently accepts `admin | dispatch | observer` in its internal role check (line 342 area). The W0 `#Wake` schema defines `admin | dispatch` only. The `observer` role, if present in the renderer, is a renderer-internal extension and NOT a valid `wake.role` value in the CUE schema. The W1 implementer must confirm whether `observer` appears in any live manifest and whether it needs to be added to the `#Wake` role enum or kept renderer-internal.
+
+**FN-2: `cue vet` invocation against SKILL.md with multi-doc frontmatter.** The I5 validator extracts frontmatter before running `cue vet`. The W1 implementer must confirm the extractor handles the SKILL.md body (second `---` delimiter) correctly — specifically that the body is stripped before `cue vet` runs, so `cue vet` sees only the frontmatter YAML/JSON (not the full SKILL.md file).
+
+**FN-3: `agent_variable.default: null` encoding.** The admin wake has `agent_variable.default: null` (no default; operator must supply). YAML `null` must round-trip correctly through the frontmatter extractor and through `cue vet`. The CUE schema must represent `null` as `null` (not `""` or absent). The W1 implementer must test the `null` case explicitly.
+
+**FN-4: `surfaces.allowed` / `surfaces.disallowed` array length.** Both wakes have long `allowed_surfaces` and `disallowed_surfaces` arrays (8–9 entries each). The CUE schema should accept open arrays (`[...string]`); no length constraint. The W1 implementer should confirm the extractor handles multi-line YAML arrays of this length without truncation.
+
+**FN-5: Body verbatim constraint.** AC2 requires the SKILL.md body to equal `prompt.md` verbatim. The W1 implementer must not paraphrase, reformat, or summarize. Any trailing newline difference in `prompt.md` must be preserved exactly, or the byte-identity oracle will fail at W2.
+
+**FN-6: FN-6 attach-incompatibility refusal (defense-in-depth).** The renderer has a refusal that fires when a wake declares `activation_log_writer: false` but its role is not `dispatch` (or some analogous incompatibility with the `attach` surface). The exact trigger condition for this refusal must be confirmed from `cn-install-wake` source before W3. AC6 requires this refusal to still fire from SKILL.md source; the W1 implementer must include a synthetic SKILL.md fixture for this smoke.
+
+**FN-7: Dual-source parity gate implementation.** W2 requires a parity gate: `render(SKILL) cmp render(JSON)`. The W1 implementer must design how this gate is implemented — either as a new `cn install-wake --source=skill` flag, a temporary parallel render path, or a CI-only comparison step. The gate must not break the existing `install-wake golden` CI check.
+
+**FN-8: Deletion sequencing.** W4 deletes `wake-provider.json` and `prompt.md`. The deletion must happen in a single commit after the byte-identical proof holds in CI — not spread across multiple commits where the renderer might be caught in a state where neither source is complete. If the renderer's source-resolution logic is `SKILL.md then JSON fallback`, the deletion is safe in a single commit. If the fallback path is removed in a separate commit, the W1 implementer must sequence the commits carefully.
+
+---
+
+## §I. Non-goals
+
+The following are explicitly out of scope for the W1→W4 migration:
+
+- **No rendered-workflow output change.** The `.github/workflows/cnos-agent-admin.yml` and `cnos-cds-dispatch.yml` files must be byte-identical before and after the migration. No functional change to the rendered substrate.
+- **No wake runtime-behavior change.** The agent executing either wake reads the same prompt, applies the same logic, and produces the same outputs after the migration as before.
+- **No renderer substrate-encoding change.** The renderer's substrate-encoding logic (GitHub Actions YAML structure, cron slot encoding, permissions block, concurrency block) is unchanged. Only the source the renderer reads changes (from JSON+prompt to SKILL.md).
+- **No new wake names.** Only `agent-admin` and `cds-dispatch` are in scope. No new wake roles beyond `admin` and `dispatch` are introduced.
+- **No Demo 0.** This migration is pre-Demo-0 infrastructure; it does not implement Demo 0 behavior.
+- **No `.cdd/releases/` work.** This is a pre-release infrastructure cycle; no release artifacts.
+- **No per-package bot identities.** The `cnos#449` follow-up (per-package bot accounts) is deferred. The migration uses the existing `sigma` substrate identity.
+- **No change to the CUE validator script.** `scripts/ci/validate-skill-frontmatter.sh` logic is unchanged; only `schemas/skill.cue` is extended.
+
+---
+
+_Authored by α@cdd.cnos (R0), 2026-06-30 (UTC). Formalizes the W0 design from cnos#524 body (`## W0 design (locked)`) and the operator W0-calls comment. No new design introduced._


### PR DESCRIPTION
## Summary

Delivers the W0 design document for cnos#524 (wake-as-skill migration) per the operator DISPATCH DIRECTIVE (W0 design only for this run).

**Artifact:** `.cdd/unreleased/524/w0-design.md` — a standalone formalization of the operator-ratified W0 wake-as-skill design contract.

**Scope:** Design only. No changes to `schemas/skill.cue`, `cn-install-wake`, workflows, goldens, or `wake-provider.json`/`prompt.md`. The W1→W4 implementation (AC1–AC7) is explicitly deferred to a subsequent dispatch.

## Design document covers

- §A: Problem statement + invariant
- §B: Complete `wake:` block schema (all 71 fields from both wake manifests covered; role-shaped admin vs dispatch output disjunction)
- §C: 5 operator design decisions with rationale and W1 implications
- §D: CUE↔renderer responsibility boundary (15-row table)
- §E: Body-as-prompt rule + byte-identity oracle
- §F: W1→W4 4-phase migration plan with oracle at each phase
- §G: W1 ACs (AC1–AC7)
- §H: FN-1 through FN-8 friction notes for the W1 implementer
- §I: 8 non-goals

## β verdict

CONVERGE — scope compliance clean; all 9 sections complete; 71/71 JSON fields covered in §B; internal coherence holds.

## Non-blocking observations for W1 implementer

- OB-1: Audit `observer` role in renderer before finalizing `#Wake` enum (FN-1)
- OB-2: Establish canonical body prose ordering for both SKILL.md files (AC2)
- OB-3: Explicitly distinguish `triggers:` (SKILL.md top-level) from `wake.input.triggers` (Gap-4)

## CDD artifacts

Under `.cdd/unreleased/524/`: `gamma-scaffold.md`, `w0-design.md`, `self-coherence.md`, `beta-review.md`, `alpha-closeout.md`, `beta-closeout.md`, `gamma-closeout.md`

Closes: partial (W0 design phase only; W1→W4 implementation requires a subsequent dispatch)
References: cnos#524

🤖 Generated with [Claude Code](https://claude.com/claude-code)