### PR TITLE
wake terminology: align output_contract prose to wake.output

### DIFF
--- a/.github/workflows/cnos-cds-dispatch.yml
+++ b/.github/workflows/cnos-cds-dispatch.yml
@@ -73,7 +73,7 @@ jobs:
 
             > ✅ **Activation state: live.** This wake is **runnable** as of cnos#487 (Sub 5C of cnos#467 wake-orchestration wave). All preconditions satisfied:
             > - cnos#454 dispatch-protocol skill is on `main` (PR #466);
-            > - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shape `output_contract` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
+            > - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shaped `wake.output` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
             > - cnos#467 Sub 5B δ wake-invoked mode amendment in cnos.cdd is on `main` (cnos#486 / PR #489).
             >
             > The corresponding substrate artifact is **`.github/workflows/cnos-cds-dispatch.yml`** (rendered via `cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml`). The `wake.activation_state: "live"` field in this module's frontmatter is the machine-readable source of truth; this banner is its prose mirror. This wake claims and executes cells through the standard selector — `dispatch:cell + protocol:cds + status:todo` — per the claim mechanism below.

--- a/src/packages/cnos.cdd/skills/cdd/delta/SKILL.md
+++ b/src/packages/cnos.cdd/skills/cdd/delta/SKILL.md
@@ -452,7 +452,7 @@ The per-round artifact set names the wake-observable contract: at R[N], the bran
 
 At each R[N] boundary, the cycle branch MUST carry the artifacts named below. The wake confirms a round complete by reading these paths; the matching package's release-time tooling (per [`cdd/SKILL.md`](../SKILL.md) artifact contract) lifts them into `.cdd/releases/docs/<date>/{N}/` on merge.
 
-Seven canonical artifact classes per [`cnos.cds/orchestrators/cds-dispatch/SKILL.md`](../../../../cnos.cds/orchestrators/cds-dispatch/SKILL.md) frontmatter `wake.output_contract.artifact_class_taxonomy`:
+Seven canonical artifact classes per [`cnos.cds/orchestrators/cds-dispatch/SKILL.md`](../../../../cnos.cds/orchestrators/cds-dispatch/SKILL.md) frontmatter `wake.output.artifact_class_taxonomy`:
 
 | Boundary | Required artifacts at `.cdd/unreleased/{N}/` |
 |---|---|
@@ -503,7 +503,7 @@ The single descriptive carve-out in this §9 is this paragraph: it names "GitHub
 
 - [`cnos.core/skills/agent/dispatch-protocol/SKILL.md`](../../../../cnos.core/skills/agent/dispatch-protocol/SKILL.md) (cnos#454) — claim sequence (§2.2), concurrency discipline (§2.3), lifecycle transitions (§2.4), drift handling (§2.6). Wake-invoked-δ consumes the claim sequence's output and honors its lifecycle transitions; the contract above maps each return token (§9.6) to a transition this skill defines.
 - [`cnos.core/skills/agent/wake-provider/SKILL.md`](../../../../cnos.core/skills/agent/wake-provider/SKILL.md) (cnos#470) — substrate-agnosticism doctrine (§3.3 substrate-leakage rule); cited as the source for §9.8 above.
-- [`cnos.cds/orchestrators/cds-dispatch/SKILL.md`](../../../../cnos.cds/orchestrators/cds-dispatch/SKILL.md) (cnos#483) — the reference dispatch-shape wake; its frontmatter `wake:` block is the dispatch-shape manifest. `wake.output_contract.artifact_class_taxonomy` is the canonical artifact set §9.5 matches; `wake.responsibilities` enumerates the lifecycle transitions §9.6 consumes.
+- [`cnos.cds/orchestrators/cds-dispatch/SKILL.md`](../../../../cnos.cds/orchestrators/cds-dispatch/SKILL.md) (cnos#483) — the reference dispatch-shape wake; its frontmatter `wake:` block is the dispatch-shape manifest. `wake.output.artifact_class_taxonomy` is the canonical artifact set §9.5 matches; `wake.responsibilities` enumerates the lifecycle transitions §9.6 consumes.
 - The body of the same [`cnos.cds/orchestrators/cds-dispatch/SKILL.md`](../../../../cnos.cds/orchestrators/cds-dispatch/SKILL.md) (cnos#483) is the wake's prompt body; it forward-references this section; the reference resolved to a landed citation once cnos#486 merged.
 - [`cdd/issue/SKILL.md`](../issue/SKILL.md) — cell-shaped issue contract; δ reads the claimed cell's issue body against this skill's §"Minimal output pattern" (§9.2 input #1).
 - [`cdd/gamma/SKILL.md`](../gamma/SKILL.md) — γ role contract; wake-invoked routing dispatches γ per its §2.5 (scaffold) and §2.7 (closeout). δ does not restate γ-side mechanics here.

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
@@ -88,7 +88,7 @@ Read this prompt fully before acting. The admin/dispatch boundary it establishes
 
 > ✅ **Activation state: live.** This wake is **runnable** as of cnos#487 (Sub 5C of cnos#467 wake-orchestration wave). All preconditions satisfied:
 > - cnos#454 dispatch-protocol skill is on `main` (PR #466);
-> - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shape `output_contract` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
+> - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shaped `wake.output` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
 > - cnos#467 Sub 5B δ wake-invoked mode amendment in cnos.cdd is on `main` (cnos#486 / PR #489).
 >
 > The corresponding substrate artifact is **`.github/workflows/cnos-cds-dispatch.yml`** (rendered via `cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml`). The `wake.activation_state: "live"` field in this module's frontmatter is the machine-readable source of truth; this banner is its prose mirror. This wake claims and executes cells through the standard selector — `dispatch:cell + protocol:cds + status:todo` — per the claim mechanism below.
@@ -366,7 +366,7 @@ If you reach a state where you cannot complete the above (capability mismatch, a
 
 ## Activation state notes
 
-This provider is LIVE in production substrate as of cnos#487 (Sub 5C of cnos#467 wake-orchestration wave). Preconditions satisfied: (a) cnos#454 dispatch-protocol skill landed on main (PR #466); (b) cnos#467 Sub 5A landed the renderer extension consuming role:dispatch + protocol + selector + dispatch-shape output_contract fields + the issues_labeled_selector_match trigger (cnos#485 / PR #488); (c) cnos#467 Sub 5B landed the δ wake-invoked mode amendment in cnos.cdd's delta SKILL (cnos#486 / PR #489). The corresponding rendered substrate artifact lives at `.github/workflows/cnos-cds-dispatch.yml` per `cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml`; the renderer no longer refuses (per wake-provider/SKILL.md §3.10 — `activation_state == "live"` is the production state). This SKILL.md body carries a matching live-state banner so the model executing the wake reads consistent state from both the frontmatter `wake.activation_state` field and this body prose. Any future flip back to declaration-only (renderer-pending / rollback) MUST update BOTH the frontmatter `wake.activation_state` AND this body's banner — they are coupled.
+This provider is LIVE in production substrate as of cnos#487 (Sub 5C of cnos#467 wake-orchestration wave). Preconditions satisfied: (a) cnos#454 dispatch-protocol skill landed on main (PR #466); (b) cnos#467 Sub 5A landed the renderer extension consuming role:dispatch + protocol + selector + dispatch-shaped wake.output fields + the issues_labeled_selector_match trigger (cnos#485 / PR #488); (c) cnos#467 Sub 5B landed the δ wake-invoked mode amendment in cnos.cdd's delta SKILL (cnos#486 / PR #489). The corresponding rendered substrate artifact lives at `.github/workflows/cnos-cds-dispatch.yml` per `cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml`; the renderer no longer refuses (per wake-provider/SKILL.md §3.10 — `activation_state == "live"` is the production state). This SKILL.md body carries a matching live-state banner so the model executing the wake reads consistent state from both the frontmatter `wake.activation_state` field and this body prose. Any future flip back to declaration-only (renderer-pending / rollback) MUST update BOTH the frontmatter `wake.activation_state` AND this body's banner — they are coupled.
 
 ---
 
@@ -425,7 +425,7 @@ open issues in this repo matching the selector (dispatch:cell + protocol:cds + s
 - cnos#476 (Sub 3 — cn install-wake renderer baseline)
 - cnos#479 / PR #481 (cutover-A — admin wake activation; both wake classes are now rendered in production)
 - cnos#454 / PR #466 (dispatch-protocol skill; 3-label claim mechanics + serialized claim guard the wake's prompt cites)
-- cnos#485 / PR #488 (Sub 5A — renderer extension consuming role:dispatch + protocol + selector + dispatch-shape output_contract + activation_state + issues_labeled_selector_match)
+- cnos#485 / PR #488 (Sub 5A — renderer extension consuming role:dispatch + protocol + selector + dispatch-shaped wake.output + activation_state + issues_labeled_selector_match)
 - cnos#486 / PR #489 (Sub 5B — δ wake-invoked mode amendment in cnos.cdd/skills/cdd/delta/SKILL.md §9; the contract this wake invokes)
 - cnos#487 (Sub 5C — this provider's activation_state flipped to live + cnos-cds-dispatch.yml committed to substrate)
 

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
@@ -73,7 +73,7 @@ jobs:
 
             > ✅ **Activation state: live.** This wake is **runnable** as of cnos#487 (Sub 5C of cnos#467 wake-orchestration wave). All preconditions satisfied:
             > - cnos#454 dispatch-protocol skill is on `main` (PR #466);
-            > - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shape `output_contract` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
+            > - cnos#467 Sub 5A renderer extension consuming `role:dispatch` + `protocol` + `selector` + dispatch-shaped `wake.output` + `issues_labeled_selector_match` is on `main` (cnos#485 / PR #488);
             > - cnos#467 Sub 5B δ wake-invoked mode amendment in cnos.cdd is on `main` (cnos#486 / PR #489).
             >
             > The corresponding substrate artifact is **`.github/workflows/cnos-cds-dispatch.yml`** (rendered via `cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml`). The `wake.activation_state: "live"` field in this module's frontmatter is the machine-readable source of truth; this banner is its prose mirror. This wake claims and executes cells through the standard selector — `dispatch:cell + protocol:cds + status:todo` — per the claim mechanism below.

--- a/src/packages/cnos.core/skills/agent/dispatch-protocol/SKILL.md
+++ b/src/packages/cnos.core/skills/agent/dispatch-protocol/SKILL.md
@@ -583,16 +583,16 @@ Confirm §2.9 defines the deliverable-proof requirement before `status:review` a
 ### Skills and issues that depend on this protocol
 
 - `agent/label-doctrine/SKILL.md` (`cnos#468`, MERGED) — defines the canonical generic label set (cnos.core-owned) and the per-protocol qualifier rule (concrete-package-owned). This skill's §1.1 cites label-doctrine as the doctrinal source; the dispatch protocol operationalizes label-doctrine's contract at claim time.
-- `agent/wake-provider/SKILL.md` (`cnos#470`, MERGED) — `cn.wake-provider.v1` declaration contract. Dispatch wakes (`role: dispatch`) declare `protocol`, `selector`, and dispatch-shape `output_contract` per its §3.9; this skill's claim algorithm reads those fields at install time.
+- `agent/wake-provider/SKILL.md` (`cnos#470`, MERGED) — `cn.wake-provider.v1` declaration contract. Dispatch wakes (`role: dispatch`) declare `protocol`, `selector`, and dispatch-shaped `wake.output` per its §3.9; this skill's claim algorithm reads those fields at install time.
 - `agent/wake-template/SKILL.md` (`cnos#450`) — renders package-owned dispatch wakes from `cn.wake-provider.v1` manifests; renders `on: issues` labeled trigger filtered by `protocol:{P}`, scheduled sweep trigger, per-protocol concurrency group, dispatch query, and claim/report steps. Cites this skill as source of truth for claim behavior.
-- `cnos.cds/orchestrators/cds-dispatch/SKILL.md` (`cnos#467 Sub 4 / PR #483`, MERGED) — first reference dispatch wake; its frontmatter `wake:` block declares `protocol: cds`, the standard `selector` (`dispatch:cell + protocol:cds + status:todo` minus excluded statuses), and the dispatch-shape `output_contract` invoking cnos.cdd as `cell_runtime`. cnos.cdd is the framework; cnos.cds is the concrete protocol.
+- `cnos.cds/orchestrators/cds-dispatch/SKILL.md` (`cnos#467 Sub 4 / PR #483`, MERGED) — first reference dispatch wake; its frontmatter `wake:` block declares `protocol: cds`, the standard `selector` (`dispatch:cell + protocol:cds + status:todo` minus excluded statuses), and the dispatch-shaped `wake.output` invoking cnos.cdd as `cell_runtime`. cnos.cdd is the framework; cnos.cds is the concrete protocol.
 - `agent/cohere/SKILL.md` (`cnos#444`) — cohere orchestrator dispatches cells per this protocol. The three-label composition is enforced at cohere's dispatch layer.
 
 ### Related issues
 
 - `cnos#454` — this skill's authoring issue. ACs in §1–§5 correspond to AC1–AC11 of cnos#454, amended for the protocol-qualifier doctrine landed via PR #480.
 - `cnos#468` — label doctrine; the two-layer ownership of labels (generic by cnos.core; protocol qualifiers by concrete-protocol packages).
-- `cnos#470` — wake-provider contract; dispatch wakes declare `protocol` + `selector` + dispatch-shape `output_contract`.
+- `cnos#470` — wake-provider contract; dispatch wakes declare `protocol` + `selector` + dispatch-shaped `wake.output`.
 - `cnos#480` — doctrine correction: cnos.cdd is framework, not concrete protocol; cnos.cds is the concrete software-development protocol.
 - `cnos#483` — Sub 4 cnos.cds dispatch wake provider (first dispatch reference instance); declaration-only until renderer + δ wake-invoked mode land.
 - `cnos#479` — cutover-A (admin wake live in production); the other half of the two-wake architecture cnos#467 establishes.


### PR DESCRIPTION
## Summary

Terminology alignment only. Follows the wake-as-skill cleanup line (#524 / #535): the author/model-facing wake output field is `wake.output`, but some active skill prose still taught the old name `output_contract`. This aligns that prose. **No schema, renderer, or behavior change.**

Distinguishes stale doctrine prose from legitimate implementation vocabulary: the renderer (`cn-install-wake`) keeps `output_contract` as its **internal synthesized-manifest field name** (`cn.wake-provider.v1`; `wake.output` → `output_contract` in the JSON it jq-queries) — that is left untouched.

## Changed

- `skills/agent/dispatch-protocol/SKILL.md` — 3 reference-list mentions: "dispatch-shape `output_contract`" → "dispatch-shaped `wake.output`".
- `cnos.cdd/skills/cdd/delta/SKILL.md` — `wake.output_contract.artifact_class_taxonomy` → `wake.output.artifact_class_taxonomy` (the frontmatter field is `wake.output`; `wake.output_contract` was wrong).
- `cnos.cds/orchestrators/cds-dispatch/SKILL.md` — three prose/banner references to "dispatch-shape output_contract" → "dispatch-shaped wake.output".
- `cds-dispatch` golden + live workflow re-rendered: the **only** rendered change is the single live-state banner line (`golden == live`); every other byte unchanged. The appendix references are not rendered, so they carry no golden impact.

## Verification (local)

- Golden/live diff is **one terminology line** only (banner); `sha256(golden)==sha256(live)`; `agent-admin` re-renders byte-identical.
- I5 frontmatter validation: 95/95, no findings.
- Both dispatch guard self-tests pass; hidden/bidi sweep clean.
- `git grep output_contract` over active docs/skills (excluding `.cdd/`, `.cn-sigma/`, `docs/evidence/`, and the renderer internals) → **NONE**. No active SKILL/doc prose teaches `output_contract` as the wake field.

## Acceptance

- [x] No active SKILL/doc prose teaches `output_contract` as the wake contract field
- [x] `wake.output` is the author-facing field name in the prose
- [x] Renderer internal `output_contract` left intact (implementation, not doctrine)
- [x] Goldens/live workflows behavior-identical; the diff is terminology/prose only
- [ ] CI green on this PR (I1/I2/I4/I5/I6/install-wake golden/#516/closeout-integrity/Go/Package/Binary)

Refs #535

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_