### PR TITLE
docs: restructure issue taxonomy into docs/development/issues/

### DIFF
--- a/.github/ISSUE_TEMPLATE/cdd-issue.md
+++ b/.github/ISSUE_TEMPLATE/cdd-issue.md
@@ -18,7 +18,16 @@ labels: ''
 
 ## Priority
 
-<!-- P0 / P1 / P2 -->
+<!-- P0 / P1 / P2 / P3 -->
+
+## Classification
+
+<!-- Label per docs/development/issues/TAXONOMY.md: one primary kind/*, one or more area/*,
+     and (only if an executable cell) dispatch:cell + protocol:*. See docs/development/issues/TRIAGE.md. -->
+
+- **kind:** <!-- kind/bugfix | kind/cleanup | kind/process | kind/feature | kind/tooling | kind/doctrine | kind/audit | kind/tracking | kind/research | kind/skill | kind/spike -->
+- **area:** <!-- area/* (one or more) -->
+- **dispatchable:** <!-- yes → dispatch:cell + protocol:cds/cdd + status:ready|todo ; no → design/tracking/research -->
 
 ## Scope
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ GitHub Issues is the single source of truth for bugs, features, and backlog.
 - Check existing issues before opening a new one
 - Include steps to reproduce, expected behavior, and actual behavior
 - For security issues, see [SECURITY.md](./SECURITY.md)
+- For issue classification and triage, see [docs/development/issues/](docs/development/issues/README.md)
 
 ### Proposing Changes
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -14,6 +14,7 @@
 - [plans/](plans) — implementation plans for specific releases.
 - [checklists/](checklists) — review/gate checklists by discipline.
 - [kata/](kata) — practice katas.
+- [issues/](issues/README.md) — issue taxonomy, triage, and dispatch policy (how issues are classified and labeled).
 
 Conceptual papers on cells and coherence (e.g. *Cell of Cells*) live in
 [`papers/`](../papers/README.md).

--- a/docs/development/issues/README.md
+++ b/docs/development/issues/README.md
@@ -1,0 +1,17 @@
+# issues/
+
+Issue taxonomy, triage, and dispatch policy — how work in this repo is
+classified, triaged, dispatched, and closed.
+
+Read:
+
+- [TAXONOMY.md](TAXONOMY.md) — the label model and issue kinds (the canonical
+  definitions of `kind/*`, `area/*`, priority, `status:*`, `dispatch:cell`,
+  `protocol:*`, and `resolution/*`).
+- [TRIAGE.md](TRIAGE.md) — how to classify, update, dispatch, close, defer, or
+  relabel an issue, and when to bring a decision to the operator.
+
+GitHub Issues is the single source of truth for the backlog (see the root
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md)). Labels are how that backlog is
+made legible and dispatchable: a coherent label set lets a human — or a dispatch
+wake — reason about the board at a glance.

--- a/docs/development/issues/TAXONOMY.md
+++ b/docs/development/issues/TAXONOMY.md
@@ -15,6 +15,10 @@ The single most important split is the primary `kind/*` — it answers "what *ki
 of work is this?" and keeps feature work, cleanup, doctrine, and process
 improvements from blurring together.
 
+This document defines the labels. For *how to apply them* — classifying, deciding
+`kind`, when to dispatch, when to close or supersede, and when a wave δ may relabel
+under MCA — see [TRIAGE.md](TRIAGE.md).
+
 ## Primary kind (choose exactly one)
 
 | Label | Meaning |
@@ -98,18 +102,11 @@ Apply on close when the reason is not a plain "done":
 These are especially useful for retiring historical experiment issues (early
 wake/OAuth test runs) and for consolidating duplicates.
 
-## Applying the taxonomy — rules of thumb
+## Applying the taxonomy
 
-1. Every open issue gets exactly one primary `kind/*` and at least one `area/*`.
-2. Add a priority; add a `status:*` only if the issue is actionable now.
-3. `dispatch:cell` + `protocol:*` go on together, and only on genuinely dispatchable cells.
-4. Non-dispatch design/tracking/research issues do **not** carry `dispatch:cell`.
-5. Close stale historical experiment issues with `resolution/superseded` (or
-   `resolution/completed` when the work actually shipped elsewhere).
-6. Consolidate duplicates: keep the canonical issue, close the rest with
-   `resolution/duplicate`.
-7. Retag legacy `enhancement`-only issues into the right `kind/*` (usually
-   `kind/feature`, `kind/process`, `kind/doctrine`, or `kind/cleanup`).
+The operational rules — how to classify, distinguish the kinds, decide dispatch
+eligibility, close/supersede/defer, and relabel under MCA — live in
+[TRIAGE.md](TRIAGE.md).
 
 ## Label lifecycle
 

--- a/docs/development/issues/TRIAGE.md
+++ b/docs/development/issues/TRIAGE.md
@@ -1,0 +1,116 @@
+# Issue triage
+
+Operational rules for turning a raw issue into a coherently-labeled,
+dispatchable (or deferred, or closed) item. The label *definitions* live in
+[TAXONOMY.md](TAXONOMY.md); this document is *how to apply them*.
+
+## Classifying a new issue
+
+1. **Pick the primary `kind/*`.** Ask "what kind of work is this?" — see the
+   decision guide below. Exactly one primary kind.
+2. **Add `area/*`.** Where does the work live? One or more.
+3. **Add a priority** (`P0`–`P3`, or `priority/deferred`).
+4. **Add a `status:*`** only if the issue is actionable now. Design/tracking/
+   research issues that aren't ready to execute carry no `status:*`.
+5. **Add `dispatch:cell` + `protocol:*`** only if the issue is a genuine,
+   proof-carrying cell the dispatch system can execute (see below).
+
+## Distinguishing the kinds
+
+The most common triage mistake is blurring these. Use the verb:
+
+| If the issue… | …it is |
+|---|---|
+| **fixes** behavior that is broken vs. current intended behavior | `kind/bugfix` |
+| **removes** stale structure / terminology / dead code / drift / noise (no new capability) | `kind/cleanup` |
+| improves **how** the work engine (CDD/CDS/cells/waves/δ/β/γ) operates | `kind/process` |
+| adds a **new** user- or product-facing capability | `kind/feature` |
+| builds command / CI / validator / generator / dev machinery | `kind/tooling` |
+| **changes the written contract** (spec/design/theory/doc) of the system | `kind/doctrine` |
+| inventories / drift-checks / reviews a baseline | `kind/audit` |
+| is an **umbrella** coordinating other issues | `kind/tracking` |
+| is an **open question** / exploration with no committed answer | `kind/research` |
+| **is a skill artifact** as its main deliverable | `kind/skill` |
+| is a **timeboxed prototype**, not final architecture | `kind/spike` |
+
+Tie-breakers:
+
+- **bugfix vs cleanup** — bugfix restores *behavior*; cleanup removes *structure/
+  noise* without changing behavior. A stale doc reference is cleanup; a validator
+  that passes when it should fail is a bugfix.
+- **process vs feature** — process improves the engine that builds things; feature
+  is a thing the engine builds. "Require review-request proof before
+  `status:review`" is process; "web console" is feature.
+- **doctrine vs process** — doctrine changes what the system *should be understood
+  to be* (a written contract); process changes *how the work happens*. They often
+  co-occur; when they do, tag the primary and, if truly necessary, a secondary.
+- **cleanup vs doctrine** — deleting a retired term is cleanup; rewriting the
+  contract that defined it is doctrine.
+
+A single secondary `kind/*` is acceptable when an issue genuinely spans two (e.g.
+a `kind/process` change that is also a `kind/bugfix`), but prefer one primary.
+
+## When to add `dispatch:cell` (and when not)
+
+Add `dispatch:cell` + `protocol:cds` (or `protocol:cdd`) **only** when the issue
+is an executable cell: scoped, with acceptance criteria and a proof oracle, that a
+dispatch wake can claim and run end-to-end. A dispatch wake claims on
+`dispatch:cell + protocol:{p} + status:todo` (minus the excluded statuses), so:
+
+- `status:ready` — shaped and approved, but held. The operator flips
+  `status:ready → status:todo` to release it. **Not** claimed while `ready`.
+- `status:todo` — claimable now.
+
+**Do NOT** add `dispatch:cell` to:
+
+- a bare design, tracking, research, or doctrine issue with no proof oracle;
+- an umbrella/roadmap issue (label it `kind/tracking`, no dispatch);
+- anything whose destination or ownership is unclear.
+
+## When to close, supersede, or defer
+
+- **Close as `resolution/completed`** when the work shipped (verify against the
+  repo — e.g. the file exists, the workflow is gone, the test passes).
+- **Close as `resolution/superseded`** when a *different* issue or a later design
+  delivered the capability. Name the superseding issue.
+- **Close as `resolution/duplicate`** (with `duplicate_of`) after confirming the
+  issues are the same; keep the richer/canonical one open.
+- **Close as `resolution/wontfix`** when the work is intentionally declined.
+- **`priority/deferred`** (kept open) when the work is real but parked.
+
+Always **verify before closing** — read the issue and check the repo state.
+Closing is reversible, but a wrong close on live work is friction.
+
+## When to ask the operator
+
+Bring a decision back rather than deciding it yourself when it is **STOP-class**:
+
+- behavior / authority / schema-vocabulary / label-or-dispatch-semantics change;
+- a non-prose (semantic) golden diff, or a release/deploy boundary;
+- deleting current operational data;
+- an unclear destination or ownership, or a conflict between two approved invariants.
+
+## When δ may relabel under MCA
+
+A parent/wave δ operating inside an **approved** contract may relabel issues as a
+minor coherent action (MCA) — and must record it — without a per-item interrupt.
+In scope for MCA relabeling:
+
+- normalizing an issue to `one kind + area(s) + priority` per this taxonomy;
+- repointing a stale `area/*` or retiring an unprefixed twin;
+- adding `resolution/*` and closing an obviously-superseded historical experiment
+  **after verifying** it against the repo;
+- consolidating a confirmed duplicate.
+
+Out of scope for MCA (STOP — ask the operator): changing an issue's **dispatch
+eligibility** (`dispatch:cell` / `protocol:*` / `status:todo`) in a way that would
+release it for execution, closing anything whose completeness is uncertain, or
+re-scoping an issue's meaning. This mirrors the wave-execution autonomy policy —
+see #539 (parent/wave δ MCA) and the CAP skill (`agent/cap/SKILL.md`).
+
+## Board hygiene
+
+Target state: every open issue carries exactly one primary `kind/*`, at least one
+`area/*`, and a priority; actionable issues carry a `status:*`; only genuine cells
+carry `dispatch:cell` + `protocol:*`; closed issues that weren't a plain
+completion carry a `resolution/*`. Umbrella/tracking issues may omit priority.


### PR DESCRIPTION
Restructures the issue taxonomy from a single file into a public `docs/development/issues/` directory (Rails/Spring-style: contribution/triage process is public, not hidden), keeping it under `docs/development/` ("how work gets done") rather than `reference/` ("canonical specs/APIs").

## Changes

- `git mv docs/development/ISSUE-LABEL-TAXONOMY.md → docs/development/issues/TAXONOMY.md` (history preserved) — the canonical label model (`kind/*`, `area/*`, priority, `status:*`, `dispatch:cell`, `protocol:*`, `resolution/*`).
- **New** `docs/development/issues/README.md` — short entrypoint.
- **New** `docs/development/issues/TRIAGE.md` — operational rules: classifying, distinguishing the kinds (bugfix vs cleanup vs process vs feature vs doctrine), when to add `dispatch:cell` (and when not), when to close/supersede/defer, when to ask the operator, and **when a wave δ may relabel under MCA** (cross-references #539 and `agent/cap/SKILL.md`).
- Linked from `docs/development/README.md`, root `CONTRIBUTING.md`, and `.github/ISSUE_TEMPLATE/cdd-issue.md` (which now also prompts for `kind`/`area`/dispatchable classification and adds `P3`).

Docs only — no code, no label changes, no dispatch/behavior change. Companion to the completed label-normalization pass and its tracker #542.

## Test plan

- [x] all relative links resolve (`TAXONOMY.md`, `TRIAGE.md`, `../../../CONTRIBUTING.md`); bidi clean
- [ ] CI green (I4 link validation in particular)

Refs #542

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_