### PR TITLE
board-map: also refresh on push to main (with self-trigger guard)

### DIFF
--- a/.github/workflows/board-map.yml
+++ b/.github/workflows/board-map.yml
@@ -12,13 +12,21 @@ name: Board map
 # .cdd/unreleased/545/remote-runner-receipt-board-map.md
 
 on:
+  # Board *data* changed — an issue moved.
   issues:
-    types: [opened, edited, closed, reopened, labeled, unlabeled, assigned, unassigned]
+    types: [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned, unassigned]
+  # Generator / template / taxonomy may have changed — regenerate from source.
+  # paths-ignore keeps the Action's own commit to docs/development/board/** from
+  # re-triggering it (no self-trigger loop).
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/development/board/**'
   workflow_dispatch: {}
   schedule:
-    # Daily fallback in case an issue-event trigger is ever missed
+    # Daily fallback in case an event trigger is ever missed
     # (e.g. a GitHub Actions outage window). Time of day is arbitrary.
-    - cron: '17 4 * * *'
+    - cron: '17 6 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
Makes the board a living repo artifact: it now refreshes on **push to `main`** (generator / template / taxonomy changes), not only on issue events.

**Self-trigger guard:** `push` is scoped with `paths-ignore: docs/development/board/**`, so the Action's own commit to the generated board does **not** re-run it — no infinite loop.

Triggers now:
- **issues** (`opened/edited/deleted/closed/reopened/labeled/unlabeled/assigned/unassigned`) — board *data* changed
- **push → main** (ignoring `docs/development/board/**`) — generator/template/taxonomy changed
- **workflow_dispatch** — manual
- **schedule** (`17 6 * * *`) — daily missed-event safety net

Workflow-only change; validated with `yaml.safe_load`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_