### PR TITLE
wake: pin claude-code-action model to Sonnet 5 (deterministic, no default drift)

### DIFF
--- a/.github/workflows/cnos-agent-admin.yml
+++ b/.github/workflows/cnos-agent-admin.yml
@@ -44,6 +44,7 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
+          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/.github/workflows/cnos-cds-dispatch.yml
+++ b/.github/workflows/cnos-cds-dispatch.yml
@@ -58,6 +58,7 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
+          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
@@ -58,6 +58,7 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
+          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/src/packages/cnos.core/commands/install-wake/cn-install-wake
+++ b/src/packages/cnos.core/commands/install-wake/cn-install-wake
@@ -909,6 +909,13 @@ fi
   echo "          github_token: \${{ secrets.SIGMA_WORKFLOW_PAT }}"
   echo "          bot_name: \"${bot_name}\""
   echo "          bot_id: \"${bot_id}\""
+  # Pin the model explicitly (cnos: operator directive) rather than
+  # inheriting claude-code-action@v1's default, so a change to the
+  # action's default model cannot silently alter what runs the cells.
+  # Sonnet 5 is the current de-facto default — pinning makes it
+  # deterministic ("dumb models, smart cells": authority lives in the
+  # cell/FSM, not the model tier).
+  echo "          model: \"claude-sonnet-5\""
   echo "          settings: |"
   echo "            {"
   echo "              \"permissions\": {"

--- a/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+++ b/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
@@ -44,6 +44,7 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
+          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
Pins the model for both wake workflows explicitly instead of inheriting `anthropics/claude-code-action@v1`'s default.

## Why
Neither wake pinned a model — both the CDS dispatch cells and the admin wake ran on the action's **inherited default** (empirically Sonnet 5 — every recent cell/wake commit on `main` carries `Co-Authored-By: Claude Sonnet 5`). That means a change to the action's default could silently alter what runs the cells. This makes it explicit and deterministic.

Behaviorally a **no-op today** — it pins the current de-facto default; it only removes future drift.

## Change
- `cn-install-wake` (the renderer): adds `model: "claude-sonnet-5"` to the generated `claude-code-action@v1` `with:` block.
- Regenerated both goldens + both live workflows (`cnos-cds-dispatch.yml`, `cnos-agent-admin.yml`). Each rendered workflow is byte-identical to its golden, so `install-wake-golden` passes.

## Verification
- `sh cn-install-wake <wake> [--out …]` regenerated all four artifacts; rendered workflow == golden for both wakes (`diff` clean).
- Both workflows parse as valid YAML; `model:` sits correctly under `with:`.

## Note
Applies to **both** wakes (shared renderer block); both already ran Sonnet 5, so current behavior is preserved for each. This operationalizes the "dumb models, smart cells" thesis — authority lives in the cell + FSM, so the model tier should be an explicit, boring constant rather than an inherited default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_