### PR TITLE
wake: add workflow_dispatch trigger to cds-dispatch (manual kick when schedule stalls)

### DIFF
--- a/.github/workflows/cnos-cds-dispatch.yml
+++ b/.github/workflows/cnos-cds-dispatch.yml
@@ -18,6 +18,7 @@ on:
     - cron: '53 * * * *'
   issues:
     types: [labeled]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -31,7 +32,7 @@ concurrency:
 
 jobs:
   wake:
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'issues' && (contains(github.event.label.name, 'dispatch:cell') || contains(github.event.label.name, 'protocol:cds') || contains(github.event.label.name, 'status:todo'))) }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && (contains(github.event.label.name, 'dispatch:cell') || contains(github.event.label.name, 'protocol:cds') || contains(github.event.label.name, 'status:todo'))) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md
@@ -36,6 +36,7 @@ wake:
     triggers:
       - schedule
       - issues_labeled_selector_match
+      - manual_dispatch
   output:
     cycle_artifact_root: ".cdd/unreleased/{N}/"
     artifact_class_taxonomy:

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
@@ -18,6 +18,7 @@ on:
     - cron: '53 * * * *'
   issues:
     types: [labeled]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -31,7 +32,7 @@ concurrency:
 
 jobs:
   wake:
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'issues' && (contains(github.event.label.name, 'dispatch:cell') || contains(github.event.label.name, 'protocol:cds') || contains(github.event.label.name, 'status:todo'))) }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && (contains(github.event.label.name, 'dispatch:cell') || contains(github.event.label.name, 'protocol:cds') || contains(github.event.label.name, 'status:todo'))) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/packages/cnos.core/commands/install-wake/cn-install-wake
+++ b/src/packages/cnos.core/commands/install-wake/cn-install-wake
@@ -746,8 +746,21 @@ while [ "$i" -lt "$trigger_count" ]; do
         echo "    types: [labeled]"
       } >> "$tmp_out"
       ;;
+    manual_dispatch)
+      # cnos#600: operator-invokable manual trigger. Emits a
+      # workflow_dispatch entry so the wake can be kicked from the
+      # Actions UI / API when GitHub's scheduled-cron delivery stalls
+      # (schedule is best-effort and drops fires — see the schedule
+      # trigger doc). No inputs: the manual run scans the same queue and
+      # runs the same claim path as a scheduled sweep (the job-level if:
+      # below allows workflow_dispatch unconditionally, exactly like
+      # schedule).
+      {
+        echo "  workflow_dispatch:"
+      } >> "$tmp_out"
+      ;;
     *)
-      manifest_error "$manifest_path: unknown trigger \"$trigger\" in input_contract.triggers (renderer recognizes: schedule, issues_opened_title_match, issues_labeled_selector_match)"
+      manifest_error "$manifest_path: unknown trigger \"$trigger\" in input_contract.triggers (renderer recognizes: schedule, issues_opened_title_match, issues_labeled_selector_match, manual_dispatch)"
       ;;
   esac
   i=$((i + 1))
@@ -810,6 +823,7 @@ echo "" >> "$tmp_out"
 has_schedule=0
 has_issues_title=0
 has_issues_labeled=0
+has_manual_dispatch=0
 i=0
 while [ "$i" -lt "$trigger_count" ]; do
   trigger="$(jq -r ".input_contract.triggers[$i]" "$manifest_path")"
@@ -817,9 +831,20 @@ while [ "$i" -lt "$trigger_count" ]; do
     schedule) has_schedule=1 ;;
     issues_opened_title_match) has_issues_title=1 ;;
     issues_labeled_selector_match) has_issues_labeled=1 ;;
+    manual_dispatch) has_manual_dispatch=1 ;;
   esac
   i=$((i + 1))
 done
+
+# cnos#600: workflow_dispatch (manual_dispatch trigger) must hit the same
+# claim path as schedule. Build the unconditional-run clause the job-level
+# if: uses so both events fire the sweep. When manual_dispatch is absent
+# (e.g. the admin wake), sched_clause is exactly "github.event_name ==
+# 'schedule'" — keeping every existing golden byte-identical.
+sched_clause="github.event_name == 'schedule'"
+if [ "$has_manual_dispatch" -eq 1 ]; then
+  sched_clause="${sched_clause} || github.event_name == 'workflow_dispatch'"
+fi
 
 title_pattern="$(jq -r '.input_contract.issues_opened_title_pattern // empty' "$manifest_path")"
 if [ -z "$title_pattern" ]; then
@@ -862,14 +887,14 @@ if [ "$has_schedule" -eq 1 ] && [ -n "$issue_event_match" ]; then
     # (no explicit event_name == 'issues' check; the issue-title
     # contains() returns false at schedule firing time, so the
     # schedule short-circuit is sufficient for admin).
-    job_if="    if: \${{ github.event_name == 'schedule' || ${issue_event_match} }}"
+    job_if="    if: \${{ ${sched_clause} || ${issue_event_match} }}"
   else
     # Dispatch shape — github.event.label is undefined at schedule
     # firing time, so we explicitly gate the issue clause on the
     # event being 'issues'. This is the OG-2 guardrail: schedule
     # events fire the sweep unconditionally; issue events fire only
     # when the labeled label is in the selector's include set.
-    job_if="    if: \${{ github.event_name == 'schedule' || (github.event_name == 'issues' && ${issue_event_match}) }}"
+    job_if="    if: \${{ ${sched_clause} || (github.event_name == 'issues' && ${issue_event_match}) }}"
   fi
 elif [ -n "$issue_event_match" ]; then
   job_if="    if: \${{ ${issue_event_match} }}"


### PR DESCRIPTION
Makes the CDS dispatch wake manually invokable when GitHub's scheduled-cron delivery stalls. Operator-authorized (option 3 for the #600 claim outage).

## Why
GitHub scheduled crons are best-effort and drop fires; #600 sat `status:todo` ~50 min through **4 consecutive skipped sweeps** (:53/:08/:23/:38) with no self-service way to force a claim (re-run 403s for this token; the `issues` event is `if:`-gated to selector labels only; there was no `workflow_dispatch`).

## Change (through the source → render → golden path, per directive)
- **Manifest** (`cds-dispatch/SKILL.md`): `input.triggers += manual_dispatch`.
- **Renderer** (`cn-install-wake`): new `manual_dispatch` case emits `workflow_dispatch:`; the job `if:` ORs `github.event_name == 'workflow_dispatch'` **alongside `schedule`**, so a manual run scans the same queue and runs the **same claim path** as a scheduled sweep. A `sched_clause` helper keeps output **byte-identical when `manual_dispatch` is absent** — so the agent-admin golden is unchanged.
- Regenerated `cnos-cds-dispatch.golden.yml` + live `.github/workflows/cnos-cds-dispatch.yml`.

## Result
```
on:
  schedule: [ :08 :23 :38 :53 ]
  issues: { types: [labeled] }
  workflow_dispatch:              # ← new
jobs.wake.if: schedule || workflow_dispatch || (issues && label ∈ selector)
```

## Verification
- Rendered == golden for **both** wakes (`diff` clean); re-render idempotent.
- agent-admin workflow + golden **byte-identical to main** (only 4 files changed).
- Model pin (#594) + scanner/finalizer (#593/#591) preserved in the regenerated cds workflow.
- Both workflows parse as valid YAML.

## Scope guardrails (per directive)
No change to selector semantics, issue labels, FSM behavior, dispatch protocol, or Sub D scope. No Demo 0. Purely additive: a manual trigger routed to the existing claim path.

After merge I'll trigger the workflow manually to claim #600.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_