### PR TITLE
wake: revert broken model pin (#594) — claude-sonnet-5 was rejected, broke all dispatch cells

### DIFF
--- a/.github/workflows/cnos-agent-admin.yml
+++ b/.github/workflows/cnos-agent-admin.yml
@@ -44,7 +44,6 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
-          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/.github/workflows/cnos-cds-dispatch.yml
+++ b/.github/workflows/cnos-cds-dispatch.yml
@@ -74,7 +74,6 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
-          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
+++ b/src/packages/cnos.cds/orchestrators/cds-dispatch/cnos-cds-dispatch.golden.yml
@@ -74,7 +74,6 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
-          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {

--- a/src/packages/cnos.core/commands/install-wake/cn-install-wake
+++ b/src/packages/cnos.core/commands/install-wake/cn-install-wake
@@ -983,13 +983,18 @@ fi
   echo "          github_token: \${{ secrets.SIGMA_WORKFLOW_PAT }}"
   echo "          bot_name: \"${bot_name}\""
   echo "          bot_id: \"${bot_id}\""
-  # Pin the model explicitly (cnos: operator directive) rather than
-  # inheriting claude-code-action@v1's default, so a change to the
-  # action's default model cannot silently alter what runs the cells.
-  # Sonnet 5 is the current de-facto default — pinning makes it
-  # deterministic ("dumb models, smart cells": authority lives in the
-  # cell/FSM, not the model tier).
-  echo "          model: \"claude-sonnet-5\""
+  # NOTE (cnos#594 reverted): do NOT emit a `model:` input here.
+  # claude-code-action@v1 does not declare `model` as an action input
+  # (GitHub warns "Unexpected input(s) 'model'"), but the value still
+  # reaches the underlying Claude Code CLI as INPUT_MODEL and IS honored.
+  # Pinning `model: "claude-sonnet-5"` made every dispatch cell error out
+  # immediately (result is_error=true, total_cost_usd=0) — the CLI ran but
+  # the model call was rejected, so no cell could claim (cnos#600 stall).
+  # The action's own default model is the working configuration; leave it
+  # unset. If an explicit pin is ever wanted, pass a VERIFIED-accessible
+  # model via `claude_args: "--model <id>"` (the declared pass-through),
+  # never a bare `model:` input, and confirm the run's result is_error is
+  # false first.
   echo "          settings: |"
   echo "            {"
   echo "              \"permissions\": {"

--- a/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
+++ b/src/packages/cnos.core/orchestrators/agent-admin/cnos-agent-admin.golden.yml
@@ -44,7 +44,6 @@ jobs:
           github_token: ${{ secrets.SIGMA_WORKFLOW_PAT }}
           bot_name: "sigma@cnos.cn-sigma.cnos"
           bot_id: "41898282"
-          model: "claude-sonnet-5"
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
**Regression fix — restores the dispatch pipeline.**

## Root cause
#594 pinned `model: "claude-sonnet-5"` in the dispatch wake. `claude-code-action@v1` doesn't declare `model` as an action input (GitHub warns *"Unexpected input(s) 'model'"*) — **but the value still reaches the Claude Code CLI as `INPUT_MODEL` and is honored.** The CLI initialized with `claude-sonnet-5` and the API **rejected it**:
```json
{ "type":"result", "is_error":true, "duration_ms":1834, "num_turns":1, "total_cost_usd":0 }
```
`$0 cost` + `is_error` = the model call failed before any work. So **every dispatch run's agent no-op'd in ~1.8s and no cell could claim** — that's the real cause of the #600 stall (proven from run `28732403924`'s job log), not GitHub cron flakiness.

Pre-#594 (no `model:` line) the CLI used its working default — which is why #593's cell ran a full cycle.

## Fix
Remove the `model:` emit from the renderer (`cn-install-wake`), restoring the action's working default model. Regenerated both goldens + live workflows.

## Preserved
- `#601` `workflow_dispatch` trigger — intact.
- `#593` recovery scanner + `#591` finalizer — intact.
- rendered == golden for both wakes; the model line is removed from **both** (the pin had applied to both).

## Follow-up note
If an explicit pin is ever wanted, pass a **verified-accessible** model via `claude_args: "--model <id>"` (the declared pass-through) — never a bare `model:` input — and confirm the run's `result.is_error` is false first. (`claude-sonnet-5` is not accepted by the OAuth token in this environment.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGCdNwPwVVhq8CHDnSTuf)_