### PR TITLE
cds-install Sub 1 (Cn=1 / PR 1): implement `cn repo install` — base installer

### DIFF
--- a/.cdd/unreleased/608/REVIEW-REQUEST.yml
+++ b/.cdd/unreleased/608/REVIEW-REQUEST.yml
@@ -1,0 +1,20 @@
+issue: 608
+protocol: cds
+cycle_branch: cycle/608
+requested_by: delta (cds-dispatch wake, wake-invoked mode)
+pr: "https://github.com/usurobor/cnos/pull/617"
+converge_verdict_ref: .cdd/unreleased/608/beta-review.md
+note: >
+  Requesting the in-progress -> review transition per beta's Round 1
+  converge verdict (round 0: iterate, one blocking finding F1 -- install
+  root resolution used main.go's unbounded .cn/-search HubPath instead of
+  git-repo-root detection, silently walking up past non-git ancestor
+  directories, violating AC1's no-silent-walk-up requirement; round 1:
+  converge, F1 independently re-verified fixed by reverting it in an
+  isolated worktree and confirming the new tests genuinely catch the
+  pre-fix bug, all AC1-AC11 independently re-derived as met, 307/307 tests
+  green, build/vet/test -race all clean). All closeout artifacts
+  (gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md,
+  beta-closeout.md, gamma-closeout.md) are present on this branch. PR #617
+  opened by delta referencing and closing #608, with 20 commits beyond the
+  cycle/608 <-> main merge-base.

--- a/.cdd/unreleased/608/alpha-closeout.md
+++ b/.cdd/unreleased/608/alpha-closeout.md
@@ -1,0 +1,33 @@
+# alpha close-out — cycle #608
+
+**Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — `cn repo install` base installer (Sub 1 / PR 1 of the #607 wave). **Verdict at merge:** converge (β R1), one iteration.
+
+---
+
+## What α built
+
+A new kernel command, `cn repo install`, registered through the existing noun-verb resolver (`RepoInstallCmd`, `Spec().Name == "repo-install"`, `Source: SourceKernel`, `NeedsHub: false`) so it can run in a plain `git init`-only repo before any `.cn/` hub exists. The domain logic lives in a new `internal/repoinstall/` package; the CLI surface is a thin `internal/cli/cmd_repo_install.go` wrapper. Both reuse the existing substrate directly — `restore.GenerateLockFromIndex`, `restore.Restore`, the `pkg.Manifest`/`pkg.Lockfile`/`pkg.PackageIndex` types, `binupdate`'s release-resolution shape — with zero reimplementation of lock generation, SHA-256 verification, or tar extraction. `docs/development/design/cn-repo-install-MOCKS.md` was landed verbatim from the operator-reviewed design branch (not re-authored), and `docs/guides/INSTALL-CDS.md` was rewritten so `cn repo install` is the canonical Layer-1 onboarding path.
+
+All eleven ACs closed with PASS-backed evidence, and the `mock_parity` block converged at 10/10 matched (A1–A5, B1–B4, E1), 0 missed. Final test count: 307 passing, 0 failing (`go test ./...`), plus clean `go vet ./...` and `go test -race ./...` on the touched packages — up from 304 at R0's signal, the +3 being the R1 fix-round's regression tests (two real-dispatch-path tests, one flag-combination test closing a narrow R0 debt item).
+
+## The one iteration, and what I learned from it
+
+β's R0 finding was real, not a nitpick: `RepoInstallCmd.Run` trusted `inv.HubPath` (populated by `main.go`'s unbounded ancestor `.cn/` walk) as the install root whenever it was non-empty, skipping the actual git-repo-root check entirely. Against a real binary, standing in a directory that is not a git repo at all but sits under some unrelated ancestor `.cn/`, the command would silently proceed — exactly the negative case AC1's own text calls out ("does not silently walk up") and exactly the failure mode `cn repo install`'s whole premise (installing where no `.cn/` yet exists) makes newly reachable, unlike the existing `NeedsHub: true` commands where the walk-up target and the git root coincide by construction.
+
+I wrote a negative test for this AC (`TestRepoInstall_NotAGitRepo_FailsClearly`) at R0 and it passed — because it hand-constructed `Invocation{HubPath: ""}` rather than driving the real dispatch path through `main.go`'s `discoverHub()`. The test satisfied the AC's literal text while stubbing around the exact boundary the AC concerned. That is the lesson worth carrying forward: a negative test built by constructing the harness input directly, instead of building the binary and driving it as a subprocess, can pass while the real invariant is false. β's Role Rule 6 (code-first, build-the-binary) is precisely the check that catches this, and it did.
+
+The R1 fix was a net deletion, not new complexity: `gitRepoRoot(ctx)` is now called unconditionally, first, before any `inv.HubPath` read; the alternative (trust `inv.HubPath` after confirming it equals the git root) was considered and rejected as an unnecessary second code path. Two new tests build the real `cn` binary and drive it as a subprocess against β's exact repro shape (ancestor `.cn/` outside any git repo) plus a stronger control (ancestor `.cn/` alongside a correctly-nested inner git repo), and I verified both genuinely fail against the pre-fix code before confirming they pass against the fix — the same "revert and re-run" discipline β used to verify my fix, applied to my own regression tests before handing them back.
+
+## Debt disclosed
+
+Seven items were named explicitly in `self-coherence.md` §Debt, none blocking any AC: (1) `cn --version` exits non-zero — pre-existing, now cross-referenced against #612 since the new install doc references it; (2) `cn cdd verify`'s small-change classifier hard-fails an in-progress `self-coherence.md` rather than warning — tooling friction forcing a mid-cycle header-format change, cross-referenced against #577; (3) `--index <URL>` + explicit `--release <tag>` untested — closed within the cycle at R1; (4) `docs/guides/README.md` nav link not added — correctly out of scope per the issue's own text (deferred to #611); (5) no lockfile-level concurrency guard — inherited from `restore.Restore`, not new; (6) no Windows support — pre-existing kernel-wide scope boundary; (7) transient CI red on `cdd-artifact-check` during incremental self-coherence authoring — expected, resolved once all sections landed, same root cause as (2).
+
+One accounting note on my own artifact, not β's or γ's: γ's scaffold text said "9 rows total" for the mock_parity set while separately naming a 10-item set (A1–A5, B1–B4, E1). I used the correct 10-row count and flagged the scaffold's arithmetic slip in `self-coherence.md` rather than silently dropping a row to match "9" or silently correcting γ's prose without comment — β independently confirmed the 10-row accounting was right.
+
+## Artifact list
+
+`src/go/internal/repoinstall/repoinstall.go` + `repoinstall_test.go` (new, 22+1 tests), `src/go/internal/cli/cmd_repo_install.go` + `cmd_repo_install_test.go` (new, 9+2 tests), `src/go/cmd/cn/main.go` (+1 registration line), `src/go/internal/hubsetup/hubsetup.go` (export rename only, `ensureGitignoreEntry` → `EnsureGitignoreEntry`, no behavior change), `docs/development/design/cn-repo-install-MOCKS.md` (new, landed verbatim), `docs/guides/INSTALL-CDS.md` (new), `.cdd/unreleased/608/self-coherence.md` (this cycle's primary artifact, R0 + R1 sections).
+
+## Final AC status
+
+AC1–AC11: all PASS, all confirmed independently by β against code and a built binary, not merely read off this artifact. AC1's negative half was the one AC that needed a round-2 fix; AC2–AC11 were unaffected by that fix and re-confirmed unchanged at R1.

--- a/.cdd/unreleased/608/beta-closeout.md
+++ b/.cdd/unreleased/608/beta-closeout.md
@@ -1,0 +1,35 @@
+# beta close-out — cycle #608
+
+**Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — `cn repo install` base installer (Sub 1 / PR 1 of the #607 wave). **Verdict:** converge after one iteration (R0 iterate → R1 fix → R1 converge).
+
+---
+
+## Review Summary
+
+Two review passes, both from fresh clones (never a reused worktree), both re-fetching `origin/main` synchronously before computing the diff base rather than trusting a session-start snapshot. R0 reviewed head `226181f4` against base `80778d68`; R1 reviewed head `712f6b87` against base `a8a3d8de` (one unrelated log-append commit ahead of α's R1 rebase point — confirmed disjoint from this cycle's diff, no re-rebase needed). One blocking finding across both rounds; everything else was independent confirmation, not correction.
+
+## Implementation Assessment
+
+All seven implementation-contract axes held throughout: Go only, kernel `cn` subcommand via the existing noun-verb resolver (not a separate binary, not a shell-out), new package under `internal/repoinstall/` reusing `restore/`, `pkg/`, `binupdate/`, `hubsetup/` directly, no `go.mod`/`go.sum` changes, `cn.deps.v1`/`cn.lock.v2`/package-index schemas byte-for-byte unchanged, `cn init`/`setup`/`deps` behavior untouched. The blocking finding was a behavioral bug at the AC1 negative-case boundary, not a contract-axis drift — worth separating cleanly, since Rule 7 (contract conformance) and Rule 4 (no merge with unresolved findings) are different gates and this cycle only ever tripped the second one.
+
+## Technical Review
+
+**Why the R0 finding was real, and how I caught it.** α's mock_parity block and self-coherence report both marked AC1 as `match`, citing `TestRepoInstall_NotAGitRepo_FailsClearly` as evidence. That test passed — but it hand-constructed `Invocation{HubPath: ""}`, bypassing `main.go`'s real `discoverHub()` walk entirely. I didn't stop at "the cited test passes." I built the actual `cn` binary and drove `cn repo install --dry-run` from a directory that was not inside any git repository but sat under an unrelated ancestor `.cn/` — the exact shape `discoverHub()`'s unbounded upward walk can hand back as `inv.HubPath`. The command proceeded past the point AC1's own text says it must fail ("does not silently walk up"), resolved the unrelated ancestor as the install root, and only stopped on an unrelated downstream error (package-index resolution). Exit code 0 up to that point, no error, silent — precisely the risk class AC1 was written to prevent, and precisely the class a report-level or test-suite-level read would have missed, since the report was true about the test and false about the invariant.
+
+This is the concrete case for Rule 6 ("anchor oracle evidence on code, not doc") extended one level further: the doc/report can be accurate about what the test suite verifies while the test suite itself stubs around the real dispatch boundary. Building the binary and driving it as a subprocess is what surfaced the gap between "the cited test passes" and "the AC's own invariant holds."
+
+**R1 re-review discipline.** I did not take α's "fixed, verified" claim on faith. I re-read `cmd_repo_install.go` at the new HEAD directly (confirmed `inv.HubPath` no longer appears anywhere in the file, not merely reordered), rebuilt the binary fresh, and re-ran my own R0 repro commands verbatim against it. I also reverted α's fix in an isolated worktree (not the reviewed branch) and re-ran α's two new regression tests against the pre-fix code to confirm they actually fail there — both did, for the exact bug class, before confirming both pass against the fix. That is the same standard I held α's original AC1 test to; applying it to α's fix-round evidence too, rather than trusting a second-round claim more readily than a first-round one, is what the converge verdict rests on.
+
+## Process Observations
+
+- The R0→iterate→R1→converge loop cost one round for one confirmed bug — not evidence of a scaffold or process failure by itself. γ's own closeout traces the gap to γ's scaffold's AC-oracle table naming only AC1's positive check, and to α's negative test stubbing around the real dispatch boundary; both are true, and the review loop caught the compound gap at normal cost, exactly as designed.
+- α's fix-round discipline matched the standard I set at R0: net deletion over added complexity, regression tests that build-and-drive the real binary rather than a synthetic harness, and an explicit revert-and-confirm-failure step before claiming the tests catch the regression class. I did not have to ask for any of that — it was already in the R1 self-coherence appendix.
+- Confidence in the R1 converge verdict is high: the fix is a strict simplification (one conditional deleted, not added), AC2–AC11 touch no changed code path this round, and every claim in this artifact was independently re-derived against a freshly built binary or a fresh `git test`/`vet`/`race` run, not read off α's transcript.
+
+## For a future reviewer of a similar cycle
+
+When a negative AC clause ("fails if X", "does not silently do Y") is tested via a hand-constructed harness input rather than a real subprocess dispatch, treat that as an open question, not closure evidence — the harness construction itself may be exactly the code path the invariant depends on. Build the binary and drive it as a subprocess whenever the AC concerns behavior at the actual dispatch/entry boundary (argument parsing, hub discovery, cwd resolution) rather than pure domain logic; a fixture-level unit test can be fully honest about the fixture and still miss the boundary.
+
+## Release Notes
+
+This close-out is written at the β R1 converge boundary, per γ's own process-gap-audit closeout (`.cdd/unreleased/608/gamma-closeout.md`): the review loop is closed (converge), but the actual `git merge` to `origin/main`, the close-keyword pre-merge gate row, and the issue-close have not executed yet — issue #608 remains `OPEN` at the time this artifact is written. That mechanical merge step, and everything at the release boundary (tag/deploy, cycle-directory move to `.cdd/releases/{X.Y.Z}/608/`), remains outstanding and is not claimed as done here. No release-boundary action is β's to take beyond executing the merge itself under the current bootstrap-mode stand-in (`beta/SKILL.md` "merge/no-merge judgment" vs. the not-yet-built mechanical runtime) — tag/deploy/disconnect stays δ's surface regardless.

--- a/.cdd/unreleased/608/beta-review.md
+++ b/.cdd/unreleased/608/beta-review.md
@@ -105,3 +105,91 @@ This is a materially different risk class from existing `NeedsHub: true` command
 Build/vet/test are clean from a fresh checkout; the seven implementation-contract axes all hold; ten of eleven ACs are independently confirmed against the actual code (not the self-coherence report). AC1's negative case, however, fails at the real dispatch boundary in a way the shipped test suite cannot detect (the test harness bypasses `main.go`'s hub-discovery walk entirely) — I reproduced this independently against the built binary. Per Role Rule 6 ("anchor oracle evidence on code, not doc" — extended here to "not a test that stubs around the real dispatch path") and Role Rule 4 ("do not merge with unresolved findings"), this is an iterate-triggering finding: it is squarely inside AC1's own explicit negative-case text, it is silent (exit 0, no error) and reproducible, and it can cause `cn repo install` to write into a directory other than the one the operator invoked it in.
 
 **Iterate.** α should fix `cmd_repo_install.go`'s repo-root resolution to always verify the actual git root (not trust an unbounded ancestor `.cn/` walk) and add a test that exercises the real `main.go`-equivalent dispatch path for this case. Once that lands, re-review should be a narrow re-check of AC1 plus a regression pass on AC2–AC11 (none of which are expected to be affected by this fix).
+
+---
+
+# beta-review — cnos#608 — R1 (re-review)
+
+## Verdict: **converge**
+
+`origin/main` re-fetched synchronously for this pass: `git rev-parse origin/main` = `a8a3d8de1b69e0b9f747508d1e5894125514e82d`. This is one commit ahead of the `c08a7483` tip α rebased onto for the R1 fix (`sigma: agent-admin heartbeat wake at cnos, 2026-07-06T18:03:31Z`, `.cn-sigma/logs/20260706.md` only — disjoint from every path this cycle's diff touches; `git diff --stat c08a7483..a8a3d8de` confirms a single-file, unrelated log append). No re-rebase needed for this review pass; nothing in the intervening commit affects any AC or the diff base.
+
+Cycle-branch head reviewed: `712f6b8743d6ebe420fc5e617e8b1d0a68d38c10` (fresh checkout via `git switch -c cycle/608-r1review origin/cycle/608`, no reused worktree).
+
+This is an independent re-review, not a rubber-stamp of α's R1 claims — every item below was re-derived from the code and a freshly built binary, not read off `self-coherence.md`'s §R1 prose.
+
+## 1. R0 blocking finding — independently re-verified fixed
+
+Read `src/go/internal/cli/cmd_repo_install.go` at current HEAD directly (not diffed against α's narrative). Confirmed:
+
+- `inv.HubPath` does not appear anywhere in the file (`grep -n HubPath src/go/internal/cli/cmd_repo_install.go` → zero hits). The R0-flagged branch (`repoRoot := inv.HubPath; if repoRoot == "" { ... }`) is gone entirely, not merely reordered.
+- `RepoInstallCmd.Run` now calls `gitRepoRoot(ctx)` unconditionally as its first substantive step after arg parsing, and fails with the exact AC1 message (`✗ cn repo install must be run inside a Git repository.`) whenever that call errors — with no conditional path around it.
+
+**Repro re-run against a freshly built binary from this exact branch HEAD** (not trusting α's transcript):
+
+```
+cd src/go && go build -o /tmp/cn_r1 ./cmd/cn
+mkdir -p /tmp/repro2/outer-hub/nested/not-a-git-repo
+mkdir /tmp/repro2/outer-hub/.cn
+cd /tmp/repro2/outer-hub/nested/not-a-git-repo
+/tmp/cn_r1 repo install --dry-run
+```
+
+Result: `✗ cn repo install must be run inside a Git repository.`, exit code 1, and `/tmp/repro2/outer-hub/.cn` remains empty (`ls -la` → only `.`/`..`). This is the exact scenario that silently proceeded to index resolution at R0. **Finding 1 is fixed**, confirmed independently.
+
+## 2. New tests — confirmed non-vacuous, real dispatch path
+
+Read `TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly` and `TestRepoInstall_RealDispatch_AncestorHubWithNestedGitRepo_UsesInnerRoot` in `src/go/internal/cli/cmd_repo_install_test.go` in full. Both call `buildCnBinary(t)` (a real `go build -o <tmp>/cn ./cmd/cn` subprocess, not a stub) and drive the resulting binary via `exec.Command` with `cmd.Dir` set to a constructed cwd — this exercises `main.go`'s actual `discoverHub()` and dispatch path, not a hand-constructed `Invocation{HubPath: ...}` (which is exactly the bypass that let the R0 bug slip through the original `TestRepoInstall_NotAGitRepo_FailsClearly`).
+
+**Reverted the fix locally and confirmed both new tests fail** (per this task's suggested verification, done rather than reasoned-about only): checked out `git show 5fd47490:.../cmd_repo_install.go` (the pre-fix content) into an isolated `git worktree` (not the reviewed branch itself), ran the two new tests against it:
+
+```
+--- FAIL: TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly
+    stderr = "✗ resolve latest cnos release: http status 403"
+    (proceeded past the git-repo check; failed on live release resolution
+    instead of the git-repo check — same bug class as β's R0 repro, though
+    the exact downstream error differs from α's transcript because this
+    sandbox's network path hit GitHub's rate limit rather than the
+    package-index-lookup failure α saw; the load-bearing fact — the git-repo
+    check is skipped entirely — is confirmed either way)
+--- FAIL: TestRepoInstall_RealDispatch_AncestorHubWithNestedGitRepo_UsesInnerRoot
+    stdout reports the ancestor as "Git repository root"; .cn/deps.json is
+    written under the ancestor .cn/, not the inner git repo — silent
+    wrong-directory install, exit 0
+```
+
+Both tests genuinely fail against the pre-fix code and pass against the fix (re-ran `go test ./internal/cli/... -run 'TestRepoInstall_RealDispatch_.*'` against the actual reviewed HEAD: both PASS). The tests are not tautological — they detect the exact regression class they were added for. Worktree torn down after (`git worktree remove --force`), reviewed branch untouched.
+
+One incidental observation: `TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly` passes no `--index`/`--release`, so if the git-repo-root check were ever accidentally removed or reordered again, this test would attempt a live `api.github.com` call rather than failing fast/hermetically — as demonstrated by the 403 above. Against the *current, fixed* code this never fires (the git-repo check runs before any network access), so this is not a regression risk today, only a latent hermeticity gap in the test's own defense-in-depth should the fix regress a second time. Non-blocking, noted for completeness rather than requiring a change.
+
+## 3. No regression — fresh build/vet/test/race, this branch
+
+Run from a clean checkout of `cycle/608-r1review` (tracking `origin/cycle/608` HEAD `712f6b87`):
+
+- `go build ./...` — clean, exit 0.
+- `go vet ./...` — clean, exit 0.
+- `go test ./...` — all 15 packages `ok`, 0 failures (307 `--- PASS`, 0 `--- FAIL` via `go test ./... -v | grep -c`). Matches α's claimed count exactly (304 at R0 + 3 new this round).
+- `go test -race -count=1 ./...` — clean, all 15 packages pass, no race reports.
+
+## 4. AC1–AC11 re-walk
+
+- **AC1**: now fully confirmed both halves — positive (fresh git repo, no prior state) unaffected by the fix, still passes via `TestRepoInstall_FreshGitRepo_EndToEnd`; negative (not-a-git-repo, including the ancestor-hub-hijack shape) now genuinely enforced at the real dispatch boundary, confirmed above. **Closed.**
+- **AC2–AC11**: no code path other than repo-root resolution changed this round (`git diff origin/main...origin/cycle/608 -- src/go/internal/cli/cmd_repo_install.go` is the only production-code hunk touching dispatch logic; `internal/repoinstall/repoinstall_test.go` gained one additional test, `TestRun_IndexHTTPURL_WithExplicitReleaseTag`, closing R0's non-blocking observation 4 — verified it exercises the remote-URL + explicit-release-tag combination, not a restatement of an existing case). Spot-re-ran the R0 evidence set (idempotence, dry-run empty-write, SHA-mismatch propagation, dispatch-cds guard, no-agent-hub-scaffold) — all still pass, unchanged from R0's independent confirmation. No regression across AC2–AC11.
+
+## 5. Rebase/force-push drift check
+
+`git log --oneline origin/main..origin/cycle/608` shows a clean, complete line: γ scaffold → α's design-doc landing → domain/cli/registration commits → α's incremental self-coherence sections → β's R0 review commit (`0e67adf5`) → α's R1 fix commit (`aef74f3e`) → α's R1 self-coherence appendix (`712f6b87`, current HEAD). No commits are missing from the history; the SHA-remapping table α added in `self-coherence.md` §R1 correctly accounts for the rebase (pre-rebase SHAs `226181f4`/`2a3699b7`/`49d0cbb2` → post-rebase `1346f894`/`68ab7edf`/`0e67adf5`, content-identical).
+
+Confirmed present and non-empty on `origin/cycle/608` at current HEAD:
+- `.cdd/unreleased/608/CLAIM-REQUEST.yml` (12 lines) — γ's pre-flight claim record, intact.
+- `.cdd/unreleased/608/gamma-scaffold.md` (189 lines) — intact.
+- `.cdd/unreleased/608/self-coherence.md` (1074 lines) — both the original §Gap/§Skills/§ACs/§Self-check/§Debt/§CDD Trace/§Review-readiness sections (R0) and the new §R1 appendix are present; nothing was rewritten in place (verified the R0 prose is byte-identical to the version β read at R0, only new content was appended).
+- `.cdd/unreleased/608/beta-review.md` — my own R0 section (this file, above the separator) is untouched by α; this R1 section is a pure append, per Role Rule "never restart completed sections."
+
+No artifact loss or drift from the force-push.
+
+## Verdict rationale
+
+α's fix is a net deletion of the buggy conditional, not new conditional complexity, and closes exactly the bug class β's R0 finding named (verified independently against a freshly built binary from this exact branch HEAD, not merely re-reading α's transcript). The two new tests exercise the real dispatch path (build + subprocess) and were confirmed — by actually reverting the fix in an isolated worktree and re-running them — to genuinely fail against the pre-fix code, so they are not vacuous regression coverage. Build/vet/test/race are all clean from a fresh checkout. AC1's negative half is now closed at the real dispatch boundary; AC2–AC11 show no regression. `origin/main` advanced by one unrelated commit since α's rebase base; it does not touch any path this cycle's diff touches and does not require another rebase before merge. All required `.cdd/unreleased/608/` artifacts are present and intact after the force-push rebase.
+
+**Converge.** This closes the review loop; the cycle proceeds to closeout (β merge + β close-out, per `beta/SKILL.md`).

--- a/.cdd/unreleased/608/beta-review.md
+++ b/.cdd/unreleased/608/beta-review.md
@@ -1,0 +1,107 @@
+# beta-review — cnos#608 — R0
+
+## Verdict: **iterate**
+
+Base SHA at review time: `origin/main` = `80778d688e04e61c66d38f2bd5962fafb0729e95` (re-fetched and confirmed current; matches α's rebased base — no drift since α's last rebase). Cycle-branch head reviewed: `226181f4c5a70fd6ab632e23f37ddc9cb5bf7925`.
+
+## Independent verification performed (not a re-read of α's claims)
+
+- Fresh clone (`git clone` into a scratch dir, not reusing any prior worktree), `git fetch origin cycle/608 && git switch -c cycle/608-review origin/cycle/608` — clean checkout, no leftover build artifacts.
+- `cd src/go && go build ./...` — clean, exit 0.
+- `go vet ./...` — clean, exit 0.
+- `go test ./...` — all packages pass, including `internal/repoinstall` and `internal/cli` (0 failures). Matches α's claimed 304-test count in shape (all green).
+- Read `internal/repoinstall/repoinstall.go`, `internal/cli/cmd_repo_install.go`, `src/go/cmd/cn/main.go`, `internal/hubsetup/hubsetup.go` diff, and the landed `docs/development/design/cn-repo-install-MOCKS.md` / `docs/guides/INSTALL-CDS.md` in full — not just the self-coherence report's excerpts.
+- Confirmed no new `go.mod`/`go.sum` entries (runtime-dependency contract axis holds).
+- Confirmed `.github/workflows/*` is untouched in the diff (`git diff --stat origin/main...HEAD` — no workflow file appears).
+- Confirmed no SKILL.md files are touched (frontmatter validator not applicable to this cycle; pre-merge gate row 3 collapse for that specific validator is legitimate).
+- Confirmed CI is green at the reviewed HEAD via `gh run list --repo usurobor/cnos --branch cycle/608` (`Build` → `success` at `226181f4`).
+- Built the actual `cn` binary (`go build -o cn ./cmd/cn`) and drove `cn repo install` directly (not through the test harness) to independently re-derive AC1's behavior — this is where a real, reproducible bug surfaced (see Findings).
+
+## AC-by-AC walk (code-first, per Rule 6)
+
+- **AC1 (kernel command, fresh-repo, no prior state)**: dispatch shape confirmed (`RepoInstallCmd.Spec().Name == "repo-install"`, `Source: SourceKernel`, `NeedsHub: false`, registered in `main.go`). The "runs from a fresh git repo" half is confirmed. **The negative half of AC1 — "fails with a clear error if not at a git repo root (does not silently walk up or scaffold)" — is FALSE at the real dispatch boundary.** See Finding 1 below. This is CONFIRMED, not asserted from the test suite: I reproduced it against the built binary.
+- **AC2** (deterministic `.cn/deps.json`): confirmed — `writeManifest` marshals a typed struct via `json.MarshalIndent`, no timestamp field, stable order. `TestRun_Idempotent_ByteIdenticalArtifacts` is a real byte-comparison test, not tautological.
+- **AC3** (`cn.lock.v2`, exact versions, SHA-256 pins): confirmed — lockfile generation is 100% delegated to `restore.GenerateLockFromIndex` (reused, not reimplemented); `grep -n sha256` in `internal/repoinstall/repoinstall.go` (non-test) returns zero hits, confirming no parallel SHA computation was introduced.
+- **AC4** (restores default triple, checksums verified): confirmed — `TestRun_SHAMismatchPropagates` uses a deliberately-corrupted fixture and asserts the *existing* verify path actually fires (a real negative test, not a happy-path-only check).
+- **AC5** (idempotent): confirmed — `TestRepoInstall_Idempotent_NoDiffOnSecondRun` uses the stronger commit-then-rerun form (a bare pre-commit `git diff --exit-code` would pass trivially; this test correctly avoids that trap).
+- **AC6** (`--dry-run` writes nothing): confirmed — code-level guarantee (`Run`'s `DryRun` branch returns before `applyInstall`, the sole owner of every write, is ever called) plus test-level `os.ReadDir` emptiness assertion.
+- **AC7** (`--release latest` / `--release <tag>` / `--index <path-or-url>`): confirmed — real `httptest.Server`-backed fixtures for the GitHub API and release-asset download path, including the relative-URL rewrite case. The live-network path is deliberately not exercised in CI, which matches the scaffold's own guidance and is not a gap.
+- **AC8** (no `.github/workflows/`, no secret requirement): confirmed by direct grep of the new source (zero hits for the named secret names, zero non-prose `.github/workflows` path construction) and by test assertion (`os.Stat(".github")` is `IsNotExist` post-install).
+- **AC9** (`--dispatch cds` fails explicitly, no partial write): confirmed — `validateDispatch` is the first statement in `Run`, before any I/O; test asserts exact stderr string, `#609` reference, and zero files written (not just "no `.github/`" — the whole `RepoRoot` is checked empty).
+- **AC10** (no agent-hub scaffold): confirmed — `internal/repoinstall` does not import `internal/hubinit` at all (checked the import block directly, not just trusting the self-coherence claim).
+- **AC11** (docs updated): confirmed — `docs/guides/INSTALL-CDS.md` opens with the one-command flow as canonical; `grep -c "cn repo install"` → 17 hits; zero "7 manual steps" framing. The design-branch draft's stale `cn.lock` filename was correctly *not* carried forward (the shipped doc uses the real `.cn/deps.lock.json` / `cn.lock.v2` path) — a genuine reconciliation, not a doc/code drift.
+
+## Implementation-contract conformance (Rule 7)
+
+All seven pinned axes checked against the diff directly:
+
+- **Language**: Go only. Confirmed.
+- **CLI integration target**: kernel `cn` subcommand via noun-verb resolution (`ResolveCommand` builds `"repo"+"-"+"install"`), not a separate binary, not shelling out to `cn` internally. Confirmed by reading `dispatch.go` and `cmd_repo_install.go`.
+- **Package scoping**: new `internal/repoinstall/` package + `cli/cmd_repo_install.go`, reusing `restore/`, `pkg/`, `binupdate/`, `hubsetup/`. No new top-level directory. Confirmed.
+- **Existing-binary disposition (coexist)**: `cmd_init.go`, `cmd_setup.go`, `cmd_deps.go` are untouched in the diff (`git diff --stat` shows zero hunks in any of them). `hubsetup.go`'s only change is a pure export rename (`ensureGitignoreEntry` → `EnsureGitignoreEntry`), same body, same call site in `hubsetup.Run` — behavior-preserving. Confirmed.
+- **Runtime dependencies**: no `go.mod`/`go.sum` changes. Confirmed.
+- **JSON/wire contract preservation**: `pkg.Manifest`/`pkg.Lockfile`/`pkg.PackageIndex` are read/written via their existing typed shapes; `git diff` on `pkg.go` shows zero hunks. Vendor path is name-based (`.cn/vendor/packages/<name>/`), confirmed unchanged (`pkg.VendorPath` untouched). Confirmed.
+- **Backward-compat invariant**: no shared code path (`restore.go`, `pkg.go`, `binupdate.go`) is modified. Confirmed.
+
+Implementation-contract conformance: **PASS** on all seven axes. The blocking finding below is a behavioral/AC-oracle bug, not a contract-axis drift.
+
+## Findings
+
+### Finding 1 — AC1's "does not silently walk up" invariant is violated at the real dispatch boundary (BLOCKING)
+
+**Severity:** major (confirmed, reproducible, silently writes into the wrong directory with exit code 0).
+
+**What's wrong:** `RepoInstallCmd.Run` (`src/go/internal/cli/cmd_repo_install.go`, lines ~107–115) does:
+
+```go
+repoRoot := inv.HubPath
+if repoRoot == "" {
+    root, gerr := gitRepoRoot(ctx)
+    ...
+}
+```
+
+`inv.HubPath` is populated by `main.go`'s `discoverHub()`, which walks **upward from cwd looking for any `.cn/` directory**, with no bound at the current git repository's root and no verification that the found directory is even a git repository. Because `RepoInstallCmd.Spec().NeedsHub == false`, `discoverHub()` still runs unconditionally before dispatch (per `main.go`'s existing, unconditional call to `discoverHub()`).
+
+If `inv.HubPath` comes back non-empty (an ancestor `.cn/` exists anywhere above cwd, for any reason — an unrelated project, a stale hub, a parent workspace), `cmd_repo_install.go` **skips `gitRepoRoot` entirely** and installs into that ancestor directory, without ever checking that cwd (or the ancestor) is a git repository at all.
+
+This directly contradicts the issue's own Mock A1 / AC1 text: *"Fails with a clear error if not at a git repo root (does not silently walk up or scaffold)."* The mock_parity block in `self-coherence.md` marks A1 as `match`, citing `TestRepoInstall_NotAGitRepo_FailsClearly` as evidence — but that test constructs `Invocation{HubPath: ""}` directly (see `runRepoInstall` test helper, `cmd_repo_install_test.go` line ~91), bypassing `main.go`'s real `discoverHub()` entirely. **No test in the diff exercises the `inv.HubPath != ""` branch at all.** The AC1 "match" claim is true only for the code path the tests happen to hit, not for the actual production dispatch path.
+
+**Reproduction (against the built binary, this branch, HEAD `226181f4`):**
+
+```
+mkdir -p /tmp/repro/outer-hub/nested/not-a-git-repo
+mkdir /tmp/repro/outer-hub/.cn                    # unrelated ancestor "hub"
+cd /tmp/repro/outer-hub/nested/not-a-git-repo      # NOT a git repo at all
+git rev-parse --show-toplevel                      # fatal: not a git repository...
+./cn repo install --dry-run
+```
+
+Output:
+```
+→ cn repo install (dry-run) — no files will be written
+✓ Git repository root: /tmp/repro/outer-hub
+✓ Resolved cnos release: 3.82.1
+✗ package(s) not found in index: cnos.core@3.82.1, ...
+```
+
+Exit code 0 up through the (unrelated) index-resolution failure — i.e., the command proceeds past the git-repo check entirely, silently treating `/tmp/repro/outer-hub` (never verified to be a git repository) as the install root. With a real reachable index, this would write `.cn/deps.json`, `.cn/deps.lock.json`, `.cn/vendor/`, and mutate `.gitignore` under `/tmp/repro/outer-hub` — not under the directory the operator is actually standing in, and not gated by any git-repo-root check at all.
+
+This is a materially different risk class from existing `NeedsHub: true` commands' use of the same `discoverHub()` walk: for those commands, `.cn/` was created by `cn init`/`cn setup` *at* the git root the operator is already working in, so the walk-up target and the git root coincide by construction. `cn repo install`'s entire premise is running in a repo that has *no* `.cn/` yet — exactly the scenario where an unrelated ancestor `.cn/` (a different project, a parent workspace, a monorepo-of-repos layout) can exist and silently hijack the install root.
+
+**What would fix it:** `RepoInstallCmd.Run` should always resolve the repo root via `gitRepoRoot(ctx)` (git's own `rev-parse --show-toplevel`), independent of `inv.HubPath`. `inv.HubPath` may still be consulted as an idempotent-rerun optimization, but only after confirming it equals the git-root value — never as a substitute for the git-repo check. The existing negative test (`TestRepoInstall_NotAGitRepo_FailsClearly`) should also be extended (or a new test added) that goes through `main.go`'s actual `discoverHub()` path (or an equivalent harness that doesn't hand-construct `Invocation{HubPath: ""}`), so this class of drift is caught by CI rather than requiring a manual binary repro.
+
+### Non-blocking observations (α already disclosed most of these; independently reviewed and agreed non-blocking)
+
+1. Design doc's Mock B table header reads "Invariants B1–B3" but lists four rows (B1–B4) — a pre-existing inconsistency in the verbatim-landed source file, correctly not silently "fixed" by α and correctly disclosed. Non-blocking.
+2. γ's scaffold miscounted "9 rows total" when the named set (A1–A5, B1–B4, E1) is actually 10 — α used the correct 10-row set and flagged the arithmetic error rather than silently dropping a row. Non-blocking, correctly handled.
+3. `cn --version` referenced in the new install doc currently exits non-zero — pre-existing, out of scope for #608 (Mock F1, later sub), correctly disclosed rather than silently reproduced without comment. Non-blocking.
+4. `--index <URL>` + explicit `--release <tag>` combination has no dedicated test (only each sub-case individually) — low risk, same code path either way, correctly disclosed as narrow test-coverage debt. Non-blocking.
+5. `checkSmallChangeArtifacts`'s hard-fail-vs-warn asymmetry between small-change and triadic in-progress artifacts (CI tooling friction, not this cycle's diff) — correctly surfaced as a γ/δ tooling observation, not self-triaged. Non-blocking for this cycle.
+6. No lockfile-level concurrency guard for simultaneous `cn repo install` runs — inherited from `restore.Restore`'s pre-existing lack of a lock primitive, not new. Non-blocking.
+
+## Verdict rationale
+
+Build/vet/test are clean from a fresh checkout; the seven implementation-contract axes all hold; ten of eleven ACs are independently confirmed against the actual code (not the self-coherence report). AC1's negative case, however, fails at the real dispatch boundary in a way the shipped test suite cannot detect (the test harness bypasses `main.go`'s hub-discovery walk entirely) — I reproduced this independently against the built binary. Per Role Rule 6 ("anchor oracle evidence on code, not doc" — extended here to "not a test that stubs around the real dispatch path") and Role Rule 4 ("do not merge with unresolved findings"), this is an iterate-triggering finding: it is squarely inside AC1's own explicit negative-case text, it is silent (exit 0, no error) and reproducible, and it can cause `cn repo install` to write into a directory other than the one the operator invoked it in.
+
+**Iterate.** α should fix `cmd_repo_install.go`'s repo-root resolution to always verify the actual git root (not trust an unbounded ancestor `.cn/` walk) and add a test that exercises the real `main.go`-equivalent dispatch path for this case. Once that lands, re-review should be a narrow re-check of AC1 plus a regression pass on AC2–AC11 (none of which are expected to be affected by this fix).

--- a/.cdd/unreleased/608/gamma-closeout.md
+++ b/.cdd/unreleased/608/gamma-closeout.md
@@ -1,0 +1,77 @@
+# γ close-out — cycle #608
+
+**Scope of this artifact.** This is γ's process-gap-audit retrospective at the β-converge boundary of the wake-invoked routing sequence (`delta/SKILL.md` §9.3 step 5 — δ dispatches γ once more after β's `verdict: converge` lands). It is written and pushed to `origin/cycle/608` **before** the cycle-PR is opened / merged; issue #608 is correctly still `OPEN` at this point (confirmed: `gh issue view 608 --json state` → `OPEN`). It is **not** the full `gamma/SKILL.md` §2.10 release-time closure declaration — `RELEASE.md` authorship, the `.cdd/unreleased/608/` → `.cdd/releases/{X.Y.Z}/608/` move, remote-branch deletion, hub-memory update, and the issue-close-state assertion all happen at actual release/merge time, which has not occurred yet. See §Triage carryforward below for what a later γ invocation (post-merge) still owes.
+
+---
+
+## Cycle summary
+
+**Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — "cds-install Sub 1 (Cn=1 / PR 1): implement `cn repo install` — base installer (dispatch none)". Sub 1 of the wave tracked at #607 (first-class CDS repo installer); PR2 (#609, renderer generalization), PR3 (#610, dispatch install), PR4 (#611, bootstrap delegation) remain out of scope and undispatched.
+
+**What shipped:**
+- A new kernel command, `cn repo install`, registered via the existing noun-verb resolver (`RepoInstallCmd`, `Spec().Name == "repo-install"`, `Source: SourceKernel`, `NeedsHub: false`) — runs in a plain `git init`-only repo before any `.cn/` hub exists.
+- `internal/repoinstall/` (new package) + `internal/cli/cmd_repo_install.go` (thin dispatch wrapper), reusing `internal/restore`'s existing `GenerateLockFromIndex`/`Restore` directly (zero reimplementation of lock generation, SHA-256 verification, or tar extraction).
+- Deterministic `.cn/deps.json` (`cn.deps.v1`) + `.cn/deps.lock.json` (`cn.lock.v2`, SHA-256-pinned, exact versions) + name-based `.cn/vendor/packages/<name>/` restore for the default triple (`cnos.core`, `cnos.cdd`, `cnos.cds`).
+- `--release latest|<tag>`, `--index <path-or-url>`, `--dry-run`; idempotent reruns; a hard dispatch guard (`--dispatch cds` fails explicitly, writes nothing, until #609 lands); no agent-hub scaffold (no `spec/SOUL.md`/`agent/`/`threads/`/`state/`, cnos#606 C4); no `.github/workflows/` touch in base mode.
+- `docs/development/design/cn-repo-install-MOCKS.md` landed verbatim from the operator-reviewed design branch (`claude/cds-install-guide-2ka54j`), and `docs/guides/INSTALL-CDS.md` rewritten so `cn repo install` is the canonical Layer-1 path.
+- All AC1–AC11 closed with PASS-backed evidence; `mock_parity` block 10/10 matched (A1–A5, B1–B4, E1), 0 missed, 0 exceeded.
+
+**Review arc:** R0 (`iterate`) → R1 fix → R1 re-review (`converge`). One blocking finding total across the whole cycle (β R0 Finding 1); the rest of both review rounds is confirmation, not correction. CI green at every reviewed HEAD; final head `7bb75914` (β R1 converge) — `Build` conclusion `success`.
+
+---
+
+## Process-gap audit
+
+### The R0 → iterate → R1 → converge loop
+
+β's R0 blocking finding: `RepoInstallCmd.Run` used `inv.HubPath` (populated by `main.go`'s unbounded upward `discoverHub()` walk, with no verification the found directory is even a git repository) as the install root whenever non-empty — silently bypassing `gitRepoRoot` and installing into an unrelated ancestor `.cn/` directory even when cwd was not inside any git repository at all. This directly contradicted AC1's own text: *"Fails with a clear error if not at a git repo root (does not silently walk up or scaffold)."* β reproduced it against the built binary, not against the test suite or the self-coherence report.
+
+**Is this a scaffold gap, review-loop-working-as-intended, or something else? Both of the first two, honestly — not either/or:**
+
+1. **It is a real, specific scaffold gap.** γ's own scaffold (`.cdd/unreleased/608/gamma-scaffold.md`) reproduced AC1's negative clause verbatim in its "Mock A" fallback table (`A1 | Fails with a clear error if not at a git repo root (does not silently walk up or scaffold).`) — the exact language was already sitting in the document γ authored. But the same scaffold's "AC oracle approach" table, the section α was actually told to build tests against, gave AC1 a concrete check naming only the positive path ("assert exit 0 and the three-file diff exists"). The negative half of the AC's own text never got translated into a required concrete check. This is an internal inconsistency inside γ's own artifact, not something α or β introduced.
+2. **α's test design compounded it.** The negative test α wrote (`TestRepoInstall_NotAGitRepo_FailsClearly`) satisfied AC1's literal text via a hand-constructed `Invocation{HubPath: ""}` — bypassing `main.go`'s real `discoverHub()` walk entirely. A test that stubs around the exact boundary an invariant concerns will pass regardless of whether the boundary itself is correct.
+3. **The review loop caught it exactly as designed, at normal cost.** β's independent re-verification discipline (`beta/SKILL.md` Role Rule 6 — anchor oracle evidence on code, not on a report; build the real binary, don't trust the test suite's framing) is precisely the safety net that exists for this class of gap: a test that satisfies the letter of an AC while missing its substance. One round (R0 → R1 → converge) is the designed cost of catching this kind of thing, not evidence of process failure. The fix itself was a net deletion of the buggy conditional (not new complexity), and β independently reverted it in an isolated worktree to confirm the new tests actually fail against the pre-fix code before converging — a level of rigor that closes the loop cleanly.
+
+**No formal `gamma/SKILL.md` §2.8 cycle-iteration trigger fired:** review rounds = 1 (not > 2); total findings across both rounds ≈ 7 (1 blocking + 6 non-blocking observations, below the mechanical-overload trigger's ≥10 floor and not majority-mechanical anyway); no avoidable tooling/environment failure (this was a substantive design/implementation bug, not a flake); `beta/SKILL.md`'s own loaded skill (Role Rule 6) is what caught the gap, so no loaded skill *failed* to prevent it on β's side.
+
+**§2.9 independent γ process-gap check — answer is yes, one concrete gap exists:** `gamma/SKILL.md`'s scaffold-authoring guidance (§2.5 Step 3b) names an "AC oracle approach" table as a required scaffold artifact but gives no rule for what happens when an AC's own text carries a negative/prohibition clause. That gap is real, generalizable beyond this cycle, and not something I am patching directly in this closeout — `gamma/SKILL.md` is canonical CDD doctrine and a same-session edit during closeout would ship an unreviewed change to every future cycle's scaffold convention. Instead: **filed [cnos#616](https://github.com/usurobor/cnos/issues/616)** (concrete next MCA — first action named: add a rule to §2.5 Step 3b requiring negative-invariant clauses to get their own concrete oracle check, with dispatch-boundary invariants requiring a built-binary/subprocess check rather than a hand-constructed harness).
+
+### γ's own arithmetic slip (self-critical accounting)
+
+γ's scaffold text claimed "9 rows total for this sub" while separately naming the row set as A1–A5, B1–B4, E1 — which sums to 10, not 9. α caught this, used the correct 10-row set, and flagged the discrepancy rather than silently dropping a row or silently correcting γ's prose. β independently confirmed the 10-row accounting was correct and the disposition non-blocking. Naming this here rather than omitting it: γ's own artifact had an arithmetic error in this cycle, caught downstream at no real cost (non-blocking, one sentence of disclosure in both `self-coherence.md` and `beta-review.md`), but it is the kind of small quality lapse worth being honest about in a retrospective that also just flagged a real oracle-precision gap in the same document.
+
+---
+
+## Follow-up issues
+
+Checked existing trackers before filing anything (`gh issue list --search`) to avoid duplicating what's already tracked:
+
+| α-disclosed debt item (`self-coherence.md` §Debt) | Disposition |
+|---|---|
+| 1. `cn --version` exits "Unknown command" — now actively referenced by the new `docs/guides/INSTALL-CDS.md` verification step | **Already tracked** — [cnos#612](https://github.com/usurobor/cnos/issues/612) AC1 targets exactly this. No new issue; added a cross-reference comment noting #608's docs now depend on it, raising urgency. |
+| 2. `cn cdd verify`'s `checkSmallChangeArtifacts` (`ledger.go` `forUnreleased=false`) hard-fails an in-progress small-change-classified `self-coherence.md`, unlike the triadic path's lenient warn — forced α to switch this cycle's section headers from `§`-prefixed to bare form mid-authorship | **Already tracked** — [cnos#577](https://github.com/usurobor/cnos/issues/577) (classifyCycleType misclassifies triadic cycles as small-change before `beta-review.md` lands). No new issue; added a cross-reference comment naming #608 as a second empirical occurrence. |
+| 3. `--index <URL>` + explicit `--release <tag>` combination untested | **Closed within the cycle** — `TestRun_IndexHTTPURL_WithExplicitReleaseTag` added in R1, closing β's R0 non-blocking observation 4. No issue needed. |
+| 4. `docs/guides/README.md` not updated with a nav link | **Not a gap** — the issue's own §Docs text explicitly defers this to #611 (bootstrap delegation). No issue needed. |
+| 5. No lockfile-level concurrency guard (simultaneous `cn repo install` invocations could race on `.cn/deps.json`/`.cn/deps.lock.json`/vendor-tree writes) | **Not filed.** Inherited from `internal/restore`'s pre-existing lack of any lock/mutex primitive — a whole-substrate architectural gap, not specific to #608, with no concrete evidence of an actual race (this is normally a single-operator, single-invocation onboarding command). Revisit if a real concurrent-invocation failure is ever reported; filing now would be speculative. |
+| 6. Windows is not a supported target | **Not filed.** A deliberate, pre-existing platform-scope boundary (`binupdate.go` already restricts platform binaries to linux/macOS) — not new debt from this cycle, and no product decision to add Windows support exists yet. Nothing actionable to file without that prior decision. |
+| 7. Transient CI red on `cdd-artifact-check` during incremental authoring | **Same root cause as item 2** — see #577 cross-reference above. |
+
+**New issue filed:** [cnos#616](https://github.com/usurobor/cnos/issues/616) — "cdd/gamma: scaffold AC-oracle-approach must propagate negative-invariant clauses with dispatch-boundary precision (cdd-protocol-gap, cycle #608)". This is the concrete next MCA for the process-gap audit's scaffold-gap finding above (labels: `P2`, `area/cdd`, `kind/skill`, `protocol:cdd`).
+
+**Total new issues this cycle: 1** (#616). Two candidate debts were already covered by existing open issues (#577, #612) and cross-referenced rather than duplicated; two were reasoned through and explicitly not filed (concurrency locking, Windows support); two were resolved or scoped-out within the cycle itself.
+
+---
+
+## Triage carryforward
+
+For the next reader (δ, or a resumed γ):
+
+1. **`alpha-closeout.md` and `beta-closeout.md` do not yet exist on `origin/cycle/608`.** Per `delta/SKILL.md` §9.3 step 5 and §9.5's converge-boundary artifact set, α and β each still owe their own closeout artifacts before the full converge boundary is complete. δ must dispatch both roles for their close-out prompts if not already in flight.
+2. **Full `gamma/SKILL.md` §2.10 closure has not run and should not run yet.** No `RELEASE.md`, no `.cdd/unreleased/608/` → `.cdd/releases/{X.Y.Z}/608/` move, no remote-branch deletion, no hub-memory update, no issue-close assertion. Issue #608 is correctly `OPEN`. These are release-time steps that belong to a later γ invocation once the cycle-PR is reviewed and actually merged to `main` (δ opens the cycle-PR and requests `status:review` per §9.6 after this closeout and α/β's closeouts are all present).
+3. **Parent wave #607** is unaffected by this cycle's completion — #609 (renderer generalization), #610 (dispatch install), #611 (bootstrap delegation) remain filing-only/operator-gated per the wave's own sequencing; nothing here changes that.
+4. **cnos#616** (new, filed this closeout) is a standalone `gamma/SKILL.md` doctrine patch, unassigned — whoever picks up the next CDD-tooling cycle should consider it alongside #577 (a related but distinct classifier gap) and #375 (the earlier rule-3.11b scaffold-gate precedent this issue's shape follows).
+5. **CI is green** at the converge HEAD `7bb7591461bdfbc30ee1291a192101336256bbc7` (`Build` → `success`, confirmed via `gh run list --branch cycle/608`).
+
+---
+
+**Cycle #608's γ process-gap audit is closed. Full cycle closure (release-time §2.10 checklist) is deferred to the merge/release step, not this converge-boundary invocation.**

--- a/.cdd/unreleased/608/gamma-closeout.md
+++ b/.cdd/unreleased/608/gamma-closeout.md
@@ -75,3 +75,20 @@ For the next reader (δ, or a resumed γ):
 ---
 
 **Cycle #608's γ process-gap audit is closed. Full cycle closure (release-time §2.10 checklist) is deferred to the merge/release step, not this converge-boundary invocation.**
+
+---
+
+## δ closeout-integrity preflight — deliverable_evidence
+
+Recorded by δ (cds-dispatch wake) before requesting `status:in-progress -> status:review`, per `cds-dispatch/SKILL.md` §"Closeout integrity preflight" (cnos#524):
+
+```yaml
+deliverable_evidence:
+  pr: "#617 (cycle/608 -> main)"
+  head_sha: "d66868317e92dfcb0e03333eb561e2b93faf230d"
+  base_sha: "c08a7483e57189760bcf5f7067904042f101bf61"
+  commits_beyond_base: 26
+  closeout_artifacts: [gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md, beta-closeout.md, gamma-closeout.md]
+```
+
+Head SHA verified via `git rev-parse origin/cycle/608` (the REVIEW-REQUEST.yml commit). All five deliverable-evidence conditions (PR exists and references #608; PR has commits beyond base; `cycle/608` exists and differs from base; all six required closeout artifacts present; this block names the PR number and commit SHA) are satisfied. `cn issues fsm evaluate --issue 608 --apply` applied `status:review` on this basis; see issue #608's δ return-token comment for the operator-facing record.

--- a/.cdd/unreleased/608/gamma-scaffold.md
+++ b/.cdd/unreleased/608/gamma-scaffold.md
@@ -1,0 +1,189 @@
+# γ scaffold — cycle #608
+
+**Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — "cds-install Sub 1 (Cn=1 / PR 1): implement `cn repo install` — base installer (dispatch none)"
+**Mode:** `design-and-build` (per the issue's own `**Mode:**` field, confirmed against the fetched issue body: `**Mode:** design-and-build`)
+**cell_kind:** `implementation` (per the issue's own `**cell_kind:**` field)
+**Parent:** #607 (wave master tracker — "first-class CDS repo installer"). Sub-issue sequence per #607's operator-enacted launch verdict: PR1 = #608 (this cycle, base installer) · PR2 = #609 (renderer generalization) · PR3 = #610 (dispatch install) · PR4 = #611 (bootstrap delegation). Only #608 is dispatched now; #609–#613 remain filing-only/operator-gated.
+**Base SHA:** `3dad64285026582a161549b8fd10108dd67a369e` (verified via `git fetch origin main && git rev-parse origin/main` at branch-creation time — this is later than the wake-invocation-time SHA `e49eaa1...`; other automation had pushed board-map commits in between. Pre-flight re-run against the live SHA, not the stale one.)
+**Branch:** `cycle/608`, created from `origin/main` at the base SHA above, pushed to `origin/cycle/608`.
+**Branch pre-flight (all confirmed before branch creation):** `origin/cycle/608` did not exist (`git ls-remote --heads origin cycle/608` empty) · no stalled `.cdd/unreleased/608/` beyond the dispatch-wake's `CLAIM-REQUEST.yml` marker (`git ls-tree -r --name-only origin/main -- .cdd/unreleased/608/` → exactly one file, the claim marker, which is expected and not stale cycle matter) · issue scope declared in the body · issue state `OPEN` (`gh issue view 608 --json state` → `OPEN`).
+
+---
+
+## CRITICAL — Design surface cited by the issue is not yet on `origin/main`
+
+The issue's own header cites: **"Design surface: `docs/development/design/cn-repo-install-MOCKS.md` (Mocks A, B, E1)."** I verified this path via `find`/`git log --all` and **it does not exist anywhere in `origin/main`'s history** (`git log --all --oneline -- '*cn-repo-install-MOCKS*'` on `origin/main` alone returns nothing).
+
+It **does** exist, however: parent issue #607's own Source-of-truth table names it as **"On branch `claude/cds-install-guide-2ka54j`"**. I fetched that branch (`git fetch origin claude/cds-install-guide-2ka54j`) and confirmed:
+- `git merge-base origin/main origin/claude/cds-install-guide-2ka54j` == `origin/main`'s current tip (`3dad6428...`) — i.e. that branch is a strict descendant of the current main tip, not a diverged fork. It is safe to pull the one file from it without any merge-conflict risk against this cycle's base.
+- The file exists there at `docs/development/design/cn-repo-install-MOCKS.md` (296 lines), status header: **"Design surface (pre-implementation). Author: kappa/operator review."** — i.e. already operator-reviewed/pinned content (#607's "Launch verdict (operator) — enacted" section references and pins the same command-name/lockfile decisions this file encodes), not a draft α needs to redesign from scratch.
+
+**α's obligation (part of this cycle's `design-and-build` design step):** land this file at the canonical path on `cycle/608`, e.g.:
+
+```
+git fetch origin claude/cds-install-guide-2ka54j
+git show origin/claude/cds-install-guide-2ka54j:docs/development/design/cn-repo-install-MOCKS.md \
+  > docs/development/design/cn-repo-install-MOCKS.md
+git add docs/development/design/cn-repo-install-MOCKS.md
+```
+
+Do **not** re-author it from prose memory — pull the exact reviewed content, then note in `self-coherence.md` that it was landed via this cycle's design step (design-and-build: "design needed before code; both happen in this cycle" — this satisfies that, since the design was already drafted and operator-reviewed elsewhere, this cycle is the one that makes it canonical on `main`'s lineage).
+
+The `claude/cds-install-guide-2ka54j` branch also carries `docs/guides/INSTALL-CDS.md` and `docs/guides/templates/cnos-install.yml` drafts, plus unrelated changes (deletions of already-released `.cdd/unreleased/{593,600}/` dirs, `.github/workflows/*` edits, `.cn-sigma/logs/*`) that are **not** part of #608's scope — those belong to later subs (#609–#611) or are stale housekeeping from whoever authored that branch. **α must cherry-pick only the specific design/docs files #608's own scope names** (the MOCKS.md file for the design surface; `INSTALL-CDS.md` per the issue's own §Docs section — but reconcile its content against #608's actual base-only scope, since the drafted doc may already describe dispatch/#609/#610 material that is out of scope here). Do not pull the whole branch or its unrelated files.
+
+I am not treating this as a dispatch-blocking ambiguity because: (a) the content is locatable, reviewed, and its exact retrieval command is now named here; (b) the mode is `design-and-build`, which explicitly allows/expects the design artifact to land within this same cycle; (c) the parent issue #607 already documents the branch/file relationship, so this is a findable fact, not an invented one. If α cannot retrieve the branch (e.g. it has been deleted or force-pushed away by the time α runs), α must STOP and escalate to γ/δ rather than inventing Mock A/B/E1 content from scratch — the exact invariant tables are reproduced below as a fallback so α is not blocked even if the branch becomes unreachable.
+
+### Fallback — Mocks A, B, E1 content (verbatim from the design branch, in case it becomes unreachable)
+
+**Mock A — human-deliverable invariants A1–A5** (`cn repo install --dry-run`, base mode):
+
+| ID | Invariant |
+|---|---|
+| A1 | Fails with a clear error if not at a git repo root (does not silently walk up or scaffold). |
+| A2 | Prints the exact release tag it will use; `--release latest` resolves to a concrete tag in the output. |
+| A3 | Lists the precise planned committed diff — and it is exactly `.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`. |
+| A4 | States dispatch mode explicitly and, in base mode, states no `.github/workflows/` change. |
+| A5 | Writes nothing (verified: `git status --porcelain` empty after `--dry-run`). |
+
+**Mock B — invariants B1–B4** (base-install committed diff):
+
+| ID | Invariant |
+|---|---|
+| B1 | Diff is exactly three files (`.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`); no `.github/workflows/` file present. |
+| B2 | `.cn/deps.lock.json` validates against `cn.lock.v2` and pins every package in `deps.json` by SHA-256. Versions are **exact** (resolved from the index), not semver ranges. |
+| B3 | **Idempotent**: a second `cn repo install` produces no further diff (`git status --porcelain` empty), with no formatting churn. |
+| B4 | **Dispatch guard**: until the renderer is generalized (#609), `cn repo install --dispatch cds` fails with an explicit "not implemented until renderer generalization lands" error and writes **no** partial `.github/workflows/cnos-cds-dispatch.yml`. |
+
+**Mock E1** (tenant-portability surface, base-install half only — E2–E4 belong to #609/#610):
+
+| ID | Invariant |
+|---|---|
+| E1 | `cn repo install` (base) writes **no** agent-hub scaffold — no `spec/SOUL.md`, `agent/`, `threads/`, `state/`; only `.cn/deps.json` + `.cn/deps.lock.json` + `.gitignore` (cnos#606 C4). |
+
+**Receipt parity contract shape** (from the design doc's own §"Receipt parity contract" — α's closeout MUST emit this block, per the issue's own "Parity requirement" section):
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-install-MOCKS.md
+  source_commit: "<sha of this file the cell built against>"
+  rows:
+    - id: A1   # one row per A1-A5, B1-B4, E1 (9 rows total for this sub)
+      expectation: "..."
+      observed: "<what the built command actually printed/did>"
+      evidence: "<test name / transcript path / commit>"
+      verdict: match | exceed | miss
+      how: "<why it matches; if exceed, why safe; if miss, gap + disposition>"
+  summary:
+    matched: <n>
+    exceeded: <n>
+    missed: 0          # MUST be 0 to converge
+    exceed_justified: <bool>
+```
+
+---
+
+## Surfaces α is expected to touch
+
+Concrete, grounded by direct reading (not asserted from the issue text alone):
+
+| Path | Current state | Expected role in this cycle |
+|---|---|---|
+| `src/go/internal/cli/cmd_repo_install.go` | **Does not exist.** | **New file.** Implements the `cn repo install` command. Per the CLI's own dispatch convention (see below), this should be a `RepoInstallCmd` type registered under `Spec().Name == "repo-install"` — noun-verb resolution (`cli.ResolveCommand` in `src/go/cmd/cn/main.go` builds the lookup key `args[0]+"-"+args[1]` = `"repo"+"-"+"install"` = `"repo-install"`), exactly the same pattern `cell-finalize`/`issues-fsm` already use for `cn cell finalize`/`cn issues fsm`. Confirmed by reading `src/go/internal/cli/dispatch.go` `ResolveCommand` (lines 42-88) and `src/go/internal/cli/cmd_cell.go` (`Name: "cell-finalize"`), `cmd_issues_fsm.go` (`Name: "issues-fsm"`). |
+| `src/go/cmd/cn/main.go` | Registers 14 kernel commands via `reg.Register(&cli.XCmd{})` (lines 29-49). | Add `reg.Register(&cli.RepoInstallCmd{})` alongside the existing registrations. No other change to `main.go`'s dispatch/help/hub-discovery logic is expected. |
+| `src/go/internal/restore/restore.go` | Existing, shipped. `GenerateLockFromIndex(hubPath, indexPath) (*LockResult, error)` (line 448) reads `.cn/deps.json`, resolves exact-match pins against a `PackageIndex`, writes `.cn/deps.lock.json` with `Schema: "cn.lock.v2"`, sorts deterministically. `Restore(ctx, hubPath, indexPath) ([]Result, error)` (line 118) does lockfile → index lookup → fetch (HTTP or local) → SHA-256 verify → tar extract → `cn.package.json` validate. **Reuse both directly — do not reimplement.** No change to this file is expected unless α finds a genuine gap (e.g. index normalization for relative-vs-absolute tarball URLs, per Implementation requirement 4) that must live here rather than in the new installer file. |
+| `src/go/internal/pkg/pkg.go` | Existing, shipped. `Manifest{Schema, Profile, Packages []ManifestDep}` (schema value `"cn.deps.v1"`, confirmed against Mock B's diff sample), `Lockfile{Schema, Packages []LockedDep}` (schema `"cn.lock.v2"`), `PackageIndex{Schema, Packages map[name]map[version]IndexEntry}` (schema `"cn.package-index.v1"`, confirmed in `pkg_test.go`). **Preserve these schemas exactly** — do not add fields or change shape. |
+| `src/go/internal/binupdate/binupdate.go` | Existing, shipped. `FetchLatestRelease(ctx, client, baseURL, repo) (*Release, error)` (line 221) calls `GET {baseURL}/repos/{repo}/releases/latest`. **Reuse candidate** for `--release latest` resolution (issue's Implementation requirement 4) rather than reimplementing a GitHub-releases-API client from scratch. α should assess whether to call this directly or extract a shared helper — either is acceptable, but do not hand-roll a second GitHub-API client. |
+| `docs/development/design/cn-repo-install-MOCKS.md` | **Does not exist on `origin/main`.** Exists (reviewed, "Enacted" per #607) on `origin/claude/cds-install-guide-2ka54j`. | **Land verbatim** (see CRITICAL section above) as this cycle's design artifact. |
+| `docs/guides/INSTALL-CDS.md` | Existing on `main` (pre-installer content) — check current content before editing; a draft also exists on the design branch. | Update per issue §Docs: canonical base path becomes `cn repo install`; keep the two-layer framing (Layer 1 package install / Layer 2 autonomous dispatch, opt-in). Reconcile against the design-branch draft but do not pull dispatch/#609/#610-scoped content prematurely. |
+| `.gitignore` (repo root, target repo being installed into — i.e. the *installed* repo's `.gitignore`, not cnos's own) | N/A — this is a runtime-written file in the *target* repo, not cnos's own `.gitignore`. cnos's own root `.gitignore` currently has no `.cn` entry (`grep -n '\.cn' .gitignore` → no hits) — irrelevant to this cycle except as a sanity check that cnos itself isn't accidentally the install target in a test. | The installer command must ensure the **target repo's** `.gitignore` contains `.cn/vendor/` (Mock A/B: exactly 3 committed files — `.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`). |
+| Test fixtures (new) | N/A | Unit + integration tests per issue §Tests: git-root detection, deterministic `.cn/deps.json` write, exact-version resolution from a fixture `index.json`, missing-package/missing-index errors, relative-tarball-URL normalization, HTTP-tarball-URL preservation, SHA-mismatch propagation, `--dry-run` no-write, idempotence, plus an integration test (temp git repo + fixture index/tarballs) and the dispatch-guard test (`--dispatch cds` fails explicitly, no partial workflow file). Follow existing test conventions in `src/go/internal/restore/restore_test.go` and `src/go/internal/cli/cmd_activate_test.go` / `registry_test.go` for fixture shape and `Invocation`-based command testing. |
+
+---
+
+## AC oracle approach
+
+| AC | Concrete check |
+|---|---|
+| **AC1** | `cn repo install` resolves via the kernel registry (`RepoInstallCmd`, `Spec().Name == "repo-install"`, `Source: SourceKernel`, `NeedsHub: false`) and runs successfully from a fresh `git init`-only repo with only `cn` on PATH — no `.cn/` hub, no vendor packages, no prior state. Oracle: integration test — temp dir, `git init`, install only the `cn` binary (build once), run `cn repo install --index <fixture>`, assert exit 0 and the three-file diff exists. |
+| **AC2** | `.cn/deps.json` byte-identical across two successive runs with the same inputs. Oracle: unit/integration test running the write twice, diffing bytes; also verify stable package ordering (sorted by name) and no timestamp field. |
+| **AC3** | `.cn/deps.lock.json` validates `Schema == "cn.lock.v2"`; every entry has exact `version` (not a range) and non-empty `sha256`. Oracle: parse the written lockfile with `pkg.ParseLockfile` (or equivalent) and assert schema + per-entry SHA-256 presence; reuse `GenerateLockFromIndex`'s existing determinism (sorted by name then version). |
+| **AC4** | `.cn/vendor/packages/cnos.core/cn.package.json`, `.../cnos.cdd/cn.package.json`, `.../cnos.cds/cn.package.json` all exist post-restore; checksums verified via `restore.Restore`'s existing SHA-256 verify step (not reimplemented). Oracle: integration test asserting file existence + a deliberately-corrupted fixture tarball produces a SHA-mismatch error (proves the existing verify path is actually wired, not bypassed). |
+| **AC5** | `cn repo install; git diff --exit-code; cn repo install; git diff --exit-code` — both exit 0. Oracle: shell/integration test exactly reproducing this sequence against a fixture index. |
+| **AC6** | `--dry-run`: `git status --porcelain` empty after; stdout lists exactly `.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore` as the planned diff (Mock A3/A5). Oracle: integration test capturing stdout + porcelain status. |
+| **AC7** | Three invocations tested independently: `--release latest` (resolves a concrete tag, e.g. via `binupdate.FetchLatestRelease` or equivalent), `--release <tag>` (pinned), `--index <path-or-url>` (fixture path and, if feasible, an `http://` fixture server). Oracle: one test per mode; `--release latest` test may need to stub/mock the GitHub API call rather than hitting it live in CI. |
+| **AC8** | `grep -RIl 'cnos-cds-dispatch' .github/workflows/` on the *target* test repo after a base install returns nothing; grep the installer's own source for any secret-name reference (`SIGMA_WORKFLOW_PAT`, `CNOS_WORKFLOW_PAT`, `CLAUDE_CODE_OAUTH_TOKEN`) outside the explicitly-out-of-scope `--dispatch cds` error-path string. Oracle: integration test asserting no `.github/workflows/` dir is created at all in base mode (default `--dispatch none`). |
+| **AC9** | `cn repo install --dispatch cds` exits non-zero with the exact error class named in the issue's §Tests ("Dispatch guard": `✗ --dispatch cds requires generalized wake renderer support (#609)` or equivalent clear message) and leaves zero `.github/workflows/` files behind. Oracle: integration test asserting exit code, stderr message content, and `git status --porcelain` shows no `.github/` changes. |
+| **AC10** | No `spec/SOUL.md`, `agent/`, `threads/`, `state/` directories created by `cn repo install` (contrast with `cn init`'s existing agent-hub scaffold — cnos#606 C4). Oracle: integration test asserting these paths do not exist post-install; explicit regression guard distinguishing installer behavior from `cn init`'s. |
+| **AC11** | `docs/guides/INSTALL-CDS.md` names `cn repo install` as the canonical base path. Oracle: grep/read the doc post-edit; no lingering "7 manual steps" framing presented as the only path. |
+
+---
+
+## Empirical anchor citations
+
+- **cnos#389** (Python-not-Go) / **cnos#391** (wrong package scoping + separate binary) / **cnos#392** (recovery — δ pinned the 7-axis contract ad hoc) / **cnos#393** (codification — the `## Implementation contract` block + δ-inward-membrane doctrine) — directly load-bearing for *this* cycle: the issue's own Implementation requirement 1 ("Kernel command, not a package command… registered in `cmd/cn/main.go`") is exactly the class of axis (CLI integration target, package scoping) that #389/#391 show α will improvise on if left unpinned. The 7-axis table in the α prompt below pins these explicitly so this cycle does not repeat that failure mode.
+- **cnos#606** (tenant dogfooding, C1–C7) — the direct customer-evidence source for this issue's C4 (agent-hub scaffold → AC10) and general onboarding-gap framing. Cited by the issue itself; not independently re-verified beyond reading #607's C1–C7 table.
+- **cnos#607** — parent wave tracker; source of the PR-sequencing verdict (base-first, dispatch-gated) and the design-branch pointer this scaffold resolves above.
+
+---
+
+## Expected diff scope (coarse — not line-by-line)
+
+- **New:** `src/go/internal/cli/cmd_repo_install.go` (the command implementation) + its `_test.go`.
+- **New:** possibly a small helper package if α judges the index-normalization / release-resolution logic (Implementation requirement 4) too large for the command file alone — acceptable, but must live under `src/go/internal/` following existing package-per-concern conventions (cf. `restore/`, `binupdate/`, `pkg/`, `hubsetup/`), not a new top-level directory.
+- **Modified:** `src/go/cmd/cn/main.go` — one new `reg.Register(&cli.RepoInstallCmd{})` line.
+- **New (landed this cycle, per CRITICAL section):** `docs/development/design/cn-repo-install-MOCKS.md`.
+- **Modified:** `docs/guides/INSTALL-CDS.md` per §Docs.
+- **New:** test fixtures (a small fixture `index.json` + fixture tarballs, or fixture HTTP server, for the integration tests) — likely under `src/go/internal/cli/testdata/` or `src/go/internal/restore/testdata/` following whatever convention `restore_test.go` already uses; check before inventing a new fixture location.
+- **No change expected:** `src/go/internal/restore/restore.go` internals (reused, not modified) unless a genuine gap surfaces in URL normalization; `src/go/internal/pkg/pkg.go` schemas (must not change shape); `cmd_init.go`, `cmd_setup.go`, `cmd_deps.go` (non-goal: must not alter `cn init`/`cn setup`/`cn deps` behavior); `.github/workflows/*` (base install must never touch this — a change here in the diff is itself a signal something has gone wrong, per AC8/AC9).
+
+---
+
+## Scope guardrails (restated by reference — see issue body for full text)
+
+- **Out of scope / non-goals** (issue's own §Non-goals): hosted registry design, full semver-range resolution, direct push to `main`, automatic autonomous dispatch, sigma-only assumptions, Claude-specific activation, agent-runtime impl, package-substrate redesign.
+- **Non-negotiable launch cut**: base install must not install the autonomous dispatch workflow under any code path reachable without `--dispatch cds`, and `--dispatch cds` itself must fail cleanly (not partially render) until #609 lands.
+- **Risk controls** (issue's own): don't commit tarball/generated cache into the target repo (only `.cn/deps.json` + `.cn/deps.lock.json` + `.gitignore` entry are committed; tarballs live in cache/tmp); don't duplicate `cn deps lock`/`restore` logic — reuse the internal functions directly.
+
+---
+
+## α prompt
+
+**Branch:** `cycle/608` (already created and pushed from `origin/main` at `3dad64285026582a161549b8fd10108dd67a369e`; switch to it, do not create a new branch.)
+
+**Task:** Implement `cn repo install` (base installer, dispatch none) per cnos#608. Before writing code: (1) land `docs/development/design/cn-repo-install-MOCKS.md` at the canonical path per this scaffold's CRITICAL section (pull from `origin/claude/cds-install-guide-2ka54j`, do not re-author); (2) re-read `src/go/internal/restore/restore.go` (`GenerateLockFromIndex`, `Restore`) and `src/go/internal/pkg/pkg.go` in full before writing any new code — these are reuse targets, not reference points to reimplement; (3) implement `src/go/internal/cli/cmd_repo_install.go` as a `RepoInstallCmd` registered under `Spec().Name == "repo-install"` (noun-verb resolution, matching the `cell-finalize`/`issues-fsm` pattern in `dispatch.go`/`cmd_cell.go`/`cmd_issues_fsm.go`), `NeedsHub: false`; (4) satisfy AC1–AC11 exactly per the oracle table above; (5) emit the `mock_parity` block (9 rows: A1–A5, B1–B4, E1) in the closeout per the design doc's own Receipt parity contract, `missed: 0`. If the design branch (`claude/cds-install-guide-2ka54j`) is unreachable, use the verbatim Mock A/B/E1 tables reproduced in this scaffold's fallback section instead of inventing content, and note the substitution in `self-coherence.md`.
+
+**## Implementation contract (pinned by δ; α MUST NOT improvise)**
+
+| Axis | Pinned value |
+|---|---|
+| Language | Go — matches the existing `cn` kernel (`src/go/...`); no other language is introduced. |
+| CLI integration target | `cn` subcommand — kernel command registered as `RepoInstallCmd` with `Spec().Name == "repo-install"`, `Source: SourceKernel`, `Tier: TierKernel`, `NeedsHub: false`. Invoked as `cn repo install` via the existing noun-verb resolver (`cli.ResolveCommand`, `args[0]+"-"+args[1]` lookup) — the same mechanism already used for `cn cell finalize` / `cn issues fsm`. Not a standalone binary, not a package-vendored command (it must run before any hub/package state exists). |
+| Package scoping | New file `src/go/internal/cli/cmd_repo_install.go` (+ `_test.go`), registered in `src/go/cmd/cn/main.go`. Reuses `src/go/internal/restore/` (`GenerateLockFromIndex`, `Restore`, `ReadPackageIndex`, `FindIndexPath`), `src/go/internal/pkg/` (Manifest/Lockfile/PackageIndex types), and `src/go/internal/binupdate/` (`FetchLatestRelease`, or an extracted equivalent) for release resolution. Any new helper package must live under `src/go/internal/` following the existing package-per-concern convention (cf. `restore/`, `binupdate/`, `pkg/`, `hubsetup/`) — no new top-level directory. |
+| Existing-binary disposition | Coexist — new primary command; no existing `cn repo install` to replace or deprecate. `cn init`, `cn setup`, `cn deps` remain byte-for-byte unchanged in behavior (non-goal; AC10 is the explicit regression guard distinguishing this installer from `cn init`'s agent-hub scaffold). |
+| Runtime dependencies | None beyond the existing Go toolchain and the standard library (`net/http` for index/tarball/release fetches, already used by `restore.go` and `binupdate.go`). No new external dependency (module) is introduced. |
+| JSON/wire contract preservation | Preserve exactly: `.cn/deps.json` schema `"cn.deps.v1"` (`pkg.Manifest`), `.cn/deps.lock.json` schema `"cn.lock.v2"` (`pkg.Lockfile`), package-index schema `"cn.package-index.v1"` (`pkg.PackageIndex`). No field additions, no shape changes. Vendored-package layout stays name-based: `.cn/vendor/packages/<name>/`, not `<name>@<version>/`. |
+| Backward-compat invariant | `cn init`, `cn setup`, `cn deps restore`, `cn deps lock` behavior is unchanged — no shared code path is modified in a way that alters their existing output or exit codes. New content (the installer command, its reused-function call sites, the design doc, the docs update) is strictly additive to the existing kernel surface. |
+
+---
+
+## β prompt
+
+**Branch:** `cycle/608`. **Oracle list:** AC1–AC11 exactly as stated in the issue body and expanded in this scaffold's "AC oracle approach" table above.
+
+Additional gates:
+- Standard `beta/SKILL.md` §"Pre-merge gate" (full row set — canonical-skill staleness re-check, merge-commit close-keyword check, etc.).
+- **Rule 7 (implementation-contract conformance)** is binding: verify the diff matches every pinned axis in the α prompt's `## Implementation contract` table above. In particular: `cn repo install` must resolve through the kernel registry as a genuine `cn` subcommand (not a separate binary, not shelling out to `cn` internally per Implementation requirement 5), must reuse `restore.Restore`/`GenerateLockFromIndex` rather than reimplementing lock/restore logic, and must not touch `.github/workflows/*` in base mode under any code path. A behaviorally-correct implementation that nonetheless ships as a separate binary, reimplements SHA-256 verification, or changes the `cn.lock.v2`/`cn.deps.v1`/package-index schema shape fails Rule 7 even if AC1–AC11's behavioral checks otherwise pass.
+- Confirm the `mock_parity` block exists in the closeout with exactly 9 rows (A1–A5, B1–B4, E1), `missed: 0`, and every `exceed` row (if any) carries a non-empty, safety-justified `how`.
+- Confirm `docs/development/design/cn-repo-install-MOCKS.md` was landed verbatim (or, if the source branch was unreachable, that α explicitly noted the fallback substitution in `self-coherence.md` rather than silently inventing content).
+- Confirm no `.github/workflows/*.yml` file appears in the diff at all (base install must never touch this surface — treat any appearance as a hard finding, not a judgment call).
+- Confirm AC9's dispatch-guard test actually exercises `--dispatch cds` and asserts both the explicit failure message and the absence of a partial `.github/workflows/cnos-cds-dispatch.yml` write.
+
+---
+
+## Friction notes (open questions for α/β — not resolved here, do not guess past them)
+
+1. **Design-branch reachability is the single largest risk to this scaffold's plan.** I verified `origin/claude/cds-install-guide-2ka54j` exists and is a clean descendant of the current `main` tip as of this scaffold's authoring time. If that branch is deleted, force-pushed, or otherwise unreachable by the time α runs, use the verbatim fallback tables above and flag the substitution — do not silently invent Mock content that looks similar but isn't the operator-reviewed original.
+2. **`docs/guides/INSTALL-CDS.md` on `main` today may already have a different/older shape** than the draft on the design branch — I did not diff the two in detail (only confirmed the design-branch draft is 256 lines of new/changed content per the `git diff --stat` I ran). α should read both and reconcile, keeping only the base-install-scoped material for this PR (the two-layer framing minus any #609/#610-specific dispatch-flag detail that oversteps this sub-issue's scope).
+3. **`--release latest` resolution mechanism is my inference, not a settled design decision.** I identified `binupdate.FetchLatestRelease` as a strong reuse candidate (same GitHub-releases-API shape this issue needs), but the issue does not name it explicitly. α may reuse it directly, extract a shared helper, or write a narrower purpose-built call — any of these satisfies the "Runtime dependencies: None new" contract row as long as no new external library is introduced. Do not treat "which exact function signature" as pinned; only the *behavior* (resolve latest release + its package index) is pinned by AC7.
+4. **Test-fixture location convention was not verified in depth** — I read `restore_test.go`'s existence but did not open it fully to confirm its exact fixture-directory convention. α should check `src/go/internal/restore/restore_test.go` and `src/go/internal/cli/cmd_activate_test.go` / `registry_test.go` before inventing a new fixture path.
+5. **The wave issue #607 lists #608 as "PR1, LAUNCHED"** and all other subs (#609–#613) as "filing-only" / operator-gated — this scaffold and the α/β prompts above are scoped strictly to #608. Do not begin any #609–#613-scoped work (renderer generalization, `--dispatch cds` actually rendering a workflow, bootstrap delegation, CLI ergonomics, PAT-free engine) even if it seems like an easy adjacent win — AC9 requires `--dispatch cds` to explicitly *fail*, not to work.

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,7 +1,7 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap, Skills, ACs]
+**completed:** [Gap, Skills, ACs, Self-check]
 
 ---
 
@@ -365,3 +365,110 @@ only path.
   stale cross-reference to reconcile; adding a new nav link there is outside
   this issue's named §Docs scope (only `docs/guides/INSTALL-CDS.md` is
   named).
+
+---
+
+## Self-check
+
+**Role self-check (alpha/SKILL.md §2.5 §Self-check): did this cycle's work
+push ambiguity onto β? Is every claim backed by evidence in the diff?**
+
+- Every AC above cites either an automated test (name + PASS, independently
+  re-run at HEAD to produce this section, not copy-pasted from an earlier
+  run) or a `grep`/`git diff`/manual-command result with the literal
+  command shown. No AC claim rests on unverified prose.
+- **Reuse audit (issue's own risk control 3: "don't duplicate `cn deps
+  lock`/`restore` logic"):** `internal/repoinstall` imports
+  `internal/restore` and calls `restore.GenerateLockFromIndex` and
+  `restore.Restore` directly — zero reimplementation of lockfile generation,
+  SHA-256 verification, or tar extraction. `grep -n "sha256\|Sum256"
+  src/go/internal/repoinstall/repoinstall.go` → zero hits (only the test
+  file, which builds fixture tarballs, imports `crypto/sha256`). Confirmed
+  by reading `restore.go` in full before writing any new code, per the
+  scaffold's own instruction.
+- **Peer enumeration (alpha/SKILL.md §2.3):** the "multiple writers of the
+  same schema" case applies to the `.gitignore` `.cn/vendor/` entry — `cn
+  setup` (`hubsetup.go`) already wrote it. Peer set = {`cn setup`, `cn repo
+  install`}. Resolved by exporting `hubsetup.EnsureGitignoreEntry` and
+  calling it from `repoinstall.applyInstall` rather than writing a second,
+  independent `.gitignore`-mutation function — one writer, two callers, not
+  two writers of the same invariant. No other multi-writer schema surface
+  was found: `.cn/deps.json`/`.cn/deps.lock.json` have exactly one writer
+  each in the whole kernel (`repoinstall.writeManifest` and
+  `restore.GenerateLockFromIndex` respectively — `cn setup` writes a
+  *different* default `deps.json` shape for its own `engineer` profile, at
+  a different call site, not a second writer of `cn repo install`'s `cds`
+  profile manifest).
+- **Harness audit (alpha/SKILL.md §2.4):** this cycle does not change any
+  parser, schema-bearing type, or manifest shape — `pkg.Manifest`,
+  `pkg.Lockfile`, `pkg.PackageIndex` are all read exactly as shipped, zero
+  field additions. The only new "producer" is `repoinstall.writeManifest`,
+  which serializes the existing `pkg.Manifest` type via
+  `json.MarshalIndent` — the same mechanism `restore.GenerateLockFromIndex`
+  already uses for `pkg.Lockfile`, so there is no new ad hoc encoder to
+  audit against a schema. Grepping `*.sh` and `.github/workflows/*.yml` for
+  `deps.json` literal writes turns up two **pre-existing** hand-rolled
+  `cn.deps.v1` writers: `.github/workflows/build.yml`'s Tier-2 CI test-hub
+  setup step (heredoc, `profile: "engineer"`, pins `cnos.core`/`cnos.kata`/
+  `cnos.cdd.kata` for CI's own package-testing purposes) and
+  `scripts/kata/06-install.sh` (same shape, kata-harness purposes). Neither
+  is a consumer of `cn repo install`/`cn setup`'s specific default-package
+  logic and neither needed a change here — the `cn.deps.v1` schema itself is
+  byte-for-byte unchanged by this cycle (no field added/removed/renamed), so
+  the harness-audit trigger condition (alpha/SKILL.md §2.4: "when the branch
+  changes a parser, schema-bearing type, manifest shape, or runtime
+  contract") does not fire. Noted here because an earlier draft of this
+  section claimed "no independent writers exist," which the grep above
+  disproves — corrected before this AC evidence was finalized, per the
+  intra-doc-repetition/closure-overclaim discipline (alpha/SKILL.md §2.3):
+  `pkg.Manifest` already has multiple legitimate writers today (`hubsetup`,
+  these two harnesses, and now `repoinstall`), each producing its own
+  package list for its own purpose; that plurality is pre-existing and
+  outside this cycle's scope to consolidate.
+- **Docs reconciliation:** the design-branch draft
+  (`origin/claude/cds-install-guide-2ka54j:docs/guides/INSTALL-CDS.md`) used
+  a stale `cn.lock` filename inconsistent with the actual shipped
+  `.cn/deps.lock.json` (`cn.lock.v2`) schema this cycle confirmed by reading
+  `restore.go` directly. Rather than land that inconsistency, the new
+  `docs/guides/INSTALL-CDS.md` in this cycle's diff uses the confirmed-real
+  path throughout, and drops the draft's Track-B (`workflow_dispatch`
+  GitHub-UI installer) section entirely, since `templates/cnos-install.yml`
+  and the installer workflow do not exist anywhere on `origin/main` (confirmed
+  via `find . -iname cnos-install.yml` → no hits) — that is #611's
+  (bootstrap delegation) scope, not #608's. Documenting a workflow file that
+  does not exist would have been a false claim.
+- **CI-schema harness (post-hoc finding, folded into this section rather
+  than treated as a separate late AC):** the `cn cdd verify` I6 gate (which
+  gates merges via `.github/workflows/build.yml`'s `cdd-artifact-check`
+  job) enforces bare `## Gap` / `## Skills` (or `## Mode`) / `## ACs` (or
+  `## AC Coverage`) / `## CDD Trace` / a `##`-line containing "self-check"
+  or "debt" section headers on `self-coherence.md` — not the `§`-prefixed
+  style (`## §Gap` etc.) this cycle initially used (and which a prior cycle,
+  #600, also used without ever actually satisfying the checker — #600's
+  mismatch was merely masked by its "triadic" classification's lenient
+  in-progress warning, not actually schema-conformant). Because cycle #608
+  is classified "small-change" by `classifyCycleType` (self-coherence.md
+  present, no `beta-review.md` yet — true for any α-authored cycle before β
+  responds) it hits `checkSmallChangeArtifacts`, which hardcodes
+  `forUnreleased=false`, turning the same header mismatch into a hard CI
+  failure rather than a warning. Fixed by switching this file's headers to
+  the bare form (commit `9fbd8fa1`) rather than requesting a
+  `.cdd/exceptions.yml` entry — the bare form is what a genuinely
+  fully-green historical cycle (#593) actually uses, so this is a
+  conformance fix, not a workaround. **Pattern observed, not
+  triaged/fixed at the tool level** (per alpha/SKILL.md §2.8 "voice: factual
+  observations only, triage is γ's job"): `checkSmallChangeArtifacts`'s
+  hardcoded `forUnreleased=false` (ledger.go line 497) appears to make it
+  structurally impossible for a small-change-classified, still-in-progress
+  self-coherence.md (i.e., any α authoring §2.5's incremental one-section-
+  per-commit sequence, on any cycle without a pre-existing beta-review.md)
+  to pass I6 mid-authorship even when using the *correct* bare header
+  convention throughout, since the same "missing sections" logic fires
+  hard-fail (not warn) until every required section exists in one commit.
+  This cycle's own commits before the final section landed are a live
+  example (`eb269381`, `a3f9b86e` both show `❌ Cycle artifact verification
+  FAILED` in Actions). This is surfaced as a pattern for γ/δ, not
+  self-triaged here.
+- No ambiguity was pushed onto β regarding the implementation-contract axes
+  (all 7 were pinned by γ at dispatch; none were relaxed or reinterpreted —
+  see §Skills above).

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,11 +1,11 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap, Skills]
+**completed:** [Gap, Skills, ACs]
 
 ---
 
-## §Gap
+## Gap
 
 **Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — "cds-install Sub 1 (Cn=1 / PR 1): implement `cn repo install` — base installer (dispatch none)"
 
@@ -70,7 +70,7 @@ disjoint from every path this cycle's diff touches.)
 
 ---
 
-## §Skills
+## Skills
 
 **Tier 1 (lifecycle):**
 - `CDD.md` — canonical lifecycle/role contract.
@@ -114,3 +114,254 @@ name-based; Backward-compat invariant: `cn init`/`setup`/`deps` behavior
 unchanged). No row was empty or TBD at dispatch time, so no γ/δ escalation
 was needed before coding. Every diff hunk in this cycle maps to one or more
 of these pinned rows — see §CDD Trace step 6 for the file-by-file mapping.
+
+---
+
+## ACs
+
+All commands below were run against branch HEAD at commit `a3f9b86e` (the
+implementation SHA is fixed at `d783ba38` — the last pure-implementation
+commit before the rebase and before this self-coherence artifact's own
+commits; SHA convention per alpha/SKILL.md §2.6 "SHA convention for
+readiness signal" — implementation SHA, not the advancing artifact-commit
+HEAD).
+
+### AC1 — kernel command, available from a fresh Git repo, no prior state
+
+**Claim:** `cn repo install` resolves via the kernel registry
+(`RepoInstallCmd`, `Spec().Name == "repo-install"`, `Source: SourceKernel`,
+`NeedsHub: false`) and runs from a fresh `git init`-only repo with no `.cn/`
+hub, no vendor packages, no prior state.
+
+**Evidence:**
+- `src/go/internal/cli/cmd_repo_install_test.go::TestRepoInstall_ResolvesViaNounVerb`
+  — asserts `ResolveCommand(reg, []string{"repo","install",...})` resolves to
+  `repo-install` with `Source: SourceKernel`, `Tier: TierKernel`,
+  `NeedsHub: false`. PASS.
+- `src/go/internal/cli/cmd_repo_install_test.go::TestRepoInstall_FreshGitRepo_EndToEnd`
+  — `git init` in a temp dir, `t.Chdir` into it, run `RepoInstallCmd.Run`
+  with a fixture `--index`; asserts `.cn/deps.json`, `.cn/deps.lock.json`,
+  `.gitignore`, and `.cn/vendor/packages/cnos.core/cn.package.json` all
+  exist afterward. PASS.
+- Manual smoke test (built binary, real `git init`, no `.cn/` present
+  beforehand): `cn help` lists `repo-install` in the kernel-commands section
+  before any hub exists; `cn repo` (bare noun) lists the `repo install`
+  subcommand via the noun-group printer, matching the `cell`/`issues`
+  pattern exactly. Transcript captured during authoring (not persisted as a
+  file — reproducible via the commands above).
+- AC1's "not a git repo" negative half is AC1 territory too (issue's own
+  Implementation requirement 2): see `TestRepoInstall_NotAGitRepo_FailsClearly`
+  (PASS) — exact message `✗ cn repo install must be run inside a Git
+  repository.`, no scaffolding.
+
+### AC2 — deterministic `.cn/deps.json`
+
+**Claim:** stable order, no timestamps, byte-identical across two runs.
+
+**Evidence:**
+- `src/go/internal/repoinstall/repoinstall_test.go::TestRun_Idempotent_ByteIdenticalArtifacts`
+  — runs `Run` twice against the same `RepoRoot` + fixture index, asserts
+  `bytes.Equal` on both `.cn/deps.json` and `.cn/deps.lock.json` reads. PASS.
+- `writeManifest` (`repoinstall.go`) uses `json.MarshalIndent` over a typed
+  `pkg.Manifest` struct (not a map) — field order is Go struct-tag order,
+  not map-iteration order; no field carries a timestamp (`pkg.Manifest` has
+  only `Schema`, `Profile`, `Packages`).
+- `TestRun_DefaultPackageSet_AllThreeRestored` additionally asserts manifest
+  package order matches `DefaultPackages`'s declared order (not resorted),
+  confirming "manifest order is operator-controlled" (restore.go's own
+  determinism doctrine) holds for the new writer too.
+
+### AC3 — deterministic `.cn/deps.lock.json` (`cn.lock.v2`, exact versions, SHA-256 pins)
+
+**Claim:** schema `cn.lock.v2`; every entry has an exact version + non-empty
+sha256.
+
+**Evidence:**
+- `TestRun_LocalIndex_EndToEnd` parses the written lockfile via
+  `pkg.ParseLockfile`, asserts `Schema == "cn.lock.v2"` and a non-empty
+  `SHA256` field. PASS.
+- The lockfile is written by `restore.GenerateLockFromIndex` — reused
+  directly, not reimplemented (see §Self-check "reuse audit" below); its
+  existing sort-by-name-then-version determinism is inherited for free.
+
+### AC4 — restores `cnos.core`/`cnos.cdd`/`cnos.cds` under name-based vendor paths; checksums verified
+
+**Claim:** `.cn/vendor/packages/<name>/cn.package.json` exists post-restore
+for all three default packages; the existing SHA-256 verify path is
+actually wired (not bypassed).
+
+**Evidence:**
+- `TestRun_DefaultPackageSet_AllThreeRestored` — installs the literal
+  default triple from a fixture index, asserts each of
+  `.cn/vendor/packages/{cnos.core,cnos.cdd,cnos.cds}/cn.package.json`
+  exists and validates via `pkg.ValidatePackageManifestData`. PASS.
+- `TestRun_SHAMismatchPropagates` — a deliberately-corrupted fixture (tarball
+  SHA-256 does not match the index's declared SHA-256) surfaces
+  `"sha256 mismatch"` on stderr and leaves no vendor directory behind. PASS.
+  This is the proof the verify step is actually wired: a bypassed/faked
+  verify would either not error, or would leave a partial vendor tree.
+- No new SHA-256 computation exists in `internal/repoinstall` — the package
+  imports neither `crypto/sha256` nor duplicates `fileSHA256`; verification
+  is 100% `restore.Restore`'s existing code path (confirmed by reading
+  `repoinstall.go`'s import list and grepping for `sha256` — zero hits
+  outside test fixture helpers, which build fixture tarballs, not verify
+  them).
+- Vendor path is name-based: `pkg.VendorPath(hubPath, name)` is unchanged
+  (`<hubPath>/.cn/vendor/packages/<name>`) — not modified by this cycle,
+  confirmed via `git diff` showing zero hunks in `pkg.go`'s `VendorPath`.
+
+### AC5 — idempotent (second run: no diff, no churn)
+
+**Claim:** `cn repo install; git diff --exit-code; cn repo install; git diff
+--exit-code` — both exit 0.
+
+**Evidence:**
+- `TestRepoInstall_Idempotent_NoDiffOnSecondRun` — runs the literal sequence
+  from the AC's own oracle text (`git diff --exit-code` after each of two
+  installs) via real `exec.Command("git", ...)` against a real
+  `git init`-created repo, **plus** the stronger form: `git add` + `git
+  commit` after the first install, then a second install, then asserts
+  `git status --porcelain` is empty. PASS. (The stronger form is the
+  meaningful proof — a bare `git diff --exit-code` before any `git add`
+  passes trivially on any first run since nothing is tracked yet; the
+  commit-then-rerun form is what actually exercises "no churn.")
+- `TestRun_Idempotent_ByteIdenticalArtifacts` (repoinstall-level) — see AC2.
+- No "already installed" special-casing was added; `Run` always regenerates
+  `.cn/deps.json`/`.cn/deps.lock.json` deterministically from the same
+  inputs, and `restore.Restore`'s existing version-match skip (restore.go
+  lines ~169-192) prevents vendor-tree rewrites when the installed version
+  already matches the lockfile pin. Idempotence is inherited from the reused
+  substrate, not reimplemented.
+
+### AC6 — `--dry-run` writes nothing; lists the planned diff
+
+**Claim:** `git status --porcelain` empty after; stdout lists exactly
+`.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`.
+
+**Evidence:**
+- `TestRun_DryRun_WritesNothing` (repoinstall) — asserts `os.ReadDir(RepoRoot)`
+  returns zero entries after a dry-run (i.e. not even a `.cn/` directory is
+  created), and stdout contains all three planned-diff filenames plus the
+  dispatch-mode statement. PASS.
+- `TestRepoInstall_DryRun_GitStatusStaysClean` (cli, real git repo) —
+  `git status --porcelain` is empty after `--dry-run`. PASS.
+- Code-level guarantee: `Run`'s dry-run branch (`repoinstall.go`, the
+  `if opts.DryRun` block) returns immediately after `printPlan`, before
+  `applyInstall` (which owns every `os.MkdirAll`/`os.WriteFile` call in the
+  non-test code path) is ever invoked.
+
+### AC7 — `--release latest`, `--release <tag>`, `--index <path-or-url>` all work
+
+**Claim:** all three resolution modes function independently.
+
+**Evidence:**
+- `TestRun_ReleaseLatest_ResolvesAndInstalls` — a fake GitHub API
+  (`httptest.Server`) answers `/repos/{repo}/releases/latest`; a fake
+  download server serves that tag's `index.json` (relative tarball URL,
+  exactly as `cn build`'s local index shape declares it) + the tarball at
+  the release-download path. Asserts `Result.ReleaseTag == "9.9.9"` and the
+  package is restored — which is only possible if the relative URL was
+  correctly rewritten to the release-download absolute URL (an
+  un-rewritten fetch would 404 against the download server, since
+  `restore.go`'s `fetchTarball` resolves local-looking URLs relative to
+  the *local temp cache dir*, not the origin server). PASS.
+- `TestRun_ReleaseTag_Pinned` — same shape with an explicit tag; the "latest"
+  API endpoint is deliberately not wired to a distinct/reachable path,
+  proving the pinned-tag path skips latest-resolution entirely (if it had
+  called `FetchLatestRelease` regardless, the fetch would fail against the
+  unregistered path). PASS.
+- `TestRun_LocalIndex_EndToEnd` / `TestRepoInstall_FreshGitRepo_EndToEnd` —
+  `--index <local path>`. PASS.
+- `TestRun_IndexHTTPURL_RelativeRewrite` — `--index <http URL>`, relative
+  tarball URL rewritten against the URL's own directory. PASS.
+- Note: `--release latest`'s live-network path (a real call to
+  `api.github.com`) is intentionally NOT exercised in CI — only the
+  `httptest`-stubbed form is, matching the scaffold's own guidance
+  ("`--release latest` test may need to stub/mock the GitHub API call
+  rather than hitting it live in CI"). This is a deliberate test-design
+  choice, not a gap: `binupdate.FetchLatestRelease` (the function this
+  cycle reuses) already has its own live-shape unit test coverage in
+  `internal/binupdate/binupdate_test.go` from prior cycles.
+
+### AC8 — base mode never writes `.github/workflows/`, never requires a secret
+
+**Claim:** no `.github/workflows/cnos-cds-dispatch.yml`; no
+`SIGMA_WORKFLOW_PAT`/`CNOS_WORKFLOW_PAT`/`CLAUDE_CODE_OAUTH_TOKEN` reference
+outside the dispatch-guard error string (which doesn't reference any of
+these anyway).
+
+**Evidence:**
+- `grep -n "SIGMA_WORKFLOW_PAT\|CNOS_WORKFLOW_PAT\|CLAUDE_CODE_OAUTH_TOKEN" src/go/internal/repoinstall/repoinstall.go src/go/internal/cli/cmd_repo_install.go`
+  → zero matches (run at HEAD `d783ba38`, confirmed unchanged through the
+  rebase since neither file was touched by the intervening `origin/main`
+  commits).
+- `grep -n "\.github/workflows" src/go/internal/repoinstall/repoinstall.go src/go/internal/cli/cmd_repo_install.go`
+  → the only three hits are prose/stdout strings stating that nothing is
+  written there (`"Dispatch: none (base install only — no
+  .github/workflows/ changes)"`, help text, package doc comment) — no code
+  path constructs a path under `.github/workflows/` or calls `os.WriteFile`
+  /`os.MkdirAll` against one.
+- `TestRun_LocalIndex_EndToEnd` and `TestRepoInstall_FreshGitRepo_EndToEnd`
+  both assert `os.Stat(filepath.Join(repoRoot, ".github"))` is
+  `os.IsNotExist` after a full base install. PASS.
+
+### AC9 — `--dispatch cds` fails explicitly, no partial `.github/workflows/` write
+
+**Claim:** exits non-zero with a clear message; leaves zero
+`.github/workflows/` files behind.
+
+**Evidence:**
+- `TestRun_DispatchCds_FailsWithNoPartialWrite` (repoinstall) — asserts the
+  error contains `"#609"`, stderr carries the **exact** string
+  `"✗ --dispatch cds requires generalized wake renderer support (#609)"`,
+  `os.ReadDir(RepoRoot)` is empty (zero files/dirs written at all, not just
+  no `.github/`), and `.github/workflows/cnos-cds-dispatch.yml` specifically
+  does not exist. PASS.
+- `TestRepoInstall_DispatchCds_CliWiring` (cli, full wiring through
+  `RepoInstallCmd.Run`) — same assertions via the real command dispatch
+  path. PASS.
+- Code-level guarantee: `validateDispatch` is the first call in `Run`,
+  before repo-root validation, before index resolution, before any
+  `os.MkdirAll`/`os.WriteFile`. A `cds` value returns an error immediately;
+  no subsequent code in `Run` executes.
+
+### AC10 — no agent-hub scaffold (no `spec/SOUL.md`, `agent/`, `threads/`, `state/`)
+
+**Claim:** regression guard distinguishing this installer from `cn init`'s
+agent-hub scaffold (cnos#606 C4).
+
+**Evidence:**
+- `TestRun_LocalIndex_EndToEnd` and `TestRepoInstall_NoAgentHubScaffold` both
+  assert `spec/SOUL.md`, `agent`, `threads`, `state` do not exist under
+  `RepoRoot` after a full install. PASS.
+- Code-level: `internal/repoinstall` does not import `internal/hubinit`
+  (the package `cn init` uses for agent-hub scaffolding) at all — confirmed
+  by reading `repoinstall.go`'s import block. The only cross-package reuse
+  is `internal/hubsetup` (for the single `.gitignore`-entry helper),
+  `internal/pkg`, `internal/restore`, `internal/binupdate`.
+
+### AC11 — docs updated so the canonical base path is `cn repo install`
+
+**Claim:** `docs/guides/INSTALL-CDS.md` names `cn repo install` as the
+canonical base path; no lingering "7 manual steps" framing presented as the
+only path.
+
+**Evidence:**
+- `docs/guides/INSTALL-CDS.md` (new file — did not exist on `origin/main`
+  before this cycle) opens with the one-command flow
+  (`curl ... | sh` then `cn repo install`) as "the canonical way to install
+  Layer 1," under a two-layer framing (Layer 1 base / Layer 2 autonomous
+  dispatch, opt-in) matching the issue's own §Docs requirement.
+  `grep -c "cn repo install" docs/guides/INSTALL-CDS.md` → 17 occurrences,
+  all consistent with the one-command path being canonical; zero
+  occurrences of "7 manual steps" or "7 steps" framing.
+- The design-branch draft's stale `cn.lock` filename (inconsistent with the
+  actual shipped `.cn/deps.lock.json` / `cn.lock.v2` schema this cycle
+  confirmed against `restore.go`) was corrected, not carried forward — see
+  §Self-check "docs reconciliation" below.
+- `docs/guides/README.md` was deliberately NOT modified — it carries no
+  existing reference to `INSTALL-CDS.md` or the old manual-install path
+  (`grep -n "INSTALL-CDS" docs/guides/README.md` → no hits), so there is no
+  stale cross-reference to reconcile; adding a new nav link there is outside
+  this issue's named §Docs scope (only `docs/guides/INSTALL-CDS.md` is
+  named).

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -841,3 +841,234 @@ Requesting β review on `cycle/608` at implementation SHA
 signal time). β should poll `origin/cycle/608` and
 `.cdd/unreleased/608/beta-review.md` per the standard coordination
 protocol.
+
+---
+
+## R1 — fix β's R0 blocking finding (AC1 silent ancestor-`.cn` walk-up)
+
+**Trigger:** `.cdd/unreleased/608/beta-review.md` (R0, verdict `iterate`),
+Finding 1 (BLOCKING): `RepoInstallCmd.Run` used `inv.HubPath` as the
+install root whenever non-empty, completely bypassing `gitRepoRoot`. β
+reproduced this against the built binary: an unrelated ancestor `.cn/`
+directory (found by `main.go`'s unbounded upward `discoverHub()` walk)
+was silently treated as the install root even when cwd was not inside
+any git repository at all — violating AC1's own text ("does not
+silently walk up or scaffold"). β also found that no test in the R0 diff
+exercised the `inv.HubPath != ""` branch: the existing negative test
+(`TestRepoInstall_NotAGitRepo_FailsClearly`) hand-constructs
+`Invocation{HubPath: ""}`, bypassing `main.go`'s real hub-discovery path
+entirely.
+
+### What changed
+
+`src/go/internal/cli/cmd_repo_install.go`, `RepoInstallCmd.Run`
+(commit `aef74f3e103d747069abb083e75c82acb8bcca54`, pre-rebase content
+identical): repo-root resolution no longer reads `inv.HubPath` at all.
+It now unconditionally calls `gitRepoRoot(ctx)` (the existing
+`git rev-parse --show-toplevel` wrapper already used by
+`cmd_cell.go`/`CellFinalizeCmd`) and fails with the exact AC1 message
+
+```
+✗ cn repo install must be run inside a Git repository.
+```
+
+whenever that call errors — regardless of what `main.go`'s
+`discoverHub()` found. `inv.HubPath` is no longer read anywhere in this
+file; the "not inside a git repository" failure is now unconditional,
+not only reachable when `inv.HubPath` happened to be empty.
+
+**Why this is the right fix, not a narrower patch:** the alternative β
+raised as acceptable ("consult `inv.HubPath` only after confirming it
+equals the git-root value") was considered and rejected as unnecessary
+complexity — `gitRepoRoot(ctx)` is cheap (one `git rev-parse` subprocess
+call, already paid on every no-hub invocation in the pre-fix code path
+too), and there is no case where trusting a pre-computed `inv.HubPath`
+instead of asking git directly saves anything but adds a
+second code path to keep in sync. Always resolving via git directly is
+strictly simpler and closes the entire bug class, not just β's specific
+repro shape.
+
+### New tests
+
+Two tests added to `src/go/internal/cli/cmd_repo_install_test.go` that
+build the actual `cn` binary (`go build -o <tmp>/cn ./cmd/cn` from the
+module root, mirroring the existing `(cd src/go && go build -o $CN_BIN
+./cmd/cn)` convention used by the shell test harnesses under
+`src/packages/cnos.cdd/commands/cdd-verify/`) and drive it as a
+subprocess — exercising `main.go`'s real `discoverHub()`, not a
+reimplementation of it, closing exactly the gap β named:
+
+- `TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly` —
+  cwd is not inside any git repository; an unrelated ancestor `.cn/`
+  exists above it (this is β's exact repro shape). Asserts: exit
+  non-zero, stderr contains the exact AC1 message, and the ancestor
+  `.cn/` directory is completely untouched (zero entries written).
+- `TestRepoInstall_RealDispatch_AncestorHubWithNestedGitRepo_UsesInnerRoot`
+  — a stronger control case: the ancestor `.cn/` exists, and cwd is
+  itself inside its *own*, different git repository nested further down
+  (a monorepo-of-repos shape). `discoverHub()` still finds the
+  unrelated ancestor `.cn/` first and returns it as `inv.HubPath`; this
+  proves the fix does not merely add an error path but actually
+  resolves the *correct* root (the inner repo, not the ancestor) even
+  when `inv.HubPath` is non-empty and points elsewhere. Asserts:
+  install succeeds, `.cn/deps.json` is written under the *inner* repo
+  root (not the ancestor), stdout reports the inner repo as the
+  resolved git root, and the ancestor `.cn/` remains empty.
+
+**Verified these tests actually catch the bug (not tautological):**
+ran both against the pre-fix code (`git stash` of the one-line
+`cmd_repo_install.go` fix only, tests still applied) —
+
+```
+--- FAIL: TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly
+    stderr = "✗ package(s) not found in index: cnos.core@3.82.1, ..."
+    (proceeded past the git-repo check entirely, using the ancestor as
+    root, and failed only on release-index resolution — exactly β's
+    reported shape)
+--- FAIL: TestRepoInstall_RealDispatch_AncestorHubWithNestedGitRepo_UsesInnerRoot
+    stdout reports "Git repository root: .../outer/" (the ancestor),
+    .cn/deps.json is written under the ancestor .cn/, not the inner
+    repo — a silent wrong-directory install, exit 0
+```
+
+then re-ran against the fix: both PASS. This is the same class of
+independent-reproduction discipline β applied at R0 (build the real
+binary, don't trust the test-suite framing alone).
+
+Also added (per γ/β's non-blocking, quick-to-close item): a third test
+in `src/go/internal/repoinstall/repoinstall_test.go`,
+`TestRun_IndexHTTPURL_WithExplicitReleaseTag`, covering the previously
+untested `--index <URL>` + explicit `--release <tag>` combination (β's
+review, non-blocking observation 4). Confirms `resolveIndex`'s
+`isRemoteURL(indexArg)` branch and a non-empty `pinFromRelease` compose
+correctly (same code path as each sub-case, now proven jointly).
+
+### AC re-verification (full pass, focus on AC1)
+
+- **AC1** — re-verified end-to-end against the *built binary* using β's
+  own repro commands verbatim (`mkdir -p
+  /tmp/repro/outer-hub/nested/not-a-git-repo`, `mkdir
+  /tmp/repro/outer-hub/.cn`, `cd .../not-a-git-repo`, `./cn repo install
+  --dry-run`). Result: `✗ cn repo install must be run inside a Git
+  repository.`, exit code 1, and `/tmp/repro/outer-hub/.cn` remains
+  empty (`ls -la` → only `.`/`..`). This is the exact scenario β
+  reported previously succeeding silently (dry-run proceeding past the
+  git-repo check into release/index resolution) — it now fails at the
+  git-repo check, first, unconditionally. The "fresh git repo, no prior
+  state" positive half of AC1 (unaffected by this fix — `gitRepoRoot`
+  was already the fallback path exercised there) re-verified still
+  passes via `TestRepoInstall_FreshGitRepo_EndToEnd`.
+- **AC2–AC11** — no code path other than repo-root resolution changed;
+  re-ran the full existing suite (all AC2–AC11 tests named in R0's
+  §ACs section) and all pass unchanged. See test counts below.
+
+### Full re-verification (all four gates β/α run this cycle)
+
+Run from `src/go/` after the fix, from a clean tree, at commit
+`aef74f3e103d747069abb083e75c82acb8bcca54` (pre-rebase) / current HEAD
+(post-rebase, see rebase note below — content identical, only ancestry
+changed):
+
+- `go build ./...` — clean, exit 0.
+- `go vet ./...` — clean, exit 0.
+- `go test ./...` — **307 tests pass, 0 fail** (`go test ./... -v |
+  grep -c '^--- PASS'` → 307; `grep -c '^--- FAIL'` → 0). R0's count was
+  304; +3 new tests this round (2 real-dispatch-path tests +1
+  flag-combination test), all passing.
+- `go test -race -count=1 ./...` — clean, all 15 packages pass, no race
+  reports.
+
+No regression in any previously-passing package (`internal/cell`,
+`internal/repoinstall`, `internal/cli`, `internal/restore`,
+`internal/pkg`, etc. — full list unchanged from R0's pass, all still
+green).
+
+### Rebase note (pre-review-gate row 1)
+
+Between R0's review-readiness signal and this round, `origin/main`
+advanced by two unrelated commits (`d6bc7c70`, `c08a7483` — both sigma
+agent-admin heartbeat log appends to `.cn-sigma/logs/20260706.md`; zero
+overlap with this cycle's diff). Per alpha/SKILL.md §2.6 row 1, I
+rebased `cycle/608` onto the new `origin/main` tip
+(`c08a7483e57189760bcf5f7067904042f101bf61`) and force-pushed with
+`--force-with-lease`. This was a clean rebase (no conflicts, no content
+changes to any commit) but it rewrote every commit's SHA on the branch,
+including β's own R0 review commit and every SHA α cited in this file's
+R0 sections above. Mapping for reproducibility (rule 3.13(a)):
+
+| Pre-rebase SHA (cited above in R0 sections) | Post-rebase SHA (same content) |
+|---|---|
+| `226181f4c5a70fd6ab632e23f37ddc9cb5bf7925` (R0 review-readiness signal commit) | `1346f894...` |
+| `2a3699b73334c3d42cbee8b3defb64f28bf3009c` (R0 "Implementation SHA" cited in §Review-readiness) | `68ab7edf...` |
+| `49d0cbb2aee54c4a4dcceade99404d14c3e329af` (β's R0 review commit, cited in `beta-review.md`'s own header) | `0e67adf5...` |
+
+None of the R0 section prose above is edited in place (per
+alpha/SKILL.md §4 "never restart completed sections" / §2.7 fix-round
+convention — this R1 appendix is additive, not a rewrite); this table
+is the resolution path for any reader who tries to `git cat-file` an R0
+SHA against current `origin/cycle/608` and finds it missing.
+
+### Non-blocking items from β's R0 review — disposition
+
+1. Design doc's Mock B "Invariants B1–B3" header vs. 4 listed rows —
+   pre-existing inconsistency in verbatim-landed source content; not
+   touched (β already agreed this is correctly left as-is).
+2. γ's "9 rows total" scaffold arithmetic note — informational only, no
+   code change; α's R0 mock_parity block already used the correct
+   10-row set.
+3. CI `checkSmallChangeArtifacts` hard-fail-vs-warn asymmetry —
+   tooling/process observation for γ/δ, out of this cycle's diff scope.
+4. `--index <URL>` + explicit `--release <tag>` — **closed this round**
+   (see New tests above, `TestRun_IndexHTTPURL_WithExplicitReleaseTag`).
+5. No lockfile-level concurrency guard — inherited pre-existing
+   `restore.Restore` limitation, explicit known debt, out of scope for
+   #608 (same disposition as R0).
+6. No Windows support for the git-subprocess-based root resolution —
+   same debt class as 5, out of scope for #608 (cnos ships Go tooling
+   cross-platform in general, but this specific gap predates this
+   cycle and is not introduced by it).
+
+### Self-check
+
+Every claim above is backed by a command run this round (test output,
+binary repro transcript, `go build`/`go vet`/`go test` exit codes) —
+none is asserted from memory of R0's shape. The fix is a net *deletion*
+of a code path (the `inv.HubPath`-as-root branch), not an addition of
+conditional complexity, so there is no new ambiguity pushed onto β: β's
+re-review is a narrow AC1-focused re-check (as β's own R0 verdict
+rationale anticipated) plus confirmation that AC2–AC11 remain
+unaffected — both are directly evidenced above with concrete SHAs and
+counts.
+
+### Review-readiness — round 2 (R1)
+
+**Base SHA:** `c08a7483e57189760bcf5f7067904042f101bf61` (current
+`origin/main` tip; branch rebased onto it this round, confirmed
+`git merge-base origin/main HEAD` == `origin/main`'s tip).
+
+**Implementation SHA:** current branch HEAD after this round's fix
+commit (rebased). Run `git log -1 --format='%H' origin/cycle/608` to
+resolve — per alpha/SKILL.md §2.6 "SHA convention", omitting a
+recorded value here rather than naming a HEAD that this very commit
+would advance past (the recursive-self-stale trap named in that
+section); the commit message of the fix itself
+(`alpha-608 R1: fix silent ancestor-.cn walk-up in cn repo install (β R0
+F1)`) is the stable anchor.
+
+**Tests:** 307 pass, 0 fail (`go test ./...`); `go test -race -count=1
+./...` clean; `go build ./...` / `go vet ./...` clean.
+
+**Known debt:** unchanged from R0 (§Debt above) plus non-blocking items
+5–6 restated above; no new debt introduced by this fix (it is a
+strict simplification of the R0 code, not new surface).
+
+**This cycle is ready for β re-review**, scoped per β's own R0
+guidance: a narrow re-check of AC1 (now closed — β's exact repro
+re-tested against the built binary and fails correctly) plus a
+regression pass on AC2–AC11 (unaffected, all still pass).
+
+Requesting β re-review on `cycle/608` at current HEAD (the fix commit
+`aef74f3e103d747069abb083e75c82acb8bcca54`'s post-rebase equivalent).
+β should poll `origin/cycle/608` and
+`.cdd/unreleased/608/beta-review.md` per the standard coordination
+protocol.

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,7 +1,7 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap, Skills, ACs, Self-check]
+**completed:** [Gap, Skills, ACs, Self-check, Debt]
 
 ---
 
@@ -472,3 +472,74 @@ push ambiguity onto β? Is every claim backed by evidence in the diff?**
 - No ambiguity was pushed onto β regarding the implementation-contract axes
   (all 7 were pinned by γ at dispatch; none were relaxed or reinterpreted —
   see §Skills above).
+
+---
+
+## Debt
+
+Known gaps and observations, disclosed explicitly rather than left implicit:
+
+1. **`cn --version` is referenced in the new `docs/guides/INSTALL-CDS.md`
+   (as the install.sh-recommended verification step) but currently exits
+   non-zero with "Unknown command"** — confirmed by building the binary and
+   running it directly. This is a **pre-existing** gap (the design doc's own
+   Mock F1, cnos#606 dogfooding, explicitly out of scope for #608 — Mocks
+   C/D/F/G belong to later subs) and this cycle does not introduce or
+   worsen it; the doc text mirrors `install.sh`'s own final verification
+   step, which already invokes `cn --version` regardless of this cycle.
+   Flagging rather than silently reproducing an already-known bug's
+   symptom without comment.
+2. **`cn cdd verify`'s small-change classification (`ledger.go`
+   `checkSmallChangeArtifacts`, `forUnreleased=false` at line 497) hard-fails
+   any in-progress `self-coherence.md` missing a required section**, unlike
+   the triadic path's lenient in-progress warning — see §Self-check for the
+   full analysis. This is a friction pattern in the CDD tooling itself
+   (affecting every α cycle's authoring window before β writes
+   `beta-review.md`), not something this cycle's diff touches or is
+   positioned to fix. Surfaced as an observation for γ/δ triage, per
+   alpha/SKILL.md §2.8's "factual observations only" voice — not
+   recommending a specific tool patch here.
+3. **`--index <URL>` combined with an explicit `--release <tag>` (both set,
+   remote index) is not independently tested** — only (a) local `--index`
+   with an explicit `--release` pin (`TestRun_DefaultPackageSet_AllThreeRestored`)
+   and (b) remote `--index` URL with no `--release` (`TestRun_IndexHTTPURL_RelativeRewrite`)
+   are covered separately. The code path is the same `resolveIndex`
+   branch either way (`isRemoteURL(indexArg)` gates URL-fetch vs local-read;
+   `pinFromRelease` is computed identically regardless of which sub-branch
+   fires), so risk is low, but the exact combination (remote URL + explicit
+   release pin together) has no dedicated test.
+4. **`docs/guides/README.md` was not updated** to add a navigation link to
+   the new `docs/guides/INSTALL-CDS.md` — the issue's own §Docs section
+   names only `docs/guides/INSTALL-CDS.md` (plus `templates/cnos-install.yml`
+   + `docs/guides/README.md` as explicitly "#611"-scoped follow-ups, per the
+   issue body's own text: "`docs/guides/templates/cnos-install.yml` +
+   `docs/guides/README.md` follow (bootstrap delegation is finalized in
+   #611)"). Not adding it is issue-scope-conformant, not an oversight, but
+   named here for completeness.
+5. **No lockfile-level concurrency guard** — two simultaneous `cn repo
+   install` invocations against the same repo could race on `.cn/deps.json`
+   / `.cn/deps.lock.json` writes or the vendor tree. This matches
+   `restore.Restore`'s own pre-existing lack of a lock/mutex (confirmed by
+   reading `restore.go` — no file-lock primitive anywhere in that package
+   either), so this cycle does not introduce a new class of risk; it is
+   inherited, not new.
+6. **Windows is not a supported target** — `cn repo install` uses no
+   Windows-specific code, but the wider `cn` kernel already restricts
+   platform binaries to linux/macOS (`binupdate.go`'s
+   `platformBinaryName`); this is pre-existing scope, not new debt from
+   this cycle.
+7. **Branch CI (the `cdd-artifact-check` / I6 job specifically) was red on
+   several interim commits** during this cycle (`eb269381`, `a3f9b86e`) —
+   expected per alpha/SKILL.md §2.5's incremental one-section-per-commit
+   authoring discipline for `self-coherence.md`, and resolved once the
+   header-format fix (`9fbd8fa1`) landed and (after this §Debt section is
+   the last content section) every required section exists in one commit.
+   §Review-readiness below re-validates this transient row at signal time,
+   per alpha/SKILL.md §2.6's "transient vs durable rows" rule.
+
+No AC is partially met — all eleven (AC1–AC11) have PASS-backed evidence in
+§ACs above. No known gap in this list blocks any AC; all are either
+pre-existing (1, 5, 6), explicitly out-of-scope-by-the-issue's-own-text (4),
+narrow test-coverage gaps on a low-risk shared code path (3), a tooling
+observation for a different role to triage (2), or a transient/resolved CI
+state (7).

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,7 +1,7 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap]
+**completed:** [Gap, Skills]
 
 ---
 
@@ -67,3 +67,50 @@ regeneration + a sigma heartbeat log entry — during this cycle; α rebased
 `cycle/608` onto the new tip per alpha/SKILL.md §2.6 row 1. No conflicts;
 the two commits touch `docs/development/board/*` and `.cn-sigma/logs/*`,
 disjoint from every path this cycle's diff touches.)
+
+---
+
+## §Skills
+
+**Tier 1 (lifecycle):**
+- `CDD.md` — canonical lifecycle/role contract.
+- `cnos.cdd/skills/cdd/alpha/SKILL.md` — this role's execution surface (§2.1
+  dispatch intake, §2.5 self-coherence, §2.6 pre-review gate, §2.7 request
+  review, §3.6 implementation-contract constraint).
+- `design/SKILL.md` not separately re-loaded as a standalone step: the design
+  artifact (`cn-repo-install-MOCKS.md`) was already operator-reviewed/pinned
+  per γ's scaffold; this cycle's "design" work was landing it verbatim, not
+  authoring new design content requiring the design skill's judgment
+  algorithm.
+- `plan/SKILL.md` not separately invoked as a standalone artifact: γ's
+  scaffold already carried a concrete "Surfaces α is expected to touch" table
+  + AC oracle mapping + expected diff scope, which functioned as the plan.
+  Sequencing was straightforward (land design doc → domain package → cli
+  wrapper → registration → tests → docs → self-coherence) with no
+  non-trivial ordering decisions requiring the plan skill's own algorithm.
+
+**Tier 2 (`cnos.eng`):**
+- `eng/go/SKILL.md` — load-bearing throughout. §2.18 ("Dispatch boundary:
+  cli/ owns dispatch only") directly shaped the repoinstall/cli split;
+  §2.17 (parse/read split, parallel-parser prohibition) governed reuse of
+  `pkg.ParsePackageIndex`/`pkg.ParseManifest`/`pkg.ParseLockfile` rather than
+  inventing new ad hoc JSON decoding; the determinism conventions (sorted
+  map-key iteration, no map-order-dependent output) shaped
+  `writeManifest`/`rewriteRelativeEntriesFromBase`.
+
+**Tier 3 (issue-specific):** none loaded beyond `eng/go` — this is a
+single-language (Go) kernel-command cycle with no CLI-ergonomics-package,
+security-review, or other Tier-3 skill named by the issue or scaffold.
+
+**Implementation contract (δ-pinned, per alpha/SKILL.md §3.6 — not
+improvised):** all 7 axes were populated in γ's scaffold (Language: Go;
+CLI integration target: kernel `cn` subcommand via noun-verb resolution;
+Package scoping: `cli/cmd_repo_install.go` + new `internal/repoinstall/`
+package, reusing `restore/`, `pkg/`, `binupdate/`; Existing-binary
+disposition: coexist, `cn init`/`setup`/`deps` unchanged; Runtime
+dependencies: none new; JSON/wire contract preservation: `cn.deps.v1` /
+`cn.lock.v2` / `cn.package-index.v1` schemas unchanged, vendor path
+name-based; Backward-compat invariant: `cn init`/`setup`/`deps` behavior
+unchanged). No row was empty or TBD at dispatch time, so no γ/δ escalation
+was needed before coding. Every diff hunk in this cycle maps to one or more
+of these pinned rows — see §CDD Trace step 6 for the file-by-file mapping.

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -640,3 +640,91 @@ reconciliation" entry — table-shape and cross-reference checks were manual
 (no markdown linter is wired into this repo's CI for prose docs, confirmed
 via `.github/workflows/*.yml` — only `validate-skill-frontmatter.sh`, which
 targets `SKILL.md` frontmatter specifically, not general guide prose).
+
+### Mock parity contract (design doc §"Receipt parity contract")
+
+Per this cycle's scope (Mocks A, B, E1 only — Mocks C/D/F/G belong to
+#609–#611, per γ's scaffold and the design doc's own header). **Row-count
+note:** γ's scaffold text says "9 rows total for this sub" while separately
+naming the row set as "A1-A5, B1-B4, E1" — that set is 5+4+1 = **10** rows,
+not 9; γ's arithmetic undercounted its own enumeration. This block uses the
+correct 10-row set (the named IDs are authoritative, not the miscounted
+total) rather than silently dropping a row to match "9." Separately: the
+design doc's own Mock B table header reads "**Invariants B1–B3**" but the
+table beneath it lists four rows (B1, B2, B3, **and** B4, the dispatch
+guard) — an intra-doc numbering drift in the landed-verbatim source file
+itself (not something α introduced or is authorized to silently correct,
+since the file was landed verbatim per γ's explicit instruction). Both
+observations are recorded here rather than acted on unilaterally.
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-install-MOCKS.md
+  source_commit: "f22d5a78967059ba1a91a8ad1256e005d1cbc9a"  # pre-rebase landing commit; content unchanged post-rebase (verified: file untouched by any origin/main commit between base SHAs)
+  rows:
+    - id: A1
+      expectation: "Fails with a clear error if not at a git repo root (does not silently walk up or scaffold)."
+      observed: "✗ cn repo install must be run inside a Git repository. (exact stderr string; exit non-zero; no files written)"
+      evidence: "cli/cmd_repo_install_test.go::TestRepoInstall_NotAGitRepo_FailsClearly"
+      verdict: match
+      how: "gitRepoRoot(ctx) failure is caught and replaced with the exact clean message before any repoinstall.Run call; no scaffolding occurs (0 dir entries created, asserted in-test)."
+    - id: A2
+      expectation: "Prints the exact release tag it will use; --release latest resolves to a concrete tag in the output."
+      observed: "✓ Resolved cnos release: 9.9.9 (fake-GitHub-API-resolved tag printed to stdout)"
+      evidence: "repoinstall/repoinstall_test.go::TestRun_ReleaseLatest_ResolvesAndInstalls"
+      verdict: match
+      how: "Run prints the resolved tag unconditionally (both dry-run and apply paths) before any write."
+    - id: A3
+      expectation: "Lists the precise planned committed diff — exactly .cn/deps.json, .cn/deps.lock.json, .gitignore."
+      observed: "dry-run stdout 'Planned committed diff (3 files):' followed by exactly those three paths, no more."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_DryRun_WritesNothing"
+      verdict: match
+      how: "printPlan's plannedFiles slice is hardcoded to exactly these three paths; no other path is ever appended to it."
+    - id: A4
+      expectation: "States dispatch mode explicitly and, in base mode, states no .github/workflows/ change."
+      observed: "'Dispatch: none (base install only — no .github/workflows/ changes)' printed in both dry-run and apply paths."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_DryRun_WritesNothing (stdout assertion), TestRun_LocalIndex_EndToEnd (apply-path stdout)"
+      verdict: match
+      how: "The exact string is emitted by both printPlan (dry-run) and Run's post-applyInstall success path (apply) — one literal in each branch."
+    - id: A5
+      expectation: "Writes nothing (verified: git status --porcelain empty after --dry-run)."
+      evidence: "cli/cmd_repo_install_test.go::TestRepoInstall_DryRun_GitStatusStaysClean; repoinstall/repoinstall_test.go::TestRun_DryRun_WritesNothing (os.ReadDir empty)"
+      observed: "git status --porcelain empty; os.ReadDir(RepoRoot) returns zero entries."
+      verdict: match
+      how: "Run's DryRun branch returns before applyInstall (the sole owner of every os.MkdirAll/os.WriteFile in the non-test path) is ever called."
+    - id: B1
+      expectation: "Diff is exactly three files (.cn/deps.json, .cn/deps.lock.json, .gitignore); no .github/workflows/ file present."
+      observed: "Post-apply repo tree: exactly those three new/modified paths plus the gitignored .cn/vendor/ tree; no .github/ directory created."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_LocalIndex_EndToEnd; cli/cmd_repo_install_test.go::TestRepoInstall_FreshGitRepo_EndToEnd"
+      verdict: match
+      how: "applyInstall's only os.WriteFile/os.MkdirAll targets are .cn/, .cn/deps.json, and (via restore.Restore) .cn/vendor/packages/*, plus hubsetup.EnsureGitignoreEntry's .gitignore write — no .github/ call site exists anywhere in the diff."
+    - id: B2
+      expectation: ".cn/deps.lock.json validates against cn.lock.v2 and pins every package in deps.json by SHA-256; versions are exact, not semver ranges."
+      observed: "Schema == \"cn.lock.v2\"; every LockedDep has a non-empty SHA256; version strings are index-resolved exact matches."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_LocalIndex_EndToEnd"
+      verdict: match
+      how: "Lockfile is generated entirely by the reused restore.GenerateLockFromIndex — its exact-match resolution semantics and schema are inherited unmodified."
+    - id: B3
+      expectation: "Idempotent: a second cn repo install produces no further diff (git status --porcelain empty), with no formatting churn."
+      observed: "git status --porcelain empty after a commit + second install; .cn/deps.json and .cn/deps.lock.json byte-identical across two runs."
+      evidence: "cli/cmd_repo_install_test.go::TestRepoInstall_Idempotent_NoDiffOnSecondRun; repoinstall/repoinstall_test.go::TestRun_Idempotent_ByteIdenticalArtifacts"
+      verdict: match
+      how: "writeManifest is a pure function of resolved inputs (no timestamps); restore.GenerateLockFromIndex is independently deterministic; restore.Restore's existing version-match skip avoids vendor-tree rewrites."
+    - id: B4
+      expectation: "Dispatch guard: until the renderer is generalized (#609), cn repo install --dispatch cds fails with an explicit error and writes no partial .github/workflows/cnos-cds-dispatch.yml."
+      observed: "✗ --dispatch cds requires generalized wake renderer support (#609); os.ReadDir(RepoRoot) empty; no .github/workflows/cnos-cds-dispatch.yml."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_DispatchCds_FailsWithNoPartialWrite; cli/cmd_repo_install_test.go::TestRepoInstall_DispatchCds_CliWiring"
+      verdict: match
+      how: "validateDispatch is the first statement in Run, before any I/O; a 'cds' value returns immediately."
+    - id: E1
+      expectation: "cn repo install (base) writes no agent-hub scaffold — no spec/SOUL.md, agent/, threads/, state/; only .cn/deps.json + .cn/deps.lock.json + .gitignore."
+      observed: "None of spec/SOUL.md, agent/, threads/, state/ exist post-install; internal/repoinstall does not import internal/hubinit at all."
+      evidence: "repoinstall/repoinstall_test.go::TestRun_LocalIndex_EndToEnd; cli/cmd_repo_install_test.go::TestRepoInstall_NoAgentHubScaffold"
+      verdict: match
+      how: "repoinstall.go's import block has zero dependency on hubinit (cn init's agent-hub-scaffold package); the two commands share no scaffolding code path."
+  summary:
+    matched: 10
+    exceeded: 0
+    missed: 0
+    exceed_justified: true
+```

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,0 +1,69 @@
+# self-coherence — cycle #608
+
+**manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
+**completed:** [Gap]
+
+---
+
+## §Gap
+
+**Issue:** [cnos#608](https://github.com/usurobor/cnos/issues/608) — "cds-install Sub 1 (Cn=1 / PR 1): implement `cn repo install` — base installer (dispatch none)"
+
+**Mode:** `design-and-build` (per the issue body's own `**Mode:**` field).
+**cell_kind:** `implementation` (per the issue body's own `**cell_kind:**` field).
+
+**Parent:** #607 (wave master tracker — "first-class CDS repo installer"). This
+cycle is PR1 of the wave (base installer, dispatch none). PR2 (#609, renderer
+generalization), PR3 (#610, dispatch install), PR4 (#611, bootstrap delegation)
+are explicitly out of scope for this cycle — only #608 is dispatched now.
+
+**Gap being closed:** cnos ships the hub/package path (`cn init`, `cn setup`,
+`cn deps restore`, `cn doctor`, `cn build`, `cn update`) but has no first-class
+"install CNOS/CDS into this repo" command. Onboarding an arbitrary Git
+repository into the CDS method requires ~7 manual steps (install `cn`, fetch
+the release index, hand-write `.cn/deps.json`, run `cn deps lock`, run
+`cn deps restore`, edit `.gitignore`, commit) and `cn init` is the wrong tool
+for this — it scaffolds a full agent-hub (`spec/SOUL.md`, `agent/`, `threads/`,
+`state/`) into a `cn-<name>/` subdirectory, not a package-substrate install
+into the current repo (cnos#606 C4).
+
+**What closes it:** a new kernel command, `cn repo install`, that:
+- runs in a plain `git init`-only repo before any `.cn/` hub or package state
+  exists;
+- resolves a cnos release (default: latest) or an explicit `--index`
+  path/URL;
+- writes deterministic `.cn/deps.json` (schema `cn.deps.v1`) pinning the
+  default package set (`cnos.core`, `cnos.cdd`, `cnos.cds`) to exact,
+  index-resolved versions;
+- reuses the existing `internal/restore` substrate directly
+  (`restore.GenerateLockFromIndex`, `restore.Restore`) to write
+  `.cn/deps.lock.json` (schema `cn.lock.v2`, SHA-256-pinned) and restore
+  packages under `.cn/vendor/packages/<name>/` (name-based, not
+  `<name>@<version>/`);
+- ensures the target repo's `.gitignore` excludes `.cn/vendor/`;
+- supports `--release latest|<tag>`, `--index <path-or-url>`,
+  `--packages <csv>`, `--dry-run`;
+- gates autonomous dispatch install behind an explicit, currently-failing
+  `--dispatch cds` flag (default `--dispatch none`) — base install never
+  writes `.github/workflows/` and never requires a workflow/agent secret;
+  dispatch install itself is #609/#610 territory, out of scope here.
+
+**Design surface:** `docs/development/design/cn-repo-install-MOCKS.md`
+(Mocks A, B, E1 — the base-install half of the wave's design doc; Mocks
+C/D/F/G belong to later subs). This file did not exist on `origin/main` at
+cycle start; per γ's scaffold it was pulled verbatim (operator-reviewed,
+"Enacted" per #607) from `origin/claude/cds-install-guide-2ka54j` rather than
+re-authored — landed in commit `f22d5a78` (pre-rebase) / `40a6706c`
+(pre-rebase second push), now at `d783ba38`'s ancestor
+`f22d5a78` → after the rebase onto `origin/main` documented below, the
+current SHA for that commit is unchanged in content (rebase was a clean,
+non-conflicting fast-forward-style replay — no file in this cycle's diff
+overlapped the intervening `origin/main` commits).
+
+**Base SHA (original, at branch creation):** `3dad64285026582a161549b8fd10108dd67a369e`
+**Base SHA (current, after α's pre-review-gate rebase):** `80778d688e04e61c66d38f2bd5962fafb0729e95`
+(`origin/main` advanced by two unrelated automation commits — board-map
+regeneration + a sigma heartbeat log entry — during this cycle; α rebased
+`cycle/608` onto the new tip per alpha/SKILL.md §2.6 row 1. No conflicts;
+the two commits touch `docs/development/board/*` and `.cn-sigma/logs/*`,
+disjoint from every path this cycle's diff touches.)

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,7 +1,7 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap, Skills, ACs, Self-check, Debt]
+**completed:** [Gap, Skills, ACs, Self-check, Debt, CDD Trace]
 
 ---
 
@@ -543,3 +543,100 @@ pre-existing (1, 5, 6), explicitly out-of-scope-by-the-issue's-own-text (4),
 narrow test-coverage gaps on a low-risk shared code path (3), a tooling
 observation for a different role to triage (2), or a transient/resolved CI
 state (7).
+
+---
+
+## CDD Trace
+
+Steps per `cnos.cds/skills/cds/CDS.md` §"Artifact contract" → §"Ordered
+flow", as realized by this cycle:
+
+1. **Design artifact** — `docs/development/design/cn-repo-install-MOCKS.md`,
+   landed verbatim from `origin/claude/cds-install-guide-2ka54j` (not
+   re-authored; operator-reviewed per #607). Commit `f22d5a78` (pre-rebase:
+   `40a6706c`).
+2. **Coherence contract** — this file's §Gap, established before any code
+   was written.
+3. **Plan** — not a standalone artifact this cycle; γ's scaffold's own
+   "Surfaces α is expected to touch" + AC oracle table served this role (see
+   §Skills for the justification).
+4. **Tests** — written alongside each domain/cli commit (test-first within
+   each commit, not as a separate preceding commit): `repoinstall_test.go`
+   (22 tests) landed in the same commit as `repoinstall.go`;
+   `cmd_repo_install_test.go` (9 tests) landed in the same commit as
+   `cmd_repo_install.go`. Total: 31 new tests, all passing at HEAD (see
+   Test Results below).
+5. **Code** — `internal/repoinstall/repoinstall.go` (domain logic),
+   `internal/cli/cmd_repo_install.go` (thin dispatch wrapper),
+   `src/go/cmd/cn/main.go` (+1 line registration),
+   `internal/hubsetup/hubsetup.go` (export rename, no behavior change).
+6. **Docs** — `docs/guides/INSTALL-CDS.md` (new).
+
+**Artifact enumeration matches diff (pre-review gate rule 11).** Every file
+in `git diff --stat origin/main..HEAD` (against `origin/main` at
+`80778d688e04e61c66d38f2bd5962fafb0729e95`, the rebased base):
+
+| File | Status | Mentioned |
+|---|---|---|
+| `.cdd/unreleased/608/gamma-scaffold.md` | γ's pre-dispatch artifact (not α-authored; already present on the branch when α checked it out) | this row |
+| `.cdd/unreleased/608/self-coherence.md` | this file | N/A (self) |
+| `docs/development/design/cn-repo-install-MOCKS.md` | new (landed verbatim) | step 1 above |
+| `docs/guides/INSTALL-CDS.md` | new | step 6 above, AC11 |
+| `src/go/cmd/cn/main.go` | modified (+1 line) | step 5 above |
+| `src/go/internal/cli/cmd_repo_install.go` | new | step 5 above |
+| `src/go/internal/cli/cmd_repo_install_test.go` | new | step 4 above |
+| `src/go/internal/hubsetup/hubsetup.go` | modified (export rename) | step 5 above, §Self-check peer enumeration |
+| `src/go/internal/repoinstall/repoinstall.go` | new | step 5 above |
+| `src/go/internal/repoinstall/repoinstall_test.go` | new | step 4 above |
+
+All 10 files in the diff are accounted for above.
+
+**Caller-path trace for new modules (pre-review gate rule 12).** For every
+new module/function, at least one non-test caller:
+- `internal/repoinstall` package (`Run`, `ParseArgs`, `Options`, `Result`,
+  `Args`) — called from `src/go/internal/cli/cmd_repo_install.go`'s
+  `RepoInstallCmd.Run` (non-test caller: `cmd_repo_install.go` lines calling
+  `repoinstall.ParseArgs(inv.Args)` and `repoinstall.Run(ctx, opts)`).
+- `RepoInstallCmd` (`cli` package) — registered and reachable via
+  `src/go/cmd/cn/main.go`'s `reg.Register(&cli.RepoInstallCmd{})`, dispatched
+  by the existing `cli.ResolveCommand`/`main()` argv-handling loop (the same
+  non-test call path every other kernel command uses — no new dispatch
+  mechanism was added).
+- `hubsetup.EnsureGitignoreEntry` (renamed from unexported
+  `ensureGitignoreEntry`) — non-test callers: `hubsetup.Run` (pre-existing,
+  `cn setup`'s call site, unchanged behavior) AND
+  `repoinstall.applyInstall` (new call site, this cycle).
+
+**Test assertion count from runner output (pre-review gate rule 13).**
+Pasted directly from `go test ./... -v 2>&1 | grep -c "^--- PASS"` /
+`grep -c "^--- FAIL"` at HEAD:
+
+```
+$ cd src/go && go test ./... -v 2>&1 | grep -E "^--- (PASS|FAIL)" | wc -l
+304
+$ ... | grep -c FAIL
+0
+$ go test ./internal/repoinstall/... -v 2>&1 | grep -c "^--- PASS"
+22
+$ go test ./internal/cli/... -run RepoInstall -v 2>&1 | grep -c "^--- PASS"
+9
+```
+
+304 total tests pass (0 fail) across the whole `src/go` module; 31 of those
+are new this cycle (22 in `internal/repoinstall`, 9 in `internal/cli`'s
+`cmd_repo_install_test.go`); the remaining 273 are pre-existing tests,
+confirmed still passing (no regression). `go build ./...`, `go vet ./...`,
+and `go test -race ./internal/repoinstall/... ./internal/cli/...
+./internal/hubsetup/...` all exit 0 at HEAD.
+
+**Polyglot re-audit (pre-review gate rule 9 / §2.6 rule 9).** Languages
+touched by this diff: Go (production + test code), Markdown (design doc
+landed verbatim + new install guide). No shell, YAML, or other language is
+touched. Go: `go vet ./...` clean, `go test ./... -race` clean on the
+touched packages. Markdown: both new/landed `.md` files were read in full
+(not just diffed) and cross-checked against real repo state (path
+existence, command existence, schema names) per §Self-check's "docs
+reconciliation" entry — table-shape and cross-reference checks were manual
+(no markdown linter is wired into this repo's CI for prose docs, confirmed
+via `.github/workflows/*.yml` — only `validate-skill-frontmatter.sh`, which
+targets `SKILL.md` frontmatter specifically, not general guide prose).

--- a/.cdd/unreleased/608/self-coherence.md
+++ b/.cdd/unreleased/608/self-coherence.md
@@ -1,7 +1,7 @@
 # self-coherence — cycle #608
 
 **manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
-**completed:** [Gap, Skills, ACs, Self-check, Debt, CDD Trace]
+**completed:** [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
 
 ---
 
@@ -728,3 +728,116 @@ mock_parity:
     missed: 0
     exceed_justified: true
 ```
+
+---
+
+## Review-readiness
+
+**Pre-review gate (alpha/SKILL.md §2.6), checked immediately before this
+signal:**
+
+1. **Cycle branch rebased onto current `origin/main`** — re-verified at
+   signal time: `origin/main` = `80778d688e04e61c66d38f2bd5962fafb0729e95`;
+   `git merge-base origin/main HEAD` = the same SHA. No drift since the
+   earlier rebase (commit `9fbd8fa1` onward); no further rebase needed.
+2. `self-coherence.md` carries the CDD Trace through step 6 (above), plus
+   §Gap/§Skills/§ACs/§Self-check/§Debt — all present in this commit.
+3. Tests present: 31 new tests (22 `internal/repoinstall`, 9 `internal/cli`),
+   plus the pre-existing 273, all passing — see §CDD Trace step 4/"Test
+   assertion count."
+4. Every AC (AC1–AC11) has evidence in §ACs.
+5. Known debt is explicit in §Debt (7 items, none blocking).
+6. Schema/shape audit: no schema changed this cycle (§Self-check "harness
+   audit").
+7. Peer enumeration: completed for the `.gitignore` multi-writer case
+   (§Self-check).
+8. Harness audit: completed (§Self-check) — no schema-bearing contract
+   changed, so no cross-language harness drift is possible from this diff.
+9. Post-patch re-audit: the header-format fix (`9fbd8fa1`) and the
+   §Self-check factual correction (writer-count claim) were each re-verified
+   against HEAD after being made — polyglot re-audit note in §CDD Trace
+   covers Go + Markdown (the only languages this diff touches).
+10. **Branch CI is green on the head commit.** `origin/cycle/608` HEAD
+    `2a3699b73334c3d42cbee8b3defb64f28bf3009c` — `Build` workflow
+    `conclusion: success` (re-confirmed at signal time via `gh run list
+    --repo usurobor/cnos --branch cycle/608 --limit 15 --json
+    headSha,conclusion,status,name`, filtered to this exact SHA). No other
+    workflow is configured to trigger on this diff:
+    `install-wake-golden.yml` only triggers on changes under
+    `src/packages/cnos.core/commands/install-wake/**` /
+    `.../orchestrators/**` / its own workflow file / `cnos-cds-dispatch.yml`
+    — none of which this diff touches (confirmed by reading the workflow's
+    `on:` path filters directly). `release.yml` triggers only on version
+    tags. `board-map.yml`/`cnos-agent-admin.yml`/`cnos-cds-dispatch.yml`
+    trigger on `issues`/`schedule`/`workflow_dispatch`, not on this push.
+    So `Build` succeeding is the complete CI signal for this branch.
+    (Several earlier commits on this branch — `eb269381` §Gap,
+    `a3f9b86e` §Skills, `9fbd8fa1` header-fix docs update in the same
+    diff as the fix, `ffb67634` §Self-check, `d049e23b` §Debt — show
+    `conclusion: failure` on the `cdd-artifact-check` job, an expected,
+    disclosed transient state during §2.5's incremental one-section-per-
+    commit authoring of this very file, per §Debt item 7; resolved at
+    `5d95e060` §CDD Trace onward.)
+11. Artifact enumeration matches diff: all 10 files in
+    `git diff --stat origin/main..HEAD` are named in §CDD Trace.
+12. Caller-path trace for new modules: done in §CDD Trace.
+13. Test assertion count pasted from runner output: done in §CDD Trace
+    (304 total, 0 fail, 31 new).
+14. **α's commit author email** — `git log -1 --format='%ae' HEAD` =
+    `alpha@cdd.cnos`, matching the canonical `alpha@{project}.cdd.cnos`
+    pattern (elision form for the cnos project). No correction needed;
+    every commit this cycle was authored under this identity from the
+    start (no drift to remediate via the retroactive-rebase path).
+15. **γ-artifact presence at the rule-3.11b surface** —
+    `.cdd/unreleased/608/gamma-scaffold.md` is present at the canonical
+    §5.1 path on `origin/cycle/608` (confirmed:
+    `git ls-tree -r origin/cycle/608 .cdd/unreleased/608/gamma-scaffold.md`
+    lists the file; it predates α's dispatch, authored by γ). Outcome:
+    **γ-artifact at canonical §5.1 path.**
+
+**Implementation SHA:** `2a3699b73334c3d42cbee8b3defb64f28bf3009c` (this is
+also current HEAD — no further commits follow this readiness signal on
+`cycle/608`, so the recursive-self-stale concern in alpha/SKILL.md §2.6's
+"SHA convention" note does not apply here: this is the final commit, not a
+readiness-signal commit that will itself advance HEAD).
+
+**Base SHA:** `80778d688e04e61c66d38f2bd5962fafb0729e95` (current
+`origin/main` tip at signal time, confirmed via `git fetch origin main` +
+`git rev-parse origin/main` immediately before writing this section).
+
+**Branch CI:** green (`Build` workflow, `conclusion: success`) at head SHA
+`2a3699b73334c3d42cbee8b3defb64f28bf3009c`, confirmed at signal time
+(not a stale/earlier-commit read).
+
+**mock_parity:** 10/10 matched, 0 missed (block above, under §CDD Trace).
+
+**Deviations from the scaffold:**
+- Section headers use the bare form (`## Gap` not `## §Gap`) rather than
+  the `§`-prefixed style used in the scaffold's own prose and in a prior
+  cycle (#600) — required for `cn cdd verify`'s I6 gate to actually pass for
+  a small-change-classified cycle (see §Self-check/§Debt for the full
+  analysis). This is a format-only deviation; content/structure matches the
+  scaffold's declared section list exactly.
+- The mock_parity block uses 10 rows (A1–A5, B1–B4, E1), not the "9" γ's
+  scaffold text stated — γ's own enumeration of that row set (A1-A5, B1-B4,
+  E1) sums to 10; the "9" appears to be an arithmetic slip in the scaffold,
+  not a deliberate scope reduction. Named explicitly rather than either
+  silently matching the wrong count or silently correcting γ's prose
+  without comment.
+- No other deviation from γ's scaffold: implementation contract axes,
+  reuse targets (`restore.GenerateLockFromIndex`/`restore.Restore`),
+  package scoping (`internal/repoinstall` + `cli/cmd_repo_install.go`),
+  and the design-doc-landing instruction were all followed as scaffolded.
+
+**Known gaps preventing full convergence:** none. All 11 ACs are fully met
+with PASS evidence; the mock_parity block shows `missed: 0`. §Debt's 7
+items are disclosed but none are partial-AC or blocking (see §Debt's
+closing paragraph for the explicit accounting).
+
+**This cycle is ready for β review.**
+
+Requesting β review on `cycle/608` at implementation SHA
+`2a3699b73334c3d42cbee8b3defb64f28bf3009c` (= current branch HEAD at
+signal time). β should poll `origin/cycle/608` and
+`.cdd/unreleased/608/beta-review.md` per the standard coordination
+protocol.

--- a/docs/development/design/cn-repo-install-MOCKS.md
+++ b/docs/development/design/cn-repo-install-MOCKS.md
@@ -1,0 +1,296 @@
+# `cn repo install` — mocked human deliverables + receipt parity contract
+
+> **Command name (operator ruling).** The installer is **`cn repo install`** —
+> a `repo` noun-group that matches the noun-group command resolver and leaves
+> room for future `cn repo status` / `cn repo doctor` / `cn repo uninstall`. It
+> coexists with the `cn install <target>` group (`cn install wake` #549,
+> `cn install cnos.core` #493). An interim draft used `cn install repo`; the
+> operator verdict pinned `cn repo install`.
+
+**Status:** Design surface (pre-implementation). Author: kappa/operator review.
+**Purpose:** Lock the *human-visible* deliverables of the CDS repo-installer wave
+**before** any code is written, and define the mechanism by which the
+implementing cell must **prove in its receipt** that what shipped matches or
+exceeds these mocks — and *how*.
+
+This file is the source of truth an implementation cell (mode:
+`design-and-build`) cites. Its ACs map 1:1 to the mocks below; its closeout
+carries the [Receipt parity contract](#receipt-parity-contract).
+
+> **Mock-first discipline.** These are *targets*, drawn before implementation.
+> Nothing here ships yet. Where a mock shows output, that is the intended
+> experience, not observed behavior. The implementing cell replaces "intended"
+> with "observed" and records any delta.
+
+---
+
+## Mock A — `cn repo install --dry-run` (base mode)
+
+Intended terminal experience, run from the root of an arbitrary repo with only
+`cn` on PATH:
+
+```console
+$ cn repo install --dry-run
+→ cnos repo install (dry-run) — no files will be written
+✓ Git repository root: /home/dev/acme-api
+✓ Resolved cnos release: v3.82.0
+  Would fetch package index + tarballs → <cache>/index.json (3 packages)
+  Would write .cn/deps.json:
+      cnos.core  3.82.0
+      cnos.cdd   3.82.0
+      cnos.cds   3.82.0
+  Would run: (internal) deps lock   → .cn/deps.lock.json
+  Would run: (internal) deps restore → .cn/vendor/packages/ (3 packages)
+  Would ensure .gitignore contains: .cn/vendor/
+  Dispatch: none (base install only — no .github/workflows/ changes)
+
+Planned committed diff (3 files):
+  A  .cn/deps.json
+  A  .cn/deps.lock.json
+  M  .gitignore
+
+Run without --dry-run to apply.
+```
+
+**Flags** (base mode): `--release latest|<tag>` resolves the CNOS release;
+`--index <path-or-url>` overrides the index for tests / local / offline
+development; `--packages a,b,c` overrides the default set; `--dispatch none`
+(default) / `cds`; `--dry-run`.
+
+**Human-deliverable invariants A1–A5**
+
+| ID | Invariant |
+|---|---|
+| A1 | Fails with a clear error if not at a git repo root (does not silently walk up or scaffold). |
+| A2 | Prints the exact release tag it will use; `--release latest` resolves to a concrete tag in the output. |
+| A3 | Lists the precise planned committed diff — and it is exactly `.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`. |
+| A4 | States dispatch mode explicitly and, in base mode, states no `.github/workflows/` change. |
+| A5 | Writes nothing (verified: `git status --porcelain` empty after `--dry-run`). |
+
+---
+
+## Mock B — base-install pull request (the committed diff)
+
+Intended PR contents after `cn repo install` (no dispatch). Vendored packages
+are **not** in the diff — they rehydrate from `.cn/deps.lock.json`.
+
+```diff
++++ b/.cn/deps.json
++{
++  "schema": "cn.deps.v1",
++  "profile": "cds",
++  "packages": [
++    { "name": "cnos.core", "version": "3.82.0" },
++    { "name": "cnos.cdd",  "version": "3.82.0" },
++    { "name": "cnos.cds",  "version": "3.82.0" }
++  ]
++}
+
++++ b/.cn/deps.lock.json  (schema cn.lock.v2 — SHA-256-pinned entries)
++++ b/.gitignore          (+ .cn/vendor/)
+```
+
+**Invariants B1–B3**
+
+| ID | Invariant |
+|---|---|
+| B1 | Diff is exactly three files (`.cn/deps.json`, `.cn/deps.lock.json`, `.gitignore`); no `.github/workflows/` file present. |
+| B2 | `.cn/deps.lock.json` validates against `cn.lock.v2` and pins every package in `deps.json` by SHA-256. Versions are **exact** (resolved from the index), not semver ranges. |
+| B3 | **Idempotent**: a second `cn repo install` produces no further diff (`git status --porcelain` empty), with no formatting churn. |
+| B4 | **Dispatch guard**: until the renderer is generalized (#609), `cn repo install --dispatch cds` fails with an explicit "not implemented until renderer generalization lands" error and writes **no** partial `.github/workflows/cnos-cds-dispatch.yml`. |
+
+---
+
+## Mock C — `cn repo install --dispatch cds` for a **non-sigma** agent
+
+The load-bearing mock: dispatch rendered for agent `acme` with the caller's own
+secret. This is the proof the sigma binding is gone.
+
+```console
+$ cn repo install --dispatch cds \
+    --agent acme \
+    --workflow-pat-secret ACME_WORKFLOW_PAT \
+    --bot-name "acme-bot" \
+    --bot-id 12345678
+→ cnos repo install — dispatch: cds (agent: acme)
+✓ base install complete (.cn/deps.json, .cn/deps.lock.json)
+✓ rendered .github/workflows/cnos-cds-dispatch.yml
+  identity:  acme  (bot acme-bot / 12345678)
+  pat secret: ACME_WORKFLOW_PAT
+⚠ dispatch grants scheduled write access on merge. Review before merging.
+  This changes .github/workflows/ — the installing token needs `workflow` scope.
+```
+
+Intended rendered header + wiring (the sections that carry identity):
+
+```yaml
+concurrency:
+  group: cds-dispatch-acme          # was: cds-dispatch-sigma
+  cancel-in-progress: false
+...
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACME_WORKFLOW_PAT }}   # was: SIGMA_WORKFLOW_PAT
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.ACME_WORKFLOW_PAT }}
+          bot_name: "acme-bot"        # was: sigma@cnos.cn-sigma.cnos
+          bot_id: "12345678"          # was: 41898282
+```
+
+**Invariants C1–C6**
+
+| ID | Invariant |
+|---|---|
+| C1 | Base install runs first; dispatch is layered on top. |
+| C2 | Missing `--workflow-pat-secret` / identity → **fails early** with a message naming what's required (no partial render). |
+| C3 | Rendered file writes exactly to `.github/workflows/cnos-cds-dispatch.yml`. |
+| C4 | **Zero sigma leak** — `grep -iE 'sigma|SIGMA_WORKFLOW_PAT|41898282' cnos-cds-dispatch.yml` returns nothing when agent ≠ sigma. (Reuse the AC7/AC8 leak-audit pattern already in `install-wake-golden.yml`.) |
+| C5 | `--agent sigma` still reproduces the current sigma-bound output byte-for-byte (backward compat; the existing golden fixture still passes). |
+| C6 | Dispatch never pushes to `main`; PR-only, and the CLI states the `workflow`-scope PAT requirement. |
+
+---
+
+## Mock D — GitHub UI (no-terminal) path
+
+`workflow_dispatch` inputs on `.github/workflows/cnos-install.yml`, delegating to
+the same `cn repo install` command (not reimplemented in YAML):
+
+```yaml
+inputs:
+  release:              { default: latest }
+  install_dispatch:     { default: false }        # true → --dispatch cds
+  workflow_pat_secret:  { default: CNOS_WORKFLOW_PAT }
+  agent:                { default: cnos }
+```
+
+**Invariants D1–D4**
+
+| ID | Invariant |
+|---|---|
+| D1 | Base run (dispatch off) opens a PR with the Mock-B diff, using the default `GITHUB_TOKEN`. |
+| D2 | Dispatch run either opens a PR containing the Mock-C workflow **or** fails with a clear message that a `workflow`-scoped PAT is required — never a half-applied state. |
+| D3 | The job body invokes `cn repo install …` — install logic is not duplicated in shell. |
+| D4 | Never pushes to `main`. |
+
+---
+
+## Mock E — tenant-portable dispatch wake (dogfooding: cnos#606 C4, C5)
+
+The first external tenant (`tsc`, cnos#606) found the rendered wake does
+`cd src/go && go build ./cmd/cn` — valid only inside the cnos repo — and that
+`cn init` drops a full agent-hub (`spec/SOUL.md`, `agent/`, `threads/`,
+`state/`) into the tree. A tenant wants **labels + wakes + `.cn/` runtime**, not
+a home hub, and its wake must acquire `cn` the way a tenant can.
+
+Intended rendered dispatch wake for a tenant (identity elided; see Mock C):
+
+```yaml
+      - name: Install cn (tenant-portable — no src/go build)
+        run: curl -fsSL https://raw.githubusercontent.com/usurobor/cnos/main/install.sh
+             | BIN_DIR="$HOME/.local/bin" sh
+      # ... claude-code-action work phase ...
+      - name: Mechanical checkpoint + PR finalizer
+        run: cn cell finalize --base-sha "${CN_WAKE_BASE_SHA:-}"   # installed cn, NOT go build
+```
+
+**Invariants E1–E4**
+
+| ID | Invariant |
+|---|---|
+| E1 | `cn repo install` (base) writes **no** agent-hub scaffold — no `spec/SOUL.md`, `agent/`, `threads/`, `state/`; only `.cn/deps.json` + `.cn/deps.lock.json` + `.gitignore` (C4). |
+| E2 | A rendered tenant dispatch wake contains **no** `cd src/go` / `go build ./cmd/cn`; it acquires `cn` via `install.sh` or a pinned release (C5). |
+| E3 | The rendered wake's finalizer/engine steps invoke the installed `cn` (e.g. `cn cell finalize`), runnable in a repo with no `src/go`. |
+| E4 | `--agent sigma` inside the cnos repo still reproduces the current `go build` self-wake byte-for-byte (backward compat; the golden is not broken by tenant mode). |
+
+---
+
+## Mock F — CLI ergonomics (dogfooding: cnos#606 C3)
+
+The tenant hit: `cn --version` → "Unknown command"; `cn init --help` **scaffolded
+a stray `cn---help/` directory**; `cn help` lists `issues-fsm` / `cell-finalize`
+but the real invocation is `cn issues fsm` / `cn cell finalize`.
+
+```console
+$ cn --version
+cn 3.82.1 (…)
+$ cn repo install --help
+cn repo install — make this repository CDS-ready …
+$ cn init --help        # a flag is never a hub name
+✗ unknown flag --help for `cn init` (did you mean `cn init <name>`?)
+```
+
+**Invariants F1–F4**
+
+| ID | Invariant |
+|---|---|
+| F1 | `cn --version` / `-V` prints the version (exit 0), not "Unknown command". |
+| F2 | `--help` / `-h` works on `cn` and every command incl. `cn repo install`. |
+| F3 | `cn init --help` (any unrecognized `--flag`) **refuses** with a clear error and scaffolds nothing — no stray `cn---help/`. |
+| F4 | `cn help` display names match real invocation (`cn issues fsm`, `cn cell finalize`), or list both forms — no name/invocation mismatch. |
+
+---
+
+## Mock G — PAT-free mechanical FSM engine + secrets runbook (dogfooding: cnos#606 C6, C7)
+
+`cn issues fsm evaluate --apply` is mechanical — it needs no agent token. The
+tenant had no fallback: every wake required `SIGMA_WORKFLOW_PAT`, and there was
+no doc naming the secrets or a hub-less label path.
+
+**Invariants G1–G4**
+
+| ID | Invariant |
+|---|---|
+| G1 | `cn repo install --dispatch cds` can render a **mechanical FSM-engine** wake that runs `cn issues fsm evaluate --apply` on the default `GITHUB_TOKEN` — no agent PAT required. |
+| G2 | The agent (claude-code-action) wake tier remains the only one that needs a `workflow`-scope PAT + `CLAUDE_CODE_OAUTH_TOKEN`; the two tiers are separable. |
+| G3 | Dispatch install ensures the canonical FSM labels **without a full hub** (hub-less `cn labels sync` / the cnos#493 mechanism) (C7). |
+| G4 | Installing dispatch emits/points to a tenant secrets runbook naming every required secret per tier. |
+
+---
+
+## Receipt parity contract
+
+The implementing cell (`cell_kind: implementation`) MUST emit this block in its
+γ close-out. It is how the cell **confirms match-or-exceed, and how**. It is a
+hard gate: any row with `verdict: miss` blocks convergence to `status:review`.
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-install-MOCKS.md
+  source_commit: "<sha of this file the cell built against>"
+  rows:
+    # one row per invariant A1..A5, B1..B4, C1..C6, D1..D4, E1..E4, F1..F4, G1..G4
+    - id: A3
+      expectation: "dry-run lists exactly .cn/deps.json, .cn/deps.lock.json, .gitignore"
+      observed: "<what the built command actually printed>"
+      evidence: "<test name / transcript path / commit>"
+      verdict: match | exceed | miss
+      how: "<why it matches; if exceed, the additional capability and why it is safe;
+             if miss, the gap + planned disposition>"
+  summary:
+    matched: <n>
+    exceeded: <n>
+    missed: <n>          # MUST be 0 to converge
+    exceed_justified: <bool>   # every 'exceed' row has a non-empty, safe `how`
+```
+
+**Rules**
+- **Coverage**: every invariant ID in Mocks A–G has exactly one row. A missing ID
+  is itself a `miss`. (Mocks E–G are the cnos#606 dogfooding surface — tenant
+  portability, ergonomics, PAT-free engine — and are not optional.)
+- **`exceed` is not a free pass**: an `exceed` verdict requires `how` to state the
+  extra capability *and* why it does not violate a non-goal (e.g. exceeding into
+  autonomous-write territory in base mode is a `miss`, not an `exceed`).
+- **Evidence is durable**: `evidence` points at a test, a captured transcript
+  under `.cdd/unreleased/<N>/`, or a commit — not prose.
+- β rejects the cell if any row's `observed`/`how` is unfalsifiable against the
+  cited evidence.
+
+---
+
+## Non-goals (inherited by the wave)
+
+Hosted live package registry · direct pushes to `main` · silent autonomous-write
+install · sigma-only default · agent-in-the-loop for base install · manual
+terminal for the GitHub UI path.

--- a/docs/guides/INSTALL-CDS.md
+++ b/docs/guides/INSTALL-CDS.md
@@ -1,0 +1,197 @@
+# Install CDS into your repo
+
+**Audience:** a human who wants to bring the cnos **CDS** (Coherence-Driven
+Software) process into an existing software repository.
+
+Installing CDS has two layers, and they are separate trust decisions:
+
+- **Layer 1 — Base package install.** Pins the `cn` toolchain reference and
+  the cnos packages (`cnos.core`, `cnos.cdd`, `cnos.cds`) in your repo. This is
+  the safe default — enough for you, or a Claude attached to the repo, to run
+  the CDS method by hand. **This is what this guide covers.**
+- **Layer 2 — Autonomous dispatch (opt-in).** A scheduled workflow that wakes
+  an agent, claims issues, and opens PRs on a cron. This needs extra secrets
+  (a `workflow`-scoped PAT, a model OAuth token) and standing write access —
+  see [§ Autonomous dispatch](#autonomous-dispatch-opt-in) before enabling it.
+
+The canonical way to install Layer 1 is one command:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/usurobor/cnos/main/install.sh | sh
+cn repo install
+```
+
+`cn repo install` is a kernel command — it runs before any hub or package
+state exists, so it works in a plain `git init`-only checkout with nothing
+more than the `cn` binary on `PATH`.
+
+---
+
+## What "installing CDS" actually means
+
+CDS is a **method**, not a service. Installed into your repo (Layer 1), the
+base layer is just three tracked artifacts:
+
+| File | Purpose |
+|---|---|
+| `.cn/deps.json` | Declares which cnos packages your repo depends on (exact versions). |
+| `.cn/deps.lock.json` | The resolved, SHA-256-pinned lockfile (schema `cn.lock.v2`). |
+| `.gitignore` (`+ .cn/vendor/`) | Vendored packages rehydrate from the lock; they are not committed. |
+
+`cn repo install` restores the packages into `.cn/vendor/packages/<name>/`
+(name-based, not version-suffixed), which includes the CDS skills
+(`skills/cds/CDS.md`, the lifecycle and selection overlays) and the
+`cn install-wake` renderer.
+
+The `cn` binary is **the body**; a model (Claude, etc.) is **the brain**. `cn`
+senses and executes; the model reads the skills and drives the CDS loop. See
+[`docs/reference/cli/CLI.md`](../reference/cli/CLI.md).
+
+`cn repo install` never writes anything under `.github/workflows/` and never
+requires a workflow or agent secret — that is Layer 2, a separate opt-in (see
+below).
+
+---
+
+## Prerequisites
+
+- A GitHub repository, checked out locally, that you can push to (or open PRs
+  against).
+- A Unix-like shell (Linux, macOS, WSL) with `curl`, to install the `cn`
+  binary.
+
+`cn repo install` itself needs nothing beyond `cn` and network access to
+GitHub Releases (or a local/offline package index — see `--index` below).
+
+---
+
+## Install (Layer 1 — base)
+
+### 1. Install the `cn` binary
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/usurobor/cnos/main/install.sh | sh
+```
+
+This downloads the pre-built binary for your platform from the latest cnos
+release, verifies its SHA-256, and installs it to `/usr/local/bin/cn`. To
+install without root:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/usurobor/cnos/main/install.sh \
+  | BIN_DIR="$HOME/.local/bin" sh
+# ensure $HOME/.local/bin is on your PATH
+```
+
+Verify:
+
+```sh
+cn --version
+```
+
+### 2. Install the base package set
+
+From your repo root:
+
+```sh
+cn repo install
+```
+
+This resolves the latest cnos release, writes `.cn/deps.json` +
+`.cn/deps.lock.json`, restores `cnos.core` / `cnos.cdd` / `cnos.cds` under
+`.cn/vendor/packages/`, and adds `.cn/vendor/` to `.gitignore`. It prints the
+resolved release tag and a summary of what it wrote/restored.
+
+Preview what would happen without writing anything:
+
+```sh
+cn repo install --dry-run
+```
+
+Useful flags (all optional — `cn repo install` alone covers the default
+case):
+
+```sh
+cn repo install --release <tag>              # pin a specific cnos release instead of latest
+cn repo install --packages cnos.core,cnos.cdd,cnos.cds
+cn repo install --index ./dist/packages/index.json   # local/offline package index
+```
+
+### 3. Commit
+
+```sh
+git add .cn/deps.json .cn/deps.lock.json .gitignore
+git commit -m "chore(cnos): install CDS packages"
+```
+
+That's the base install. You (or an attached Claude) can now open
+`.cn/vendor/packages/cnos.cds/skills/cds/CDS.md` and run the CDS lifecycle.
+
+`cn repo install` is idempotent: running it again with the same inputs
+produces no further diff.
+
+---
+
+## Autonomous dispatch (opt-in, Layer 2)
+
+The base install gives you the CDS *method*. The **dispatch loop** is the
+automation from the cnos repo itself: a scheduled workflow
+(`cnos-cds-dispatch.yml`) that wakes an agent, claims `dispatch:cell +
+protocol:cds + status:todo` issues, runs each cell through the δ role
+contract, and opens PRs with receipts. See the
+[dispatch orchestrator skill](../../src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md)
+for the full protocol.
+
+`cn repo install --dispatch cds` is the intended entry point for installing
+this layer, but **it is not implemented yet** — the wake renderer must be
+generalized away from its current sigma-specific binding first (tracked as a
+separate cell). Today, `cn repo install --dispatch cds` fails explicitly with
+a clear error and writes nothing; it does not partially render a workflow
+file. Once the renderer generalization lands, this guide's Layer 2 section
+will cover the full opt-in flow (required secrets: a `workflow`-scoped PAT and
+a model OAuth token; standing write access implications; the mechanical
+FSM-engine tier that needs no agent token).
+
+Until then, the renderer is available as a package command once packages are
+restored:
+
+```sh
+cn install-wake cds-dispatch --out .github/workflows/cnos-cds-dispatch.yml
+```
+
+with the caveats named in the
+[dispatch orchestrator skill](../../src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md)
+(today it is bound to the `sigma` agent identity/secret).
+
+---
+
+## Verifying the install
+
+```sh
+cn repo install          # idempotent; re-running produces no further diff
+ls .cn/vendor/packages    # cnos.core, cnos.cdd, cnos.cds
+cat .cn/vendor/packages/cnos.cds/skills/cds/SKILL.md   # the CDS loader skill
+```
+
+## Uninstalling
+
+Remove `.cn/deps.json`, `.cn/deps.lock.json`, the `.cn/vendor/` gitignore
+line, and (if you enabled Layer 2) `.github/workflows/cnos-cds-dispatch.yml`.
+The `cn` binary is just a file on your `PATH`; delete it wherever `install.sh`
+placed it.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `✗ cn repo install must be run inside a Git repository.` | Run it from inside a checked-out Git repo (`git init` at minimum) — `cn repo install` never walks up looking for one or scaffolds a repo for you. |
+| `package(s) not found in index` | The requested `--packages` entry isn't published in the resolved release/index. Check spelling, or pin `--release` to a tag that publishes it. |
+| `package(s) have multiple versions in index; pass --release to pin one` | You passed `--index` pointing at a multi-version index with no `--release`; add `--release <tag>` to disambiguate. |
+| `cn: command not found` after install | `install.sh` put `cn` outside your `PATH`. Re-run with `BIN_DIR="$HOME/.local/bin"` and add that dir to `PATH`. |
+| `--dispatch cds` fails with "requires generalized wake renderer support (#609)" | Expected today — Layer 2 dispatch install is gated on renderer generalization. See [§ Autonomous dispatch](#autonomous-dispatch-opt-in). |
+
+## Related
+
+- [`docs/reference/cli/CLI.md`](../reference/cli/CLI.md) — CLI reference.
+- [`docs/development/design/cn-repo-install-MOCKS.md`](../development/design/cn-repo-install-MOCKS.md) — the design surface `cn repo install` was built against.
+- [dispatch orchestrator skill](../../src/packages/cnos.cds/orchestrators/cds-dispatch/SKILL.md) — the autonomous dispatch loop (Layer 2).

--- a/src/go/cmd/cn/main.go
+++ b/src/go/cmd/cn/main.go
@@ -47,6 +47,7 @@ func main() {
 	reg.Register(&cli.CellFinalizeCmd{})
 	reg.Register(&cli.IssuesMapCmd{})
 	reg.Register(&cli.IssuesFsmCmd{})
+	reg.Register(&cli.RepoInstallCmd{})
 
 	// Discover hub: walk up from cwd to find .cn/.
 	hubPath := discoverHub()

--- a/src/go/internal/cli/cmd_repo_install.go
+++ b/src/go/internal/cli/cmd_repo_install.go
@@ -98,21 +98,26 @@ func (c *RepoInstallCmd) Run(ctx context.Context, inv Invocation) error {
 		return err
 	}
 
-	// Repo-root resolution: reuse the existing gitRepoRoot helper
-	// (cmd_cell.go) rather than duplicating a `git rev-parse
-	// --show-toplevel` wrapper. inv.HubPath is only populated when
-	// main.go's discoverHub found an existing .cn/ directory — the
-	// common case for a fresh repo is an empty HubPath, since this
-	// command's entire purpose is to run before .cn/ exists.
-	repoRoot := inv.HubPath
-	if repoRoot == "" {
-		root, gerr := gitRepoRoot(ctx)
-		if gerr != nil {
-			fmt.Fprintf(inv.Stderr, "✗ cn repo install must be run inside a Git repository.\n")
-			return fmt.Errorf("repo install: not inside a git repository: %w", gerr)
-		}
-		repoRoot = root
+	// Repo-root resolution: ALWAYS resolve via the actual git repository
+	// root (git rev-parse --show-toplevel, wrapped by gitRepoRoot in
+	// cmd_cell.go) — never via inv.HubPath. inv.HubPath is populated by
+	// main.go's discoverHub(), which walks upward from cwd looking for
+	// ANY ancestor .cn/ directory, with no bound at the current git
+	// repository's root and no check that the found directory is even a
+	// git repository at all. Trusting inv.HubPath here would let an
+	// unrelated ancestor .cn/ (a different project, a stale hub, a
+	// parent workspace, a monorepo-of-repos layout) silently hijack the
+	// install root — exactly the scenario `cn repo install` must guard
+	// against, since its entire premise is running in a repo that has no
+	// .cn/ yet (β R0 finding, cnos#608). Always ask git directly; this
+	// also makes the "not inside a git repository" failure unconditional
+	// instead of only reachable when inv.HubPath happens to be empty.
+	root, gerr := gitRepoRoot(ctx)
+	if gerr != nil {
+		fmt.Fprintf(inv.Stderr, "✗ cn repo install must be run inside a Git repository.\n")
+		return fmt.Errorf("repo install: not inside a git repository: %w", gerr)
 	}
+	repoRoot := root
 
 	opts := repoinstall.Options{
 		RepoRoot:  repoRoot,

--- a/src/go/internal/cli/cmd_repo_install.go
+++ b/src/go/internal/cli/cmd_repo_install.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/usurobor/cnos/src/go/internal/repoinstall"
+)
+
+const repoInstallHelp = `cn repo install - Install the base CNOS/CDS package set into this repository
+
+USAGE:
+  cn repo install [flags]
+
+DESCRIPTION:
+  Makes an arbitrary Git repository CDS-ready with one command (cnos#608).
+  Resolves a cnos release (or an explicit package index), writes a
+  deterministic .cn/deps.json + .cn/deps.lock.json, restores the default
+  package set (cnos.core, cnos.cdd, cnos.cds) under .cn/vendor/packages/,
+  and ensures .gitignore excludes the vendor tree.
+
+  This is a kernel (built-in) command — it runs before any hub/package
+  state exists, and before any .cn/ directory is present.
+
+  Base install never writes .github/workflows/ and never requires a
+  workflow/agent PAT. Autonomous dispatch install (--dispatch cds) is a
+  separate, explicit opt-in gated on renderer generalization (#609); until
+  that lands, --dispatch cds fails explicitly and writes nothing.
+
+FLAGS:
+  --release V     "latest" (default) or a pinned release tag (e.g. 3.82.0)
+  --index P       Package index path or http(s) URL — overrides --release
+                   (local/offline/test workflows; skips release resolution)
+  --packages CSV  Comma-separated package names (default: cnos.core,cnos.cdd,cnos.cds)
+  --dispatch D    "none" (default) — base install only.
+                  "cds" — NOT implemented until #609; fails explicitly.
+  --dry-run       Report the intended writes/fetches/restores; write nothing
+
+EXAMPLES:
+  cn repo install
+  cn repo install --release latest --packages cnos.core,cnos.cdd,cnos.cds --dispatch none
+  cn repo install --dry-run
+  cn repo install --index ./dist/packages/index.json --packages cnos.core,cnos.cdd,cnos.cds
+
+EXIT CODES:
+  0  Success (installed, or --dry-run reported the plan)
+  1  Error (not a git repo, package/index resolution failure, restore
+     failure, or --dispatch cds)
+
+INVARIANTS:
+  - .cn/deps.json / .cn/deps.lock.json: deterministic (stable order, no
+    timestamps), byte-identical across repeated runs with the same inputs.
+  - .cn/vendor/packages/<name>/: name-based path (not <name>@<version>/).
+  - Idempotent: a second run produces no further git diff.
+  - No agent-hub scaffold is written (no spec/SOUL.md, agent/, threads/,
+    state/) — contrast with 'cn init'.
+`
+
+// RepoInstallCmd implements "cn repo install" (cnos#608) — the base
+// CNOS/CDS package installer. Resolves via the noun-verb dispatcher
+// (cli.ResolveCommand builds the "repo"+"-"+"install" = "repo-install"
+// lookup key), the same mechanism already used by "cn cell finalize" /
+// "cn issues fsm".
+//
+// NeedsHub is false: this command must run before any .cn/ hub exists —
+// that is the entire point of a repo installer.
+//
+// Domain logic lives in internal/repoinstall (eng/go §2.18); this file
+// owns only flag parsing + git-root resolution + dispatch wiring.
+type RepoInstallCmd struct{}
+
+func (c *RepoInstallCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "repo-install",
+		Summary:  "Install the base CNOS/CDS package set into this repository",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: false,
+	}
+}
+
+func (c *RepoInstallCmd) Help() string {
+	return repoInstallHelp
+}
+
+func (c *RepoInstallCmd) Run(ctx context.Context, inv Invocation) error {
+	for _, a := range inv.Args {
+		if a == "--help" || a == "-h" {
+			fmt.Fprint(inv.Stdout, repoInstallHelp)
+			return nil
+		}
+	}
+
+	args, err := repoinstall.ParseArgs(inv.Args)
+	if err != nil {
+		fmt.Fprintf(inv.Stderr, "✗ cn repo install: %s\n\n", err)
+		fmt.Fprint(inv.Stderr, repoInstallHelp)
+		return err
+	}
+
+	// Repo-root resolution: reuse the existing gitRepoRoot helper
+	// (cmd_cell.go) rather than duplicating a `git rev-parse
+	// --show-toplevel` wrapper. inv.HubPath is only populated when
+	// main.go's discoverHub found an existing .cn/ directory — the
+	// common case for a fresh repo is an empty HubPath, since this
+	// command's entire purpose is to run before .cn/ exists.
+	repoRoot := inv.HubPath
+	if repoRoot == "" {
+		root, gerr := gitRepoRoot(ctx)
+		if gerr != nil {
+			fmt.Fprintf(inv.Stderr, "✗ cn repo install must be run inside a Git repository.\n")
+			return fmt.Errorf("repo install: not inside a git repository: %w", gerr)
+		}
+		repoRoot = root
+	}
+
+	opts := repoinstall.Options{
+		RepoRoot:  repoRoot,
+		Release:   args.Release,
+		IndexPath: args.IndexPath,
+		Packages:  args.Packages,
+		Dispatch:  args.Dispatch,
+		DryRun:    args.DryRun,
+		Stdout:    inv.Stdout,
+		Stderr:    inv.Stderr,
+	}
+
+	_, err = repoinstall.Run(ctx, opts)
+	return err
+}

--- a/src/go/internal/cli/cmd_repo_install_test.go
+++ b/src/go/internal/cli/cmd_repo_install_test.go
@@ -1,0 +1,293 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+)
+
+// --- fixtures ---
+
+func makeRepoInstallTarGz(t *testing.T, files map[string]string) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tw.Close()
+	gw.Close()
+	data := buf.Bytes()
+	h := sha256.Sum256(data)
+	return data, hex.EncodeToString(h[:])
+}
+
+// writeFixtureIndex writes a single-package, single-version index.json +
+// tarball to a temp dir (relative URL, like `cn build` produces) and
+// returns the index path.
+func writeFixtureIndex(t *testing.T, name, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := `{"name": "` + name + `", "version": "` + version + `"}`
+	tarData, sha := makeRepoInstallTarGz(t, map[string]string{"cn.package.json": manifest})
+	tarName := name + "-" + version + ".tar.gz"
+	if err := os.WriteFile(filepath.Join(dir, tarName), tarData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			name: {version: {URL: tarName, SHA256: sha}},
+		},
+	}
+	indexPath := filepath.Join(dir, "index.json")
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(indexPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return indexPath
+}
+
+// initGitRepo runs `git init` (+ minimal identity config) in dir.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@cnos.test")
+	runGit(t, dir, "config", "user.name", "cnos-test")
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func runRepoInstall(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := &RepoInstallCmd{}
+	err := cmd.Run(context.Background(), Invocation{
+		Args:   args,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	return stdout.String(), stderr.String(), err
+}
+
+// --- dispatch wiring ---
+
+// AC1 (dispatch shape): "cn repo install" resolves via the kernel
+// registry's noun-verb resolution to RepoInstallCmd, the same mechanism
+// already used by "cn cell finalize" / "cn issues fsm".
+func TestRepoInstall_ResolvesViaNounVerb(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(&RepoInstallCmd{})
+
+	res := ResolveCommand(reg, []string{"repo", "install", "--dry-run"})
+	if res.Command == nil {
+		t.Fatal("expected 'repo install' to resolve to a command")
+	}
+	if res.Command.Spec().Name != "repo-install" {
+		t.Errorf("resolved command = %q, want repo-install", res.Command.Spec().Name)
+	}
+	if got := res.Command.Spec(); got.Source != SourceKernel || got.Tier != TierKernel || got.NeedsHub {
+		t.Errorf("spec = %+v, want kernel/kernel-tier/NeedsHub=false", got)
+	}
+}
+
+func TestRepoInstall_HelpFlag(t *testing.T) {
+	stdout, _, err := runRepoInstall(t, []string{"--help"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"cn repo install", "--release", "--index", "--packages", "--dispatch", "--dry-run"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("--help output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRepoInstall_UnknownFlag(t *testing.T) {
+	_, stderr, err := runRepoInstall(t, []string{"--bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	if !strings.Contains(stderr, "--bogus") {
+		t.Errorf("stderr should name the unknown flag, got: %q", stderr)
+	}
+}
+
+// AC1: fails with a clear error if not at a git repo root — does not
+// silently walk up or scaffold anything.
+func TestRepoInstall_NotAGitRepo_FailsClearly(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	_, stderr, err := runRepoInstall(t, []string{"--dry-run"})
+	if err == nil {
+		t.Fatal("expected error outside a git repository")
+	}
+	if !strings.Contains(stderr, "✗ cn repo install must be run inside a Git repository.") {
+		t.Errorf("stderr = %q, want the exact git-repo-required message", stderr)
+	}
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("must not scaffold anything when not a git repo; found: %v", entries)
+	}
+}
+
+// AC1 end-to-end: a fresh `git init`-only repo, no .cn/ hub, no vendor
+// packages, no prior state — cn repo install succeeds and the three-file
+// diff exists.
+func TestRepoInstall_FreshGitRepo_EndToEnd(t *testing.T) {
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	stdout, stderr, err := runRepoInstall(t, []string{
+		"--index", indexPath,
+		"--packages", "cnos.core",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	for _, f := range []string{
+		filepath.Join(".cn", "deps.json"),
+		filepath.Join(".cn", "deps.lock.json"),
+		".gitignore",
+	} {
+		if _, statErr := os.Stat(filepath.Join(repoDir, f)); statErr != nil {
+			t.Errorf("expected %s to exist: %v", f, statErr)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, ".cn", "vendor", "packages", "cnos.core", "cn.package.json")); statErr != nil {
+		t.Errorf("cnos.core not restored: %v", statErr)
+	}
+}
+
+// AC5: cn repo install; git diff --exit-code; cn repo install; git diff
+// --exit-code — both must exit 0, and (the stronger form) git status
+// --porcelain is empty after committing once and re-running.
+func TestRepoInstall_Idempotent_NoDiffOnSecondRun(t *testing.T) {
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	args := []string{"--index", indexPath, "--packages", "cnos.core"}
+
+	if _, stderr, err := runRepoInstall(t, args); err != nil {
+		t.Fatalf("first install: %v\n%s", err, stderr)
+	}
+	runGit(t, repoDir, "diff", "--exit-code")
+
+	runGit(t, repoDir, "add", ".cn/deps.json", ".cn/deps.lock.json", ".gitignore")
+	runGit(t, repoDir, "commit", "-q", "-m", "install cds base layer")
+
+	if _, stderr, err := runRepoInstall(t, args); err != nil {
+		t.Fatalf("second install: %v\n%s", err, stderr)
+	}
+	runGit(t, repoDir, "diff", "--exit-code")
+
+	status := runGit(t, repoDir, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("git status --porcelain not empty after second install:\n%s", status)
+	}
+}
+
+// AC6: --dry-run writes nothing; git status --porcelain stays empty.
+func TestRepoInstall_DryRun_GitStatusStaysClean(t *testing.T) {
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	stdout, stderr, err := runRepoInstall(t, []string{"--index", indexPath, "--packages", "cnos.core", "--dry-run"})
+	if err != nil {
+		t.Fatalf("Run: %v\n%s", err, stderr)
+	}
+	for _, want := range []string{".cn/deps.json", ".cn/deps.lock.json", ".gitignore"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("dry-run stdout missing %q:\n%s", want, stdout)
+		}
+	}
+
+	status := runGit(t, repoDir, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("git status --porcelain not empty after --dry-run:\n%s", status)
+	}
+}
+
+// AC9: --dispatch cds fails explicitly through the full CLI wiring, with
+// no partial .github/workflows/cnos-cds-dispatch.yml.
+func TestRepoInstall_DispatchCds_CliWiring(t *testing.T) {
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	_, stderr, err := runRepoInstall(t, []string{"--index", indexPath, "--dispatch", "cds"})
+	if err == nil {
+		t.Fatal("expected --dispatch cds to fail")
+	}
+	if !strings.Contains(stderr, "#609") {
+		t.Errorf("stderr should name #609, got: %q", stderr)
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, ".github")); !os.IsNotExist(statErr) {
+		t.Error(".github must not exist after --dispatch cds fails")
+	}
+}
+
+// AC10 regression guard: cn repo install must not scaffold the agent-hub
+// tree that cn init writes (spec/SOUL.md, agent/, threads/, state/).
+func TestRepoInstall_NoAgentHubScaffold(t *testing.T) {
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	if _, stderr, err := runRepoInstall(t, []string{"--index", indexPath, "--packages", "cnos.core"}); err != nil {
+		t.Fatalf("Run: %v\n%s", err, stderr)
+	}
+	for _, p := range []string{"spec", "agent", "threads", "state"} {
+		if _, statErr := os.Stat(filepath.Join(repoDir, p)); !os.IsNotExist(statErr) {
+			t.Errorf("agent-hub path %q must not exist after cn repo install", p)
+		}
+	}
+}

--- a/src/go/internal/cli/cmd_repo_install_test.go
+++ b/src/go/internal/cli/cmd_repo_install_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -289,5 +290,164 @@ func TestRepoInstall_NoAgentHubScaffold(t *testing.T) {
 		if _, statErr := os.Stat(filepath.Join(repoDir, p)); !os.IsNotExist(statErr) {
 			t.Errorf("agent-hub path %q must not exist after cn repo install", p)
 		}
+	}
+}
+
+// --- real dispatch-path regression (cnos#608 β R0 finding) ---
+//
+// Every test above drives RepoInstallCmd.Run directly via
+// runRepoInstall, which hand-constructs an Invocation{HubPath: ""}. That
+// bypasses main.go's discoverHub() entirely — the function that
+// populates inv.HubPath in the real `cn` binary by walking upward from
+// cwd looking for ANY ancestor .cn/ directory, unbounded by the current
+// git repository's root and without ever checking that the found
+// directory is itself a git repository. β's R0 review found that
+// cmd_repo_install.go used to trust a non-empty inv.HubPath as the
+// install root outright, skipping the git-repo-root check entirely —
+// and that no test in the original diff could have caught it, because
+// the test harness never exercises the inv.HubPath != "" branch through
+// a faithful discoverHub()-shaped path.
+//
+// The tests below close that gap by building the actual cn binary and
+// invoking it as a subprocess — main.go's real discoverHub() runs, not a
+// reimplementation of it — against a cwd that (a) is not a git repo at
+// all and (b) has an unrelated ancestor .cn/ directory that discoverHub
+// would find.
+
+// buildCnBinary builds the real `cn` binary once per test (from the
+// module root, mirroring the `(cd src/go && go build -o $CN_BIN
+// ./cmd/cn)` convention already used by the shell test harnesses under
+// src/packages/cnos.cdd/commands/cdd-verify/) and returns its path.
+func buildCnBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "cn")
+	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/cn")
+	cmd.Dir = repoGoModuleRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build ./cmd/cn: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// repoGoModuleRoot resolves the src/go module root from this test file's
+// own path (runtime.Caller), independent of the process's current
+// working directory — several sibling tests in this file call
+// t.Chdir, and this helper must not depend on ordering relative to
+// those.
+func repoGoModuleRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	// thisFile: .../src/go/internal/cli/cmd_repo_install_test.go
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+// AC1 (real dispatch path): cwd is NOT inside any git repository at all,
+// but an unrelated ancestor directory happens to contain a .cn/
+// directory (e.g. a different project, a stale hub, a parent
+// workspace). main.go's discoverHub() will find that ancestor and
+// populate inv.HubPath with it. cn repo install must still fail with
+// AC1's exact error — it must never silently treat the discovered
+// ancestor as the install root, and must not touch it.
+func TestRepoInstall_RealDispatch_AncestorHubOutsideGitRepo_FailsClearly(t *testing.T) {
+	binPath := buildCnBinary(t)
+
+	// Layout:
+	//   outer/.cn/                        <- unrelated ancestor "hub"; not a git repo itself
+	//   outer/nested/not-a-git-repo/      <- cwd; not inside any git repo
+	outer := t.TempDir()
+	ancestorHub := filepath.Join(outer, ".cn")
+	if err := os.MkdirAll(ancestorHub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(outer, "nested", "not-a-git-repo")
+	if err := os.MkdirAll(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(binPath, "repo", "install", "--dry-run")
+	cmd.Dir = cwd
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	if runErr == nil {
+		t.Fatalf("expected `cn repo install` to fail outside a git repository (ancestor .cn found at %s); stdout:\n%s\nstderr:\n%s", ancestorHub, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "✗ cn repo install must be run inside a Git repository.") {
+		t.Errorf("stderr = %q, want the exact AC1 git-repo-required message", stderr.String())
+	}
+
+	// The ancestor "hub" must be completely untouched — no silent
+	// walk-up install, no write of any kind under outer/ (beyond the
+	// two directories this test itself created).
+	hubEntries, rerr := os.ReadDir(ancestorHub)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(hubEntries) != 0 {
+		t.Errorf("ancestor .cn/ must not be written to; found: %v", hubEntries)
+	}
+	outerEntries, rerr := os.ReadDir(outer)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	for _, e := range outerEntries {
+		if e.Name() != ".cn" && e.Name() != "nested" {
+			t.Errorf("unexpected entry written under the ancestor directory: %s", e.Name())
+		}
+	}
+}
+
+// AC1 (real dispatch path, control case): the same ancestor-.cn/ layout,
+// but cwd IS inside its own git repository (nested under the ancestor
+// hub, mirroring a monorepo-of-repos layout). discoverHub() still finds
+// the unrelated ancestor .cn/ first (it walks up from cwd and stops at
+// the first .cn/ found, which sits above the inner git repo's root), so
+// this must also resolve to the INNER repo's root — never the
+// ancestor's — and must succeed there, not silently install into the
+// ancestor.
+func TestRepoInstall_RealDispatch_AncestorHubWithNestedGitRepo_UsesInnerRoot(t *testing.T) {
+	binPath := buildCnBinary(t)
+	indexPath := writeFixtureIndex(t, "cnos.core", "9.9.9")
+
+	outer := t.TempDir()
+	ancestorHub := filepath.Join(outer, ".cn")
+	if err := os.MkdirAll(ancestorHub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	innerRepo := filepath.Join(outer, "nested", "actual-git-repo")
+	if err := os.MkdirAll(innerRepo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, innerRepo)
+
+	cmd := exec.Command(binPath, "repo", "install", "--index", indexPath, "--packages", "cnos.core")
+	cmd.Dir = innerRepo
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("cn repo install: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Git repository root: "+innerRepo) {
+		t.Errorf("stdout should report the inner repo as the resolved root, got:\n%s", stdout.String())
+	}
+
+	if _, statErr := os.Stat(filepath.Join(innerRepo, ".cn", "deps.json")); statErr != nil {
+		t.Errorf("expected .cn/deps.json to be written under the inner repo root: %v", statErr)
+	}
+
+	ancestorEntries, rerr := os.ReadDir(ancestorHub)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(ancestorEntries) != 0 {
+		t.Errorf("ancestor .cn/ must not be written to; found: %v", ancestorEntries)
 	}
 }

--- a/src/go/internal/hubsetup/hubsetup.go
+++ b/src/go/internal/hubsetup/hubsetup.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	// 3. .gitignore entry for .cn/vendor/.
-	if err := ensureGitignoreEntry(opts.HubPath, opts.Stdout); err != nil {
+	if err := EnsureGitignoreEntry(opts.HubPath, opts.Stdout); err != nil {
 		return err
 	}
 
@@ -120,9 +120,14 @@ func ensureDefaultDeps(path, version string, stdout io.Writer) error {
 	return nil
 }
 
-// ensureGitignoreEntry adds ".cn/vendor/" to .gitignore if it is not
+// EnsureGitignoreEntry adds ".cn/vendor/" to .gitignore if it is not
 // already present. Creates .gitignore if it does not exist. Idempotent.
-func ensureGitignoreEntry(hubPath string, stdout io.Writer) error {
+//
+// Exported (cnos#608) so cn repo install (internal/repoinstall) can reuse
+// this exact logic rather than duplicating it — cn setup and cn repo
+// install both need the same ".cn/vendor/" gitignore invariant, and this
+// is the single canonical writer.
+func EnsureGitignoreEntry(hubPath string, stdout io.Writer) error {
 	giPath := filepath.Join(hubPath, ".gitignore")
 	entry := ".cn/vendor/"
 

--- a/src/go/internal/repoinstall/repoinstall.go
+++ b/src/go/internal/repoinstall/repoinstall.go
@@ -1,0 +1,557 @@
+// Package repoinstall implements `cn repo install` — the base CNOS/CDS
+// package installer (cnos#608).
+//
+// It makes an arbitrary Git repository CDS-ready with one command: it
+// resolves a cnos release (or an explicit package index), writes a
+// deterministic .cn/deps.json + .cn/deps.lock.json, restores the default
+// package set (cnos.core, cnos.cdd, cnos.cds) under .cn/vendor/packages/,
+// and ensures .gitignore excludes the vendor tree.
+//
+// This package reuses the existing lock/restore substrate directly
+// (internal/restore) rather than reimplementing SHA-256 verification or
+// lockfile generation — see restore.GenerateLockFromIndex and
+// restore.Restore. It does not write any agent-hub scaffold (cf.
+// internal/hubinit, which cn init uses) and it never touches
+// .github/workflows/ in base mode: --dispatch cds is explicitly gated
+// until #609 (renderer generalization) lands.
+//
+// This package is cli/-boundary compliant per eng/go §2.18: all domain
+// logic lives here, and cli/cmd_repo_install.go is a thin wrapper.
+package repoinstall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/usurobor/cnos/src/go/internal/binupdate"
+	"github.com/usurobor/cnos/src/go/internal/hubsetup"
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/restore"
+)
+
+// DefaultRepo is the GitHub "owner/repo" slug releases are resolved
+// against absent an override (tests point this at a fixture server).
+const DefaultRepo = "usurobor/cnos"
+
+const (
+	defaultAPIBaseURL  = "https://api.github.com"
+	defaultDownloadURL = "https://github.com"
+
+	// manifestSchema/manifestProfile are the exact wire values written to
+	// .cn/deps.json. Per the implementation contract these must not change
+	// shape — pkg.Manifest is the canonical type (schema "cn.deps.v1").
+	manifestSchema  = "cn.deps.v1"
+	manifestProfile = "cds"
+)
+
+// DefaultPackages is the base package set `cn repo install` pins absent
+// an explicit --packages override. Order is significant: it is the order
+// written to .cn/deps.json (manifest order is operator-controlled, per
+// restore.GenerateLockFromIndex's own doc comment; the lockfile it
+// generates is independently sorted for determinism).
+var DefaultPackages = []string{"cnos.core", "cnos.cdd", "cnos.cds"}
+
+// httpClientDefault mirrors the timeout used by restore.go/binupdate.go
+// (OCaml curl flags: --connect-timeout 10 --max-time 300).
+var httpClientDefault = &http.Client{Timeout: 300 * time.Second}
+
+// Args is the parsed flag set for `cn repo install`.
+type Args struct {
+	Release   string   // "" or "latest" resolves the newest release; anything else pins a tag
+	IndexPath string   // --index override: local path or http(s) URL
+	Packages  []string // --packages csv override; nil uses DefaultPackages
+	Dispatch  string   // "" / "none" (default) or "cds"
+	DryRun    bool
+}
+
+// ParseArgs parses the `cn repo install` flag set. Two-token
+// "--flag value" form only, matching the convention in
+// internal/cell.ParseFinalizeArgs.
+func ParseArgs(argv []string) (Args, error) {
+	var a Args
+	for i := 0; i < len(argv); i++ {
+		switch argv[i] {
+		case "--dry-run":
+			a.DryRun = true
+		case "--release":
+			v, err := takeValue(argv, &i, "--release")
+			if err != nil {
+				return a, err
+			}
+			a.Release = v
+		case "--index":
+			v, err := takeValue(argv, &i, "--index")
+			if err != nil {
+				return a, err
+			}
+			a.IndexPath = v
+		case "--packages":
+			v, err := takeValue(argv, &i, "--packages")
+			if err != nil {
+				return a, err
+			}
+			a.Packages = splitPackages(v)
+		case "--dispatch":
+			v, err := takeValue(argv, &i, "--dispatch")
+			if err != nil {
+				return a, err
+			}
+			a.Dispatch = v
+		default:
+			return a, fmt.Errorf("unknown flag %q", argv[i])
+		}
+	}
+	return a, nil
+}
+
+func takeValue(argv []string, i *int, flag string) (string, error) {
+	if *i+1 >= len(argv) {
+		return "", fmt.Errorf("%s requires a value", flag)
+	}
+	*i++
+	return argv[*i], nil
+}
+
+func splitPackages(csv string) []string {
+	var out []string
+	for _, p := range strings.Split(csv, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Options carries the runtime configuration for a `cn repo install` run.
+type Options struct {
+	// RepoRoot is the resolved Git repository root to install into.
+	// Required — git-root detection is the caller's responsibility
+	// (cli/cmd_repo_install.go, mirroring cli/cmd_cell.go's gitRepoRoot
+	// precedent) so this package stays testable with a plain t.TempDir().
+	RepoRoot string
+
+	Release   string
+	IndexPath string
+	Packages  []string
+	Dispatch  string
+	DryRun    bool
+
+	// Repo is the "owner/repo" slug used to resolve releases and
+	// construct download URLs. Defaults to DefaultRepo.
+	Repo string
+	// HTTPClient, APIBaseURL, DownloadBase allow tests to point release
+	// resolution and index/tarball fetches at an httptest.Server, mirroring
+	// binupdate.Options' equivalent test seams.
+	HTTPClient   *http.Client
+	APIBaseURL   string
+	DownloadBase string
+
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Result records the outcome of a Run, for tests that want structured
+// assertions beyond stdout scraping.
+type Result struct {
+	// ReleaseTag is the resolved release tag. Empty when an explicit
+	// --index value was used with no --release override (index-only flow).
+	ReleaseTag string
+	Manifest   pkg.Manifest
+	DryRun     bool
+}
+
+// Run executes `cn repo install` against opts.RepoRoot.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	if err := validateDispatch(opts.Dispatch); err != nil {
+		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+		return nil, err
+	}
+	if opts.RepoRoot == "" {
+		return nil, fmt.Errorf("repo install: RepoRoot is required")
+	}
+
+	repo := opts.Repo
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	apiBase := opts.APIBaseURL
+	if apiBase == "" {
+		apiBase = defaultAPIBaseURL
+	}
+	dlBase := opts.DownloadBase
+	if dlBase == "" {
+		dlBase = defaultDownloadURL
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = httpClientDefault
+	}
+
+	names := opts.Packages
+	if len(names) == 0 {
+		names = append([]string(nil), DefaultPackages...)
+	}
+
+	fmt.Fprintf(opts.Stdout, "→ cn repo install")
+	if opts.DryRun {
+		fmt.Fprintf(opts.Stdout, " (dry-run) — no files will be written")
+	}
+	fmt.Fprintln(opts.Stdout)
+	fmt.Fprintf(opts.Stdout, "✓ Git repository root: %s\n", opts.RepoRoot)
+
+	idxPath, idx, releaseTag, cleanup, err := resolveIndex(ctx, client, apiBase, dlBase, repo, opts.Release, opts.IndexPath)
+	if err != nil {
+		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+		return nil, err
+	}
+	defer cleanup()
+
+	if releaseTag != "" {
+		fmt.Fprintf(opts.Stdout, "✓ Resolved cnos release: %s\n", releaseTag)
+	} else {
+		fmt.Fprintf(opts.Stdout, "✓ Using package index: %s\n", opts.IndexPath)
+	}
+
+	deps, err := resolvePins(idx, names, releaseTag)
+	if err != nil {
+		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+		return nil, err
+	}
+
+	manifest := pkg.Manifest{Schema: manifestSchema, Profile: manifestProfile, Packages: deps}
+	plannedFiles := []string{
+		filepath.Join(".cn", "deps.json"),
+		filepath.Join(".cn", "deps.lock.json"),
+		".gitignore",
+	}
+
+	if opts.DryRun {
+		printPlan(opts.Stdout, manifest, plannedFiles, releaseTag, opts.IndexPath)
+		return &Result{ReleaseTag: releaseTag, Manifest: manifest, DryRun: true}, nil
+	}
+
+	if err := applyInstall(ctx, opts, manifest, idxPath); err != nil {
+		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+		return nil, err
+	}
+
+	fmt.Fprintf(opts.Stdout, "Dispatch: none (base install only — no .github/workflows/ changes)\n")
+	fmt.Fprintf(opts.Stdout, "\n✓ cn repo install complete.\n")
+
+	return &Result{ReleaseTag: releaseTag, Manifest: manifest, DryRun: false}, nil
+}
+
+// validateDispatch enforces the base/dispatch trust-layer split (Mock B4 /
+// AC9): --dispatch cds must fail explicitly, before any write, until the
+// wake renderer is generalized (#609).
+func validateDispatch(d string) error {
+	switch d {
+	case "", "none":
+		return nil
+	case "cds":
+		return fmt.Errorf("--dispatch cds requires generalized wake renderer support (#609)")
+	default:
+		return fmt.Errorf("unknown --dispatch value %q (want \"none\" or \"cds\")", d)
+	}
+}
+
+// applyInstall performs the non-dry-run write path: .cn/deps.json,
+// .cn/deps.lock.json (via restore.GenerateLockFromIndex), package restore
+// (via restore.Restore), and the .gitignore entry (via
+// hubsetup.EnsureGitignoreEntry — reused, not duplicated).
+func applyInstall(ctx context.Context, opts Options, manifest pkg.Manifest, idxPath string) error {
+	cnDir := filepath.Join(opts.RepoRoot, ".cn")
+	if err := os.MkdirAll(cnDir, 0755); err != nil {
+		return fmt.Errorf("create .cn: %w", err)
+	}
+
+	manifestPath := filepath.Join(cnDir, "deps.json")
+	if err := writeManifest(manifestPath, manifest); err != nil {
+		return err
+	}
+	fmt.Fprintf(opts.Stdout, "✓ wrote .cn/deps.json\n")
+
+	lockResult, err := restore.GenerateLockFromIndex(opts.RepoRoot, idxPath)
+	if err != nil {
+		return fmt.Errorf("deps lock: %w", err)
+	}
+	fmt.Fprintf(opts.Stdout, "✓ wrote .cn/deps.lock.json (%d package(s))\n", lockResult.Count)
+
+	installed, err := restore.Restore(ctx, opts.RepoRoot, idxPath)
+	if err != nil {
+		return fmt.Errorf("deps restore: %w", err)
+	}
+	if restore.HasErrors(installed) {
+		for _, r := range restore.Errors(installed) {
+			fmt.Fprintf(opts.Stderr, "✗ %s@%s: %v\n", r.Name, r.Version, r.Err)
+		}
+		return fmt.Errorf("deps restore: %d package(s) failed", len(restore.Errors(installed)))
+	}
+	for _, r := range installed {
+		fmt.Fprintf(opts.Stdout, "✓ restored %s@%s\n", r.Name, r.Version)
+	}
+
+	if err := hubsetup.EnsureGitignoreEntry(opts.RepoRoot, opts.Stdout); err != nil {
+		return fmt.Errorf("gitignore: %w", err)
+	}
+
+	return nil
+}
+
+// writeManifest writes .cn/deps.json deterministically: stable field
+// order (json.MarshalIndent over a struct, not a map), the exact package
+// order Run resolved (operator-controlled, per restore.go's own
+// determinism comment), and no timestamp field.
+func writeManifest(path string, m pkg.Manifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal deps.json: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write deps.json: %w", err)
+	}
+	return nil
+}
+
+// printPlan renders the --dry-run report (Mock A). It writes nothing to
+// disk — the caller (Run) returns immediately after this call.
+func printPlan(w io.Writer, m pkg.Manifest, plannedFiles []string, releaseTag, indexArg string) {
+	if releaseTag != "" {
+		fmt.Fprintf(w, "  Would fetch package index + tarballs for release %s (%d package(s))\n", releaseTag, len(m.Packages))
+	} else {
+		fmt.Fprintf(w, "  Would fetch package index from %s (%d package(s))\n", indexArg, len(m.Packages))
+	}
+	fmt.Fprintf(w, "  Would write .cn/deps.json:\n")
+	for _, d := range m.Packages {
+		fmt.Fprintf(w, "      %-12s %s\n", d.Name, d.Version)
+	}
+	fmt.Fprintf(w, "  Would run: (internal) deps lock    → .cn/deps.lock.json\n")
+	fmt.Fprintf(w, "  Would run: (internal) deps restore → .cn/vendor/packages/ (%d package(s))\n", len(m.Packages))
+	fmt.Fprintf(w, "  Would ensure .gitignore contains: .cn/vendor/\n")
+	fmt.Fprintf(w, "Dispatch: none (base install only — no .github/workflows/ changes)\n\n")
+	fmt.Fprintf(w, "Planned committed diff (%d files):\n", len(plannedFiles))
+	for _, f := range plannedFiles {
+		fmt.Fprintf(w, "  %s\n", f)
+	}
+	fmt.Fprintf(w, "\nRun without --dry-run to apply.\n")
+}
+
+// --- Index resolution ---
+
+// resolveIndex determines the package index to install from. It returns
+// a local file path that restore.GenerateLockFromIndex/restore.Restore can
+// read directly, the parsed index (for pin resolution), the resolved
+// release tag ("" when an explicit --index value was used with no
+// --release override), and a cleanup func removing any temp files this
+// call created (always non-nil; safe to defer unconditionally).
+func resolveIndex(ctx context.Context, client *http.Client, apiBase, dlBase, repo, release, indexArg string) (indexPath string, idx *pkg.PackageIndex, releaseTag string, cleanup func(), err error) {
+	noop := func() {}
+
+	pinFromRelease := ""
+	if release != "" && release != "latest" {
+		pinFromRelease = release
+	}
+
+	if indexArg != "" {
+		if isRemoteURL(indexArg) {
+			body, ferr := fetchBytes(ctx, client, indexArg)
+			if ferr != nil {
+				return "", nil, "", noop, fmt.Errorf("fetch package index %s: %w", indexArg, ferr)
+			}
+			parsed, perr := pkg.ParsePackageIndex(body)
+			if perr != nil {
+				return "", nil, "", noop, fmt.Errorf("parse package index %s: %w", indexArg, perr)
+			}
+			rewritten := rewriteRelativeEntries(parsed, indexArg)
+			tmpPath, tmpCleanup, werr := writeTempIndex(rewritten)
+			if werr != nil {
+				return "", nil, "", noop, werr
+			}
+			return tmpPath, rewritten, pinFromRelease, tmpCleanup, nil
+		}
+
+		data, rerr := os.ReadFile(indexArg)
+		if rerr != nil {
+			return "", nil, "", noop, fmt.Errorf("read package index %s: %w", indexArg, rerr)
+		}
+		parsed, perr := pkg.ParsePackageIndex(data)
+		if perr != nil {
+			return "", nil, "", noop, fmt.Errorf("parse package index %s: %w", indexArg, perr)
+		}
+		// Local path: used directly, exactly like the existing
+		// cn build → dist/ → cn deps restore dev workflow — relative
+		// tarball URLs are resolved by restore.go against indexPath's
+		// own directory, so no rewriting is needed here.
+		return indexArg, parsed, pinFromRelease, noop, nil
+	}
+
+	// No explicit --index: resolve a release and fetch its index.
+	tag := release
+	if tag == "" || tag == "latest" {
+		rel, rerr := binupdate.FetchLatestRelease(ctx, client, apiBase, repo)
+		if rerr != nil {
+			return "", nil, "", noop, fmt.Errorf("resolve latest cnos release: %w", rerr)
+		}
+		tag = rel.Tag
+	}
+
+	base := fmt.Sprintf("%s/%s/releases/download/%s/", dlBase, repo, tag)
+	indexURL := base + "index.json"
+	body, ferr := fetchBytes(ctx, client, indexURL)
+	if ferr != nil {
+		return "", nil, "", noop, fmt.Errorf("fetch package index for release %s: %w", tag, ferr)
+	}
+	parsed, perr := pkg.ParsePackageIndex(body)
+	if perr != nil {
+		return "", nil, "", noop, fmt.Errorf("parse package index for release %s: %w", tag, perr)
+	}
+
+	rewritten := rewriteRelativeEntriesFromBase(parsed, base)
+	tmpPath, tmpCleanup, werr := writeTempIndex(rewritten)
+	if werr != nil {
+		return "", nil, "", noop, werr
+	}
+	return tmpPath, rewritten, tag, tmpCleanup, nil
+}
+
+// isRemoteURL returns true if the URL has an http:// or https:// scheme.
+// Mirrors restore.go's unexported helper of the same name/behavior — kept
+// local rather than exported cross-package because it is a one-line
+// string check, not a shared parser (eng/go §2.17 governs parser
+// duplication, not trivial scheme checks).
+func isRemoteURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// fetchBytes GETs url and returns the response body. Used for both
+// index.json fetches (release + explicit --index URL forms).
+func fetchBytes(ctx context.Context, client *http.Client, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http get: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http status %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// rewriteRelativeEntries rewrites relative tarball URLs in idx against
+// the directory of indexURL (an http(s) URL the index itself was fetched
+// from). Absolute (http/https) entries are left untouched.
+func rewriteRelativeEntries(idx *pkg.PackageIndex, indexURL string) *pkg.PackageIndex {
+	u, err := url.Parse(indexURL)
+	if err != nil {
+		// indexURL was already successfully fetched via this exact string,
+		// so a parse failure here would be unreachable in practice; fall
+		// back to leaving entries untouched rather than panicking.
+		return idx
+	}
+	dir := *u
+	dir.Path = path.Dir(u.Path) + "/"
+	dir.RawQuery = ""
+	dir.Fragment = ""
+	return rewriteRelativeEntriesFromBase(idx, dir.String())
+}
+
+// rewriteRelativeEntriesFromBase returns a copy of idx with every
+// relative (non-http, non-absolute-path) tarball URL prefixed with base.
+// Implementation requirement 4 (issue #608): normalize the index into a
+// form restore.Restore's existing fetchTarball can consume — after this
+// rewrite, every entry is an absolute http(s) URL, so fetchTarball's
+// isRemoteURL branch always fires regardless of indexDir.
+func rewriteRelativeEntriesFromBase(idx *pkg.PackageIndex, base string) *pkg.PackageIndex {
+	out := &pkg.PackageIndex{Schema: idx.Schema, Packages: make(map[string]map[string]pkg.IndexEntry, len(idx.Packages))}
+	for name, versions := range idx.Packages {
+		outVersions := make(map[string]pkg.IndexEntry, len(versions))
+		for v, e := range versions {
+			if !isRemoteURL(e.URL) && !filepath.IsAbs(e.URL) {
+				e.URL = base + e.URL
+			}
+			outVersions[v] = e
+		}
+		out.Packages[name] = outVersions
+	}
+	return out
+}
+
+// writeTempIndex marshals idx to a temp file outside the target repo's
+// working tree (so it never appears in `git status`) and returns its
+// path plus a cleanup func.
+func writeTempIndex(idx *pkg.PackageIndex) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "cn-repo-install-index-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create temp index dir: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(dir) }
+
+	data, merr := json.MarshalIndent(idx, "", "  ")
+	if merr != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("marshal package index: %w", merr)
+	}
+	p := filepath.Join(dir, "index.json")
+	if werr := os.WriteFile(p, data, 0644); werr != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("write temp package index: %w", werr)
+	}
+	return p, cleanup, nil
+}
+
+// --- Pin resolution ---
+
+// resolvePins resolves an exact version for each requested package name
+// against idx. When pinVersion is set (a resolved release tag or an
+// explicit --release value), every package must be present at exactly
+// that version. Otherwise (index-only flow, no --release), a package
+// with exactly one version in the index resolves unambiguously to that
+// version; zero or multiple versions is an error naming the package.
+func resolvePins(idx *pkg.PackageIndex, names []string, pinVersion string) ([]pkg.ManifestDep, error) {
+	deps := make([]pkg.ManifestDep, 0, len(names))
+	var missing []string
+	var ambiguous []string
+
+	for _, name := range names {
+		versions := idx.Packages[name]
+		switch {
+		case pinVersion != "":
+			if _, ok := versions[pinVersion]; !ok {
+				missing = append(missing, fmt.Sprintf("%s@%s", name, pinVersion))
+				continue
+			}
+			deps = append(deps, pkg.ManifestDep{Name: name, Version: pinVersion})
+		case len(versions) == 1:
+			for v := range versions {
+				deps = append(deps, pkg.ManifestDep{Name: name, Version: v})
+			}
+		case len(versions) == 0:
+			missing = append(missing, name)
+		default:
+			ambiguous = append(ambiguous, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("package(s) not found in index: %s", strings.Join(missing, ", "))
+	}
+	if len(ambiguous) > 0 {
+		return nil, fmt.Errorf("package(s) have multiple versions in index; pass --release to pin one: %s", strings.Join(ambiguous, ", "))
+	}
+	return deps, nil
+}

--- a/src/go/internal/repoinstall/repoinstall_test.go
+++ b/src/go/internal/repoinstall/repoinstall_test.go
@@ -1,0 +1,725 @@
+package repoinstall
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+)
+
+// --- fixture helpers ---
+
+// makeTarGz creates a .tar.gz in memory containing the given files
+// (map of relative-path → content), writes it to a temp file, and
+// returns the raw bytes + hex SHA-256. Mirrors restore_test.go's helper
+// of the same name/shape (test-local duplication of a fixture builder,
+// not a production parser — eng/go §2.17 governs parser dedup, not test
+// fixture helpers).
+func makeTarGz(t *testing.T, files map[string]string) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tw.Close()
+	gw.Close()
+	data := buf.Bytes()
+	h := sha256.Sum256(data)
+	return data, hex.EncodeToString(h[:])
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeLocalIndex writes a single-package, single-version index.json plus
+// its tarball to a temp "dist/packages"-shaped directory (relative URL,
+// like `cn build` produces), and returns the index path.
+func writeLocalIndex(t *testing.T, name, version, manifestJSON string) string {
+	t.Helper()
+	dir := t.TempDir()
+	tarData, sha := makeTarGz(t, map[string]string{"cn.package.json": manifestJSON})
+	tarName := name + "-" + version + ".tar.gz"
+	if err := os.WriteFile(filepath.Join(dir, tarName), tarData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			name: {version: {URL: tarName, SHA256: sha}},
+		},
+	}
+	indexPath := filepath.Join(dir, "index.json")
+	writeJSON(t, indexPath, idx)
+	return indexPath
+}
+
+func noopStdio() (*bytes.Buffer, *bytes.Buffer) {
+	return &bytes.Buffer{}, &bytes.Buffer{}
+}
+
+// --- validateDispatch ---
+
+func TestValidateDispatch(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+		want609 bool
+	}{
+		{"", false, false},
+		{"none", false, false},
+		{"cds", true, true},
+		{"bogus", true, false},
+	}
+	for _, c := range cases {
+		err := validateDispatch(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateDispatch(%q) err = %v, wantErr %v", c.in, err, c.wantErr)
+			continue
+		}
+		if c.want609 && (err == nil || !strings.Contains(err.Error(), "#609")) {
+			t.Errorf("validateDispatch(%q) = %v, want mention of #609", c.in, err)
+		}
+	}
+}
+
+// --- ParseArgs ---
+
+func TestParseArgs(t *testing.T) {
+	a, err := ParseArgs([]string{
+		"--release", "3.82.0",
+		"--index", "./dist/packages/index.json",
+		"--packages", "cnos.core, cnos.cdd ,cnos.cds",
+		"--dispatch", "none",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("ParseArgs: %v", err)
+	}
+	if a.Release != "3.82.0" {
+		t.Errorf("Release = %q", a.Release)
+	}
+	if a.IndexPath != "./dist/packages/index.json" {
+		t.Errorf("IndexPath = %q", a.IndexPath)
+	}
+	want := []string{"cnos.core", "cnos.cdd", "cnos.cds"}
+	if len(a.Packages) != len(want) {
+		t.Fatalf("Packages = %v, want %v", a.Packages, want)
+	}
+	for i, p := range want {
+		if a.Packages[i] != p {
+			t.Errorf("Packages[%d] = %q, want %q", i, a.Packages[i], p)
+		}
+	}
+	if a.Dispatch != "none" {
+		t.Errorf("Dispatch = %q", a.Dispatch)
+	}
+	if !a.DryRun {
+		t.Error("DryRun = false, want true")
+	}
+}
+
+func TestParseArgs_UnknownFlag(t *testing.T) {
+	_, err := ParseArgs([]string{"--bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+func TestParseArgs_MissingValue(t *testing.T) {
+	_, err := ParseArgs([]string{"--release"})
+	if err == nil {
+		t.Fatal("expected error for missing --release value")
+	}
+}
+
+// --- resolvePins ---
+
+func TestResolvePins_PinnedVersionFound(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {"3.82.0": {URL: "u", SHA256: "s"}},
+	}}
+	deps, err := resolvePins(idx, []string{"cnos.core"}, "3.82.0")
+	if err != nil {
+		t.Fatalf("resolvePins: %v", err)
+	}
+	if len(deps) != 1 || deps[0].Name != "cnos.core" || deps[0].Version != "3.82.0" {
+		t.Errorf("deps = %+v", deps)
+	}
+}
+
+func TestResolvePins_PinnedVersionMissing(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {"1.0.0": {URL: "u", SHA256: "s"}},
+	}}
+	_, err := resolvePins(idx, []string{"cnos.core"}, "3.82.0")
+	if err == nil {
+		t.Fatal("expected error for missing pin")
+	}
+	if !strings.Contains(err.Error(), "cnos.core@3.82.0") {
+		t.Errorf("error should name the missing pin, got: %v", err)
+	}
+}
+
+func TestResolvePins_SingleVersionNoPreference(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {"9.9.9": {URL: "u", SHA256: "s"}},
+	}}
+	deps, err := resolvePins(idx, []string{"cnos.core"}, "")
+	if err != nil {
+		t.Fatalf("resolvePins: %v", err)
+	}
+	if len(deps) != 1 || deps[0].Version != "9.9.9" {
+		t.Errorf("deps = %+v", deps)
+	}
+}
+
+func TestResolvePins_MissingPackage(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{}}
+	_, err := resolvePins(idx, []string{"cnos.core"}, "")
+	if err == nil {
+		t.Fatal("expected error for missing package")
+	}
+	if !strings.Contains(err.Error(), "cnos.core") {
+		t.Errorf("error should name the missing package, got: %v", err)
+	}
+}
+
+func TestResolvePins_AmbiguousVersionsWithoutRelease(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {"1.0.0": {}, "2.0.0": {}},
+	}}
+	_, err := resolvePins(idx, []string{"cnos.core"}, "")
+	if err == nil {
+		t.Fatal("expected error for ambiguous versions")
+	}
+	if !strings.Contains(err.Error(), "--release") {
+		t.Errorf("error should suggest --release, got: %v", err)
+	}
+}
+
+// --- rewriteRelativeEntriesFromBase / rewriteRelativeEntries ---
+
+func TestRewriteRelativeEntriesFromBase(t *testing.T) {
+	idx := &pkg.PackageIndex{Schema: "cn.package-index.v1", Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {
+			"1.0.0": {URL: "cnos.core-1.0.0.tar.gz", SHA256: "s1"},
+		},
+		"cnos.cdd": {
+			"1.0.0": {URL: "https://example.com/cnos.cdd-1.0.0.tar.gz", SHA256: "s2"},
+		},
+	}}
+	out := rewriteRelativeEntriesFromBase(idx, "https://dl.example.com/owner/repo/releases/download/1.0.0/")
+
+	got := out.Packages["cnos.core"]["1.0.0"].URL
+	want := "https://dl.example.com/owner/repo/releases/download/1.0.0/cnos.core-1.0.0.tar.gz"
+	if got != want {
+		t.Errorf("relative URL rewritten = %q, want %q", got, want)
+	}
+
+	// HTTP-tarball-URL preservation: an already-absolute entry must not
+	// be touched (double-prefixing would break the fetch).
+	gotAbs := out.Packages["cnos.cdd"]["1.0.0"].URL
+	if gotAbs != "https://example.com/cnos.cdd-1.0.0.tar.gz" {
+		t.Errorf("absolute URL was mutated: %q", gotAbs)
+	}
+
+	// Original must be untouched (pure function).
+	if idx.Packages["cnos.core"]["1.0.0"].URL != "cnos.core-1.0.0.tar.gz" {
+		t.Error("rewriteRelativeEntriesFromBase mutated its input")
+	}
+}
+
+func TestRewriteRelativeEntries_DerivesBaseFromIndexURL(t *testing.T) {
+	idx := &pkg.PackageIndex{Packages: map[string]map[string]pkg.IndexEntry{
+		"cnos.core": {"1.0.0": {URL: "cnos.core-1.0.0.tar.gz"}},
+	}}
+	out := rewriteRelativeEntries(idx, "https://dl.example.com/owner/repo/releases/download/9.9.9/index.json")
+	got := out.Packages["cnos.core"]["1.0.0"].URL
+	want := "https://dl.example.com/owner/repo/releases/download/9.9.9/cnos.core-1.0.0.tar.gz"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- End-to-end Run: local index path ---
+
+func TestRun_LocalIndex_EndToEnd(t *testing.T) {
+	indexPath := writeLocalIndex(t, "cnos.core", "9.9.9", `{"name": "cnos.core", "version": "9.9.9"}`)
+	repoRoot := t.TempDir()
+
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core"},
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if res.DryRun {
+		t.Error("Result.DryRun = true, want false")
+	}
+	if res.ReleaseTag != "" {
+		t.Errorf("ReleaseTag = %q, want empty (index-only flow)", res.ReleaseTag)
+	}
+
+	// AC2/AC3: .cn/deps.json + .cn/deps.lock.json exist and parse.
+	depsPath := filepath.Join(repoRoot, ".cn", "deps.json")
+	data, err := os.ReadFile(depsPath)
+	if err != nil {
+		t.Fatalf("read deps.json: %v", err)
+	}
+	m, err := pkg.ParseManifest(data)
+	if err != nil {
+		t.Fatalf("parse deps.json: %v", err)
+	}
+	if m.Schema != "cn.deps.v1" {
+		t.Errorf("deps.json schema = %q, want cn.deps.v1", m.Schema)
+	}
+	if len(m.Packages) != 1 || m.Packages[0].Name != "cnos.core" || m.Packages[0].Version != "9.9.9" {
+		t.Errorf("deps.json packages = %+v", m.Packages)
+	}
+
+	lockPath := filepath.Join(repoRoot, ".cn", "deps.lock.json")
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read deps.lock.json: %v", err)
+	}
+	lf, err := pkg.ParseLockfile(lockData)
+	if err != nil {
+		t.Fatalf("parse deps.lock.json: %v", err)
+	}
+	if lf.Schema != "cn.lock.v2" {
+		t.Errorf("lockfile schema = %q, want cn.lock.v2", lf.Schema)
+	}
+	if len(lf.Packages) != 1 || lf.Packages[0].SHA256 == "" {
+		t.Errorf("lockfile packages = %+v, want a non-empty sha256", lf.Packages)
+	}
+
+	// AC4: package restored under the name-based vendor path.
+	pkgManifest := filepath.Join(pkg.VendorPath(repoRoot, "cnos.core"), "cn.package.json")
+	if _, err := os.Stat(pkgManifest); err != nil {
+		t.Errorf("cn.package.json not restored: %v", err)
+	}
+
+	// AC10 regression guard: no agent-hub scaffold.
+	for _, p := range []string{"spec/SOUL.md", "agent", "threads", "state"} {
+		if _, err := os.Stat(filepath.Join(repoRoot, p)); !os.IsNotExist(err) {
+			t.Errorf("agent-hub scaffold path %q must not exist (err=%v)", p, err)
+		}
+	}
+
+	// AC8: no .github/workflows/ in base mode.
+	if _, err := os.Stat(filepath.Join(repoRoot, ".github")); !os.IsNotExist(err) {
+		t.Errorf(".github must not exist after base install (err=%v)", err)
+	}
+
+	// .gitignore contains the vendor entry.
+	gi, err := os.ReadFile(filepath.Join(repoRoot, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gi), ".cn/vendor/") {
+		t.Errorf(".gitignore = %q, want .cn/vendor/ entry", gi)
+	}
+}
+
+// AC2/AC5: .cn/deps.json and .cn/deps.lock.json are byte-identical across
+// two successive runs with the same inputs (determinism + idempotence).
+func TestRun_Idempotent_ByteIdenticalArtifacts(t *testing.T) {
+	indexPath := writeLocalIndex(t, "cnos.core", "9.9.9", `{"name": "cnos.core", "version": "9.9.9"}`)
+	repoRoot := t.TempDir()
+
+	run := func() ([]byte, []byte) {
+		stdout, stderr := noopStdio()
+		_, err := Run(context.Background(), Options{
+			RepoRoot:  repoRoot,
+			IndexPath: indexPath,
+			Packages:  []string{"cnos.core"},
+			Stdout:    stdout,
+			Stderr:    stderr,
+		})
+		if err != nil {
+			t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+		}
+		deps, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "deps.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		lock, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "deps.lock.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return deps, lock
+	}
+
+	deps1, lock1 := run()
+	deps2, lock2 := run()
+
+	if !bytes.Equal(deps1, deps2) {
+		t.Errorf("deps.json not byte-identical across runs:\n--- 1 ---\n%s\n--- 2 ---\n%s", deps1, deps2)
+	}
+	if !bytes.Equal(lock1, lock2) {
+		t.Errorf("deps.lock.json not byte-identical across runs:\n--- 1 ---\n%s\n--- 2 ---\n%s", lock1, lock2)
+	}
+}
+
+// --dry-run must write nothing at all, not even a .cn/ directory.
+func TestRun_DryRun_WritesNothing(t *testing.T) {
+	indexPath := writeLocalIndex(t, "cnos.core", "9.9.9", `{"name": "cnos.core", "version": "9.9.9"}`)
+	repoRoot := t.TempDir()
+
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core"},
+		DryRun:    true,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if !res.DryRun {
+		t.Error("Result.DryRun = false, want true")
+	}
+
+	entries, err := os.ReadDir(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("dry-run must write nothing under RepoRoot; found: %v", entries)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{".cn/deps.json", ".cn/deps.lock.json", ".gitignore"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run stdout missing planned-diff entry %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "Dispatch: none") {
+		t.Errorf("dry-run stdout must state dispatch mode:\n%s", out)
+	}
+}
+
+func TestRun_MissingIndexFile(t *testing.T) {
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: filepath.Join(t.TempDir(), "nonexistent-index.json"),
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing index file")
+	}
+	if !strings.Contains(stderr.String(), "✗") {
+		t.Errorf("stderr should carry a diagnostic, got: %q", stderr.String())
+	}
+}
+
+func TestRun_MissingPackageInIndex(t *testing.T) {
+	indexPath := writeLocalIndex(t, "cnos.core", "9.9.9", `{"name": "cnos.core", "version": "9.9.9"}`)
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core", "cnos.cdd"}, // cnos.cdd absent from the fixture index
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err == nil {
+		t.Fatal("expected error for package not present in index")
+	}
+	if !strings.Contains(err.Error(), "cnos.cdd") {
+		t.Errorf("error should name the missing package, got: %v", err)
+	}
+	// No partial writes on failure.
+	if _, statErr := os.Stat(filepath.Join(repoRoot, ".cn")); !os.IsNotExist(statErr) {
+		t.Error(".cn must not exist after a failed resolve (pin resolution happens before any write)")
+	}
+}
+
+// SHA-mismatch propagation: restore.Restore's existing verify step must
+// not be silently bypassed by this installer.
+func TestRun_SHAMismatchPropagates(t *testing.T) {
+	dir := t.TempDir()
+	tarData, _ := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "9.9.9"}`})
+	tarName := "cnos.core-9.9.9.tar.gz"
+	os.WriteFile(filepath.Join(dir, tarName), tarData, 0644)
+
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"9.9.9": {URL: tarName, SHA256: "deliberately-wrong-sha256"}},
+		},
+	}
+	indexPath := filepath.Join(dir, "index.json")
+	writeJSON(t, indexPath, idx)
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core"},
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err == nil {
+		t.Fatal("expected error for sha256 mismatch")
+	}
+	if !strings.Contains(stderr.String(), "sha256 mismatch") {
+		t.Errorf("stderr should surface the sha256 mismatch, got: %q", stderr.String())
+	}
+	if _, statErr := os.Stat(pkg.VendorPath(repoRoot, "cnos.core")); !os.IsNotExist(statErr) {
+		t.Error("vendor dir must not exist after a sha256 mismatch")
+	}
+}
+
+// AC9: --dispatch cds fails explicitly, before any write, with no partial
+// .github/workflows/ file.
+func TestRun_DispatchCds_FailsWithNoPartialWrite(t *testing.T) {
+	indexPath := writeLocalIndex(t, "cnos.core", "9.9.9", `{"name": "cnos.core", "version": "9.9.9"}`)
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core"},
+		Dispatch:  "cds",
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err == nil {
+		t.Fatal("expected --dispatch cds to fail")
+	}
+	if !strings.Contains(err.Error(), "#609") {
+		t.Errorf("error should name #609, got: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "✗ --dispatch cds requires generalized wake renderer support (#609)") {
+		t.Errorf("stderr should carry the exact dispatch-guard message, got: %q", stderr.String())
+	}
+	entries, rerr := os.ReadDir(repoRoot)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("--dispatch cds must write nothing; found: %v", entries)
+	}
+	if _, statErr := os.Stat(filepath.Join(repoRoot, ".github", "workflows", "cnos-cds-dispatch.yml")); !os.IsNotExist(statErr) {
+		t.Error("no partial .github/workflows/cnos-cds-dispatch.yml may exist")
+	}
+}
+
+// --- Release-resolution flows (httptest servers stand in for GitHub) ---
+
+// newFakeGitHub returns (apiServer, dlServer) where apiServer answers
+// /repos/{repo}/releases/latest like the real GitHub API, and dlServer
+// serves index.json + tarball(s) at the release-download URL shape:
+// /{repo}/releases/download/{tag}/<file>.
+func newFakeGitHub(t *testing.T, repo, tag string, indexBody []byte, tarballs map[string][]byte) (*httptest.Server, *httptest.Server) {
+	t.Helper()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name": %q, "target_commitish": "main"}`, tag)
+	}))
+	t.Cleanup(api.Close)
+
+	prefix := "/" + repo + "/releases/download/" + tag + "/"
+	dl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == prefix+"index.json" {
+			w.Write(indexBody)
+			return
+		}
+		for name, data := range tarballs {
+			if r.URL.Path == prefix+name {
+				w.Write(data)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(dl.Close)
+
+	return api, dl
+}
+
+// AC7 (--release latest): resolves a concrete tag via the GitHub releases
+// API, fetches that release's index.json, rewrites its relative tarball
+// URL to the release-download URL, and installs successfully — proving
+// the rewrite (not just the API call) actually happened, since a fetch
+// against the un-rewritten relative URL would 404 against dlServer.
+func TestRun_ReleaseLatest_ResolvesAndInstalls(t *testing.T) {
+	tarData, tarSHA := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "9.9.9"}`})
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			// Relative URL, exactly as `cn build`'s local index shape would
+			// declare it — proves rewriteRelativeEntriesFromBase actually
+			// runs on the release-fetched index, not only on --index inputs.
+			"cnos.core": {"9.9.9": {URL: "cnos.core-9.9.9.tar.gz", SHA256: tarSHA}},
+		},
+	}
+	indexBody, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := "acme/widgets"
+	api, dl := newFakeGitHub(t, repo, "9.9.9", indexBody, map[string][]byte{"cnos.core-9.9.9.tar.gz": tarData})
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:     repoRoot,
+		Release:      "latest",
+		Packages:     []string{"cnos.core"},
+		Repo:         repo,
+		APIBaseURL:   api.URL,
+		DownloadBase: dl.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if res.ReleaseTag != "9.9.9" {
+		t.Errorf("ReleaseTag = %q, want 9.9.9", res.ReleaseTag)
+	}
+	if res.Manifest.Packages[0].Version != "9.9.9" {
+		t.Errorf("manifest pinned version = %q, want 9.9.9", res.Manifest.Packages[0].Version)
+	}
+	pkgManifest := filepath.Join(pkg.VendorPath(repoRoot, "cnos.core"), "cn.package.json")
+	if _, err := os.Stat(pkgManifest); err != nil {
+		t.Errorf("cnos.core not restored via release flow: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "9.9.9") {
+		t.Errorf("stdout should print the resolved release tag:\n%s", stdout.String())
+	}
+}
+
+// AC7 (--release <tag>): a pinned tag skips "latest" resolution entirely
+// and fetches that tag's release assets directly.
+func TestRun_ReleaseTag_Pinned(t *testing.T) {
+	tarData, tarSHA := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "1.2.3"}`})
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.2.3": {URL: "cnos.core-1.2.3.tar.gz", SHA256: tarSHA}},
+		},
+	}
+	indexBody, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := "acme/widgets"
+	// No "latest" endpoint registered on a distinct path — if Run called
+	// FetchLatestRelease despite an explicit tag, the download server
+	// would 404 on a tag it never served, since we only wire index.json
+	// under the "1.2.3" download prefix below.
+	_, dl := newFakeGitHub(t, repo, "1.2.3", indexBody, map[string][]byte{"cnos.core-1.2.3.tar.gz": tarData})
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:     repoRoot,
+		Release:      "1.2.3",
+		Packages:     []string{"cnos.core"},
+		Repo:         repo,
+		DownloadBase: dl.URL,
+		Stdout:       stdout,
+		Stderr:       stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if res.ReleaseTag != "1.2.3" {
+		t.Errorf("ReleaseTag = %q, want 1.2.3", res.ReleaseTag)
+	}
+}
+
+// AC7 (--index <URL>): an explicit http(s) index URL is fetched, its
+// relative tarball URL is rewritten against the URL's own directory, and
+// install succeeds.
+func TestRun_IndexHTTPURL_RelativeRewrite(t *testing.T) {
+	tarData, tarSHA := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "5.0.0"}`})
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"5.0.0": {URL: "cnos.core-5.0.0.tar.gz", SHA256: tarSHA}},
+		},
+	}
+	indexBody, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dist/packages/index.json":
+			w.Write(indexBody)
+		case "/dist/packages/cnos.core-5.0.0.tar.gz":
+			w.Write(tarData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err = Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: srv.URL + "/dist/packages/index.json",
+		Packages:  []string{"cnos.core"},
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	pkgManifest := filepath.Join(pkg.VendorPath(repoRoot, "cnos.core"), "cn.package.json")
+	if _, err := os.Stat(pkgManifest); err != nil {
+		t.Errorf("cnos.core not restored via HTTP index flow: %v", err)
+	}
+}

--- a/src/go/internal/repoinstall/repoinstall_test.go
+++ b/src/go/internal/repoinstall/repoinstall_test.go
@@ -771,3 +771,56 @@ func TestRun_IndexHTTPURL_RelativeRewrite(t *testing.T) {
 		t.Errorf("cnos.core not restored via HTTP index flow: %v", err)
 	}
 }
+
+// AC7 combination: --index <URL> together with an explicit --release
+// <tag> (not "latest"). TestRun_IndexHTTPURL_RelativeRewrite and
+// TestRun_ReleaseTag_Pinned each exercise one of these independently;
+// this test exercises resolveIndex's isRemoteURL(indexArg) branch with a
+// non-empty pinFromRelease at the same time — the untested flag
+// combination β's R0 review flagged as narrow test-coverage debt.
+func TestRun_IndexHTTPURL_WithExplicitReleaseTag(t *testing.T) {
+	tarData, tarSHA := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "7.7.7"}`})
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"7.7.7": {URL: "cnos.core-7.7.7.tar.gz", SHA256: tarSHA}},
+		},
+	}
+	indexBody, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dist/packages/index.json":
+			w.Write(indexBody)
+		case "/dist/packages/cnos.core-7.7.7.tar.gz":
+			w.Write(tarData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: srv.URL + "/dist/packages/index.json",
+		Release:   "7.7.7",
+		Packages:  []string{"cnos.core"},
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if res.ReleaseTag != "7.7.7" {
+		t.Errorf("ReleaseTag = %q, want 7.7.7 (explicit --release must still pin the version even when --index is also given)", res.ReleaseTag)
+	}
+	pkgManifest := filepath.Join(pkg.VendorPath(repoRoot, "cnos.core"), "cn.package.json")
+	if _, err := os.Stat(pkgManifest); err != nil {
+		t.Errorf("cnos.core not restored via --index URL + --release combo: %v", err)
+	}
+}

--- a/src/go/internal/repoinstall/repoinstall_test.go
+++ b/src/go/internal/repoinstall/repoinstall_test.go
@@ -357,6 +357,54 @@ func TestRun_LocalIndex_EndToEnd(t *testing.T) {
 	}
 }
 
+// AC4 (literal default set): absent --packages, Run installs exactly the
+// default triple (cnos.core, cnos.cdd, cnos.cds) under
+// .cn/vendor/packages/<name>/, each with a validated cn.package.json.
+func TestRun_DefaultPackageSet_AllThreeRestored(t *testing.T) {
+	dir := t.TempDir()
+	idx := pkg.PackageIndex{Schema: "cn.package-index.v1", Packages: map[string]map[string]pkg.IndexEntry{}}
+	for _, name := range DefaultPackages {
+		tarData, sha := makeTarGz(t, map[string]string{
+			"cn.package.json": `{"name": "` + name + `", "version": "3.82.0"}`,
+		})
+		tarName := name + "-3.82.0.tar.gz"
+		os.WriteFile(filepath.Join(dir, tarName), tarData, 0644)
+		idx.Packages[name] = map[string]pkg.IndexEntry{"3.82.0": {URL: tarName, SHA256: sha}}
+	}
+	indexPath := filepath.Join(dir, "index.json")
+	writeJSON(t, indexPath, idx)
+
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	res, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		Release:   "3.82.0", // pins the shared version across all three, mirroring Mock A
+		IndexPath: indexPath,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+	}
+	if len(res.Manifest.Packages) != len(DefaultPackages) {
+		t.Fatalf("manifest packages = %+v, want the default triple", res.Manifest.Packages)
+	}
+	for i, name := range DefaultPackages {
+		if res.Manifest.Packages[i].Name != name {
+			t.Errorf("manifest.Packages[%d].Name = %q, want %q (default order preserved)", i, res.Manifest.Packages[i].Name, name)
+		}
+		manifestPath := filepath.Join(pkg.VendorPath(repoRoot, name), "cn.package.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			t.Errorf("%s: cn.package.json not restored: %v", name, err)
+			continue
+		}
+		if err := pkg.ValidatePackageManifestData(data, name); err != nil {
+			t.Errorf("%s: manifest validation failed: %v", name, err)
+		}
+	}
+}
+
 // AC2/AC5: .cn/deps.json and .cn/deps.lock.json are byte-identical across
 // two successive runs with the same inputs (determinism + idempotence).
 func TestRun_Idempotent_ByteIdenticalArtifacts(t *testing.T) {


### PR DESCRIPTION
Refs #608. Closes #608.

## Summary

Implements `cn repo install` — a first-class, kernel-level Go command that installs the base CNOS/CDS package set (`cnos.core`, `cnos.cdd`, `cnos.cds`) into an arbitrary Git repository in one supported, idempotent, reviewable operation. Autonomous dispatch install is explicitly out of scope for this PR (gated behind #609; `--dispatch cds` fails cleanly with no partial write).

- New command: `src/go/internal/cli/cmd_repo_install.go` + domain logic in `src/go/internal/repoinstall/repoinstall.go`.
- Reuses existing `restore.GenerateLockFromIndex` / `restore.Restore` internals — no reimplemented verification, `cn.lock.v2` schema preserved byte-for-byte.
- Flags: `--release latest|<tag>`, `--index <path-or-url>`, `--packages <csv>`, `--dispatch none` (default; `cds` fails explicitly), `--dry-run`.
- Docs: `docs/guides/INSTALL-CDS.md` updated to the canonical `cn repo install` base path (two-layer framing preserved).

## Cycle history

R0 (α implement, all 11 ACs + 10/10 mock-parity) → β R0 **iterate** (blocking: `cmd_repo_install.go` resolved install root via `main.go`'s unbounded `.cn/`-search `HubPath` instead of git-repo-root detection, silently walking up past non-git ancestor directories — AC1 violation) → α R1 (unconditional `gitRepoRoot` resolution; added subprocess-driven tests exercising the real dispatch path, confirmed failing pre-fix / passing post-fix) → β R1 **converge** (independently re-verified the fix, reverted it in an isolated worktree to confirm the new tests genuinely catch the bug, reran build/vet/test/race fresh).

Follow-up filed: #616 (γ-scaffold process-gap: AC negative/prohibition clauses need a concrete oracle-table entry, not just narrative mention).

## Acceptance criteria

AC1–AC11 all verified (see `.cdd/unreleased/608/self-coherence.md` §R0/§R1 for command-level evidence). `go build/vet/test/test -race ./...` all clean; 307 tests passing (31 new).

## Artifacts

`.cdd/unreleased/608/{gamma-scaffold,self-coherence,beta-review,alpha-closeout,beta-closeout,gamma-closeout}.md`

---
_Dispatched and run by the `cds-dispatch` wake (protocol:cds) — γ/α/β routed by δ per `cnos.cdd/skills/cdd/delta/SKILL.md` §9._