### PR TITLE
cn CLI ergonomics for onboarding: --help/--version/init-flag/name-align

### DIFF
--- a/.cdd/unreleased/612/CLAIM-REQUEST.yml
+++ b/.cdd/unreleased/612/CLAIM-REQUEST.yml
@@ -1,0 +1,4 @@
+claimed_by: cds-dispatch/local-run-20260708
+protocol: cds
+requested_at: 2026-07-08
+issue: 612

--- a/.cdd/unreleased/612/REVIEW-REQUEST.yml
+++ b/.cdd/unreleased/612/REVIEW-REQUEST.yml
@@ -1,0 +1,18 @@
+issue: 612
+protocol: cds
+cycle_branch: cycle/612
+requested_by: delta (cds-dispatch wake, wake-invoked mode)
+pr: "https://github.com/usurobor/cnos/pull/631"
+converge_verdict_ref: .cdd/unreleased/612/beta-review.md
+note: >
+  Requesting the in-progress -> review transition per beta's Round 0
+  converge verdict (one blocking finding: cn status printed the same
+  non-invocable hyphenated command names cn help was fixing for AC4,
+  found by independent rebuild + re-drive of the binary, not named in
+  the issue's own AC text; fixed same round via the same InvocationName
+  helper, re-verified against a rebuilt binary). All closeout artifacts
+  (gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md,
+  beta-closeout.md, gamma-closeout.md) are present on this branch.
+  go build/vet/test clean across src/go and the three co-located modules
+  (issues-fsm, issues-map, cdd-verify). PR #631 opened by delta referencing
+  and closing #612, 1 commit beyond the cycle/612 <-> main merge-base.

--- a/.cdd/unreleased/612/alpha-closeout.md
+++ b/.cdd/unreleased/612/alpha-closeout.md
@@ -1,0 +1,22 @@
+# α close-out — cycle #612
+
+**Verdict at hand-off:** β converged in R0 after one blocking finding (fixed same round — see `beta-review.md` Finding 1 / `self-coherence.md`).
+
+**Diff summary:**
+- `src/go/cmd/cn/main.go` — top-level `--version`/`-V`/`--help`/`-h`; per-command `--help`/`-h` before the hub gate.
+- `src/go/internal/cli/dispatch.go` — `InvocationName`.
+- `src/go/internal/cli/help.go` (new) — `HelpProvider` interface + `PrintCommandHelp`.
+- `src/go/internal/cli/cmd_help.go`, `cmd_status.go` — use `InvocationName` for display.
+- `src/go/internal/cli/cmd_init.go` — refuse unrecognized flags.
+- `src/go/internal/cli/cmd_activate.go` — `Help()` method (parity fix, prevents regression from the new generic interception).
+- `.github/workflows/build.yml` — F1-F4 end-to-end smoke test against the real binary.
+- Tests: `dispatch_test.go` (+1 test), `help_test.go` (new, 3 tests), `cmd_help_test.go` (new, 1 test), `cmd_init_test.go` (new, 3 tests).
+
+**No production behavior change outside the four named commands' CLI-argv handling.** No FSM change, no installer change (issue's own non-goals), no schema change, no new external dependency.
+
+**Debt disclosed (none blocking):**
+1. CI smoke test's F4 leak-check is a hand-enumerated grep list (7 names) rather than a fully generic assertion over the registry — acceptable given the existing style of the surrounding smoke-test step, flagged by β as a non-blocking observation, not filed as a follow-up issue (low value: a new command with this exact collision shape is rare, and the Go unit tests already cover the mechanism generically via `TestInvocationName`).
+
+**mock_parity:** see `self-coherence.md` — F1/F3 match, F2/F4 exceed (both justified, both safe, both are "fix the same class of bug in an adjacent location β found," not new capability). 0 missed.
+
+**Build/test status at hand-off:** `go build ./...`, `go vet ./...`, `go test ./...` (src/go) — all green. `issues-fsm`, `issues-map`, `cdd-verify` co-located modules — all green. Manual end-to-end verification against the built binary for every AC1-AC4 scenario, run twice (once pre-status.go-fix, once post-fix).

--- a/.cdd/unreleased/612/beta-closeout.md
+++ b/.cdd/unreleased/612/beta-closeout.md
@@ -1,0 +1,13 @@
+# β close-out — cycle #612
+
+**Rounds:** 1 (R0 converge — one blocking finding, fixed and re-verified same round; see `beta-review.md`).
+
+**Independent verification performed:** rebuilt the binary from the diff myself (not the α-reported binary); drove every AC1-AC4 scenario directly, plus adjacent edge cases not named in the issue text (hub-gated commands' `--help`, dead `Help()` methods now wired, `repo install`'s pre-existing rich help preserved byte-for-byte, `cn init <validname>` regression check); ran the full build/vet/test matrix across all four Go modules touched by or adjacent to this change; manually re-checked the dispatch-boundary CI import guard against every changed `cmd_*.go` file; read every new/changed test for whether it's meaningful; read the new CI shell block line by line for scripting correctness.
+
+**Blocking findings:** 1 (status.go AC4-class gap — see `beta-review.md` Finding 1), fixed within the same round, independently re-verified post-fix against a rebuilt binary.
+
+**Non-blocking observations:** 3, none requiring a follow-up issue (see `beta-review.md`).
+
+**Rule 7 (implementation-contract conformance):** N/A in the strict sense — this cycle's scaffold did not pin a formal `## Implementation contract` axis table (unlike #608's larger scope), but the equivalent check — "no FSM/installer behavior change, no schema change" — was verified: `go issues fsm evaluate` and `repoinstall` packages are untouched by this diff (`git diff --stat` confirms no files under `internal/repoinstall/` or the `issues-fsm`/`issues-map` modules).
+
+**Verdict:** converge. No follow-up issue filed — the one non-blocking gap identified (CI grep list not fully generic) is a minor, explicitly-justified simplicity trade-off, not a debt item worth tracking separately.

--- a/.cdd/unreleased/612/beta-review.md
+++ b/.cdd/unreleased/612/beta-review.md
@@ -1,0 +1,27 @@
+# β review — cycle #612
+
+## §R1 (R0 — first pass)
+
+**Method:** Did not trust α's report. Built the binary independently (`go build -o /tmp/cn-review ./cmd/cn`) from the staged diff and drove it directly for every AC1-AC4 scenario named in the issue plus adjacent edge cases (hub-gated commands' `--help`, previously-dead `Help()` methods, `repo install`'s pre-existing rich help, regressions on valid `cn init <name>`). Ran the full build/vet/test matrix across `src/go` and the three co-located modules (`cnos.issues/commands/issues-fsm`, `cnos.issues/commands/issues-map`, `cnos.cdd/commands/cdd-verify`). Checked the dispatch-boundary CI guard against every changed `cmd_*.go` file. Read the new/changed Go tests for whether they're meaningful or tautological. Read the new CI smoke-test shell block for scripting bugs.
+
+### Finding 1 (blocking → fixed same round)
+
+`cn status`, run inside any hub, prints the raw hyphenated registry keys (`cdd-verify`, `cell-return`, `cell-finalize`, `issues-fsm`, `issues-map`, `repo-install`) — the identical AC4 bug class fixed in `cn help`, missed because the issue's own AC4 text names only `cn help`. Root cause: `cmd_status.go`'s `registryToCommandInfo()` forwards `spec.Name` unchanged into `hubstatus.CommandInfo.Name`, and `hubstatus.go` prints it verbatim.
+
+Reproduction: `cn init tenant && cd cn-tenant && cn status` (pre-fix) shows `cdd-verify`, `cell-finalize`, etc. in the "Commands:" section.
+
+**Disposition:** Same root cause, same fix (`InvocationName`), same architectural boundary (`cmd_status.go` already builds `CommandInfo` from a `Registry` it has in scope; `hubstatus` package deliberately stays `cli`-import-free per its own doc comment, so the fix correctly lives at the call site, not inside `hubstatus`). Fixed in this round — see `self-coherence.md` §"Not in the original AC text". Re-verified independently post-fix (`cn init verifyhub && cd cn-verifyhub && cn status` — clean output, all seven previously-hyphenated names now show their space form).
+
+### Non-blocking observations
+
+1. `cn init --help`'s exact behavior (usage text, exit 0) diverges from the illustrative transcript in `docs/development/design/cn-repo-install-MOCKS.md` §Mock F, which shows `--help` itself being refused with an "unknown flag" error. This is not a defect: AC2's own text requires `--help`/`-h` to work globally, which necessarily takes priority over the mock's illustrative (and, given AC2, self-contradictory) transcript — F3's own wording separately confirms `--help` is only "any unrecognized `--flag`" as an *example* of the underlying bug class (a flag being silently treated as a positional hub name), not a literal requirement that `--help` itself must error. Both interpretations are satisfied here: no stray directory is ever created either way (checked in both the `cmd_init_test.go` unit tests and the CI smoke test's F3 block).
+2. The CI smoke test's F4 leak-check grep list is a fixed set of 7 command names — it will not catch a *new* future command with the same collision shape unless someone remembers to add it to the grep. Acceptable for this cycle (matches the existing style of hand-enumerated command lists already present in `build.yml`'s other steps, e.g. the `for c in ...` loop two lines above it); a fully generic regression guard would need a small dedicated Go test asserting `InvocationName` is called for every registered command's display path, which is out of scope for this cycle's AC text.
+3. Pre-existing cosmetic misalignment in `cn help`'s `%-12s` column padding for names ≥13 chars (e.g. `cell finalize`) predates this diff and is unrelated to it — not a finding, noted only to distinguish it from actual review findings.
+
+### Test quality check
+
+`cmd_help_test.go`, `cmd_init_test.go`, `help_test.go`, and the new `TestInvocationName` case in `dispatch_test.go` were read in full: each exercises a real collision/no-collision case or a real negative-path assertion (no directory created, error names the flag), not a tautology. The CI smoke-test block was read line by line for shell correctness (quoting, `set -euo pipefail` behavior, `cd -` usage, cleanup on both success and failure paths) — no bugs found after Finding 1's status.go gap prompted a closer second pass of the whole block.
+
+### Verdict
+
+**converge.** One blocking finding (status.go AC4-class gap), fixed within this same review round and independently re-verified against the rebuilt binary. No other blocking findings. All of AC1-AC4 hold against the actual binary, not just the test suite's framing of them.

--- a/.cdd/unreleased/612/gamma-closeout.md
+++ b/.cdd/unreleased/612/gamma-closeout.md
@@ -1,0 +1,40 @@
+# γ close-out — cycle #612
+
+**Scope of this artifact.** Process-gap-audit retrospective at the β-converge boundary, written before the cycle-PR is opened. Issue #612 remains `OPEN` at this point. Full release-time closure (`.cdd/unreleased/612/` → `.cdd/releases/{X.Y.Z}/612/`, `RELEASE.md`, branch deletion) is deferred to the actual merge/release step.
+
+---
+
+## Cycle summary
+
+**Issue:** [cnos#612](https://github.com/usurobor/cnos/issues/612) — CLI ergonomics for onboarding, per `docs/development/design/cn-repo-install-MOCKS.md` §Mock F. Sub-issue of the #607 wave; customer evidence from cnos#606 C3 (`tsc`, the first external tenant) and escalated by the operator as release-blocking against #618's next public binary cut.
+
+**What shipped:** `cn --version`/`-V`; global and per-command `--help`/`-h` (including four commands whose rich `Help()` text existed but was previously dead code, never wired to any dispatch path); `cn init` refusing unrecognized flags instead of scaffolding a stray directory from one; `cn help` and `cn status` (the latter found by β, not named in the issue) displaying the space-separated form that actually invokes each command instead of a non-dispatchable internal registry key. All four ACs closed with `mock_parity` evidence (2 match, 2 justified-exceed, 0 missed). An end-to-end CI smoke-test step was added against the real built binary, not just unit tests.
+
+**Review arc:** R0 converge, with one blocking finding (a second instance of the AC4 bug class, in `cn status`) found and fixed within the same round. No iteration back to α was needed.
+
+---
+
+## Process-gap audit
+
+**Was γ's own scaffold complete?** Mostly — the "AC oracle approach" table and "Surfaces touched" table correctly anticipated three of the four fix locations (`main.go`, `dispatch.go`/`cmd_help.go`, `cmd_init.go`) and correctly flagged the dead-`Help()`-method discovery pattern as a likely finding (the scaffold's β prompt explicitly told β to "grep for other call sites" printing `spec.Name` directly — which is exactly how the `cmd_status.go` gap was found). The scaffold did not itself name `cmd_status.go` as a surface, which is the one gap: AC4's own issue text scopes itself to `cn help` only, and the scaffold inherited that scope without independently auditing for other `spec.Name`-printing call sites before dispatch. This is a smaller, less structurally significant version of the same failure mode #608's γ closeout (cnos#616) already named and filed a doctrine fix for — negative/adjacent-surface clauses in an AC's own text don't automatically get an independent oracle unless someone thinks to look. Not filing a new issue for this instance: cnos#616 (open, from #608's closeout) already covers exactly this class of gap in `gamma/SKILL.md`'s scaffold-authoring guidance, and this cycle's own β prompt already demonstrated the mitigating practice (explicitly telling β to grep for sibling surfaces) that caught it here at zero cost (same review round, no iteration). Filing a second issue for the same doctrine gap would be duplicative.
+
+**Cycle-iteration trigger check (`gamma/SKILL.md` §2.8):** review rounds = 1 (not > 2); total findings = 1 blocking + 3 non-blocking (below the ≥10 mechanical-overload floor, and the blocking finding was substantive, not mechanical); no avoidable tooling/environment failure. No trigger fires.
+
+---
+
+## Follow-up issues
+
+No new issues filed. The one process-gap identified above is already covered by the open cnos#616 (filed during #608's closeout); no new debt items surfaced beyond the one non-blocking CI-grep-specificity observation in `beta-review.md`, which was judged not worth a separate tracker (see `beta-closeout.md`).
+
+---
+
+## Triage carryforward
+
+1. `alpha-closeout.md` and `beta-closeout.md` are both present on this branch alongside this file.
+2. Full release-time closure has not run — issue #612 stays `OPEN` until the cycle-PR merges.
+3. δ still owes: `REVIEW-REQUEST.yml`, opening/confirming the PR (mechanical finalizer, `cn cell finalize`), and requesting `status:in-progress → status:review` via `cn issues fsm evaluate --issue 612 --apply` once the deliverable-evidence preflight (cds-dispatch/SKILL.md §"Closeout integrity preflight", cnos#524) is satisfied.
+4. Parent wave #607 is unaffected; #609-#611 (renderer generalization, dispatch install, bootstrap delegation) remain their own sub-issues, untouched by this cycle.
+
+---
+
+**Cycle #612's γ process-gap audit is closed. Full cycle closure is deferred to the merge/release step.**

--- a/.cdd/unreleased/612/gamma-closeout.md
+++ b/.cdd/unreleased/612/gamma-closeout.md
@@ -38,3 +38,20 @@ No new issues filed. The one process-gap identified above is already covered by 
 ---
 
 **Cycle #612's γ process-gap audit is closed. Full cycle closure is deferred to the merge/release step.**
+
+---
+
+## δ closeout-integrity preflight — deliverable_evidence
+
+Recorded by δ (cds-dispatch wake) before requesting `status:in-progress -> status:review`, per `cds-dispatch/SKILL.md` §"Closeout integrity preflight" (cnos#524):
+
+```yaml
+deliverable_evidence:
+  pr: "#631 (cycle/612 -> main)"
+  head_sha: "8db8ff4b4a41d35112f86ac5fa7775743ee8a4f6"
+  base_sha: "407e942a309922e102b88ed96a83ba47c8e93c6d"
+  commits_beyond_base: 1
+  closeout_artifacts: [gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md, beta-closeout.md, gamma-closeout.md]
+```
+
+All five deliverable-evidence conditions (PR exists and references #612; PR has commits beyond base; `cycle/612` exists and differs from base; all six required closeout artifacts present; this block names the PR number and commit SHA) are satisfied.

--- a/.cdd/unreleased/612/gamma-scaffold.md
+++ b/.cdd/unreleased/612/gamma-scaffold.md
@@ -1,0 +1,74 @@
+# γ scaffold — cycle #612
+
+**Issue:** [cnos#612](https://github.com/usurobor/cnos/issues/612) — "cds-install Sub 5: `cn` CLI ergonomics for onboarding (--help / --version / init-flag / name-align)"
+**Mode:** `design-and-build` (per the issue's own `**Mode:**` field).
+**cell_kind:** `implementation` (defaulted; issue body carries no explicit `cell_kind:` field).
+**Refs:** #607 (wave master tracker). **Customer source:** cnos#606 C3 (first external tenant, `tsc`).
+**Design surface:** `docs/development/design/cn-repo-install-MOCKS.md` §"Mock F — CLI ergonomics" (on `main` already — confirmed present at `.../cn-repo-install-MOCKS.md:209-232`, no design-branch pull needed, unlike #608's Mock A/B/E1).
+**Base SHA:** `main` HEAD at claim time (see CLAIM-REQUEST.yml / claim comment on the issue).
+**Branch:** `cycle/612`, created from `main` at the base SHA, no prior commits.
+**Branch pre-flight:** no prior `origin/cycle/612`; no prior `.cdd/unreleased/612/` artifacts beyond this wake's own `CLAIM-REQUEST.yml`; no `status:changes` history; issue state `OPEN`. Classified `run_class: first_pass` (see the claim comment) — repair re-entry preflight (cds-dispatch/SKILL.md §"Repair re-entry preflight") not required.
+
+---
+
+## Bug reproduction (verified against the built binary before any fix)
+
+All three symptoms named in the issue reproduce exactly as described, confirmed by building `./src/go/cmd/cn` at the claimed base SHA and running it directly (not inferred from the issue text):
+
+1. `cn --version` / `-V` → `✗ Unknown command: --version` / `-V`.
+2. `cn --help` / `-h` (top level) → same "Unknown command" path. Per-command `--help` is inconsistent: `doctor`/`status`/`deps`/`dispatch` (all `NeedsHub: true`) error `"requires a hub"` before ever looking at `--help`; `build`/`update`/`setup` (all `NeedsHub: false`, no internal `--help` handling) silently no-op, exit 0, print nothing; `repo install` and `activate` already handle `--help` correctly (existing inline checks). `dispatch`, `cell return`, `cell resume`, `cell finalize` each already carry a rich `Help() string` method — but nothing in `Run()` ever calls it; the method is dead code, never reached.
+3. `cn init --help` → creates a directory literally named `cn---help/`. Root cause: `hubinit.validHubName` accepts `-` as a valid hub-name character, and `cmd_init.go` treats any positional `Args[0]` as the hub name with no flag check — `"--help"` passes `validHubName` unmodified.
+4. (AC4, not independently reproduced as a "failure" but confirmed as the described mismatch): `cn help` prints internal registry keys (`issues-fsm`, `cell-finalize`, `repo-install`, `cdd-verify`, `cell-return`, `cell-resume`, `issues-map`) verbatim. None of these hyphenated flat tokens actually dispatch to the command — `cli.ResolveCommand`'s flat-form path explicitly rejects any name whose pre-first-hyphen prefix collides with a sibling noun-group member (`dispatch.go` lines ~58-69), which is true for every one of the seven names above (each has at least one sibling under the same noun, or — for the singleton "cdd"/"repo" groups — collides with itself, since `GroupMembers` includes the exact-name registration). Typing the displayed name literally (e.g. `cn issues-fsm`) resolves to a noun-group listing, not the command; only the two-word form (`cn issues fsm`) actually runs it.
+
+---
+
+## Surfaces touched
+
+| Path | Role |
+|---|---|
+| `src/go/cmd/cn/main.go` | Add top-level `--version`/`-V` and `--help`/`-h` interception (before `ResolveCommand`); add per-command `--help`/`-h` interception (before the `NeedsHub` gate, after command resolution). |
+| `src/go/internal/cli/dispatch.go` | Add `InvocationName(reg, name) string` — returns the noun-verb space form for any name shadowed by a noun-group collision (reusing the existing `GroupMembers` check `ResolveCommand` already performs for its own reject logic), unchanged otherwise. |
+| `src/go/internal/cli/help.go` (new) | `HelpProvider` interface (`Help() string`) + `PrintCommandHelp(w, reg, cmd)`: prints the command's own `Help()` text if it implements the interface, else a generic `"Usage: cn <InvocationName> [args...]\n\n<Summary>\n"` fallback. |
+| `src/go/internal/cli/cmd_help.go` | Use `InvocationName` instead of raw `spec.Name` in all three listing sections (kernel/repo-local/package). |
+| `src/go/internal/cli/cmd_status.go` | Same fix as `cmd_help.go`, applied to `registryToCommandInfo` (β found this during review — `cn status` had the identical display bug, not named in the issue's own AC text but the same bug class). |
+| `src/go/internal/cli/cmd_init.go` | Refuse any `Args[0]` that `isFlag()` (existing helper from `cmd_activate.go`) before treating it as the positional hub name. |
+| `src/go/internal/cli/cmd_activate.go` | Add `Help() string` (returning the existing `activateHelp` const) so the new generic `--help` interception in `main.go` doesn't regress `activate`'s already-correct rich help output. |
+| `.github/workflows/build.yml` | Extend the existing "Smoke test" step with an end-to-end F1-F4 oracle block against the real built binary. |
+
+**No change:** `RepoInstallCmd`'s own inline `--help` handling (left in place — still correct, still reachable for `--help` anywhere in its arg list, not just position 0); `hubinit.go` (the flag guard is added at the `cli` dispatch layer, not the domain layer, matching the existing `RepoInstallCmd`/`gitRepoRoot` precedent of keeping domain packages free of CLI-argv concerns); FSM/installer behavior (issue's own §Out-of-scope).
+
+---
+
+## AC oracle approach
+
+| AC | Concrete check |
+|---|---|
+| **AC1** | `cn --version` / `-V` exit 0, stdout matches `^cn v`. |
+| **AC2** | `cn --help` / `-h` exit 0. Every registered command's `--help` exits 0 (looped in the CI smoke test and exercised individually in Go unit tests for the generic-fallback and HelpProvider paths). `cn repo install --help` still documents `--release`/`--index`/`--packages`/`--dispatch`/`--dry-run` (pre-existing content, unaffected by the new dispatch path — verified byte-identical). |
+| **AC3** | `cn init --help` and `cn init --anything-unrecognized` both: exit nonzero from `InitCmd.Run` when reached directly (Go unit tests), and — critically — never create a directory at all when run through the real binary (CI smoke test; the `--help` case never even reaches `InitCmd.Run` in the live binary, since `main.go`'s generic interception now short-circuits first — the negative "no stray dir" assertion covers both paths). `cn init myhub` (valid positional name) still creates `cn-myhub/` (regression check). |
+| **AC4** | `cn help` and `cn status` never print `issues-fsm`, `cell-finalize`, `cell-return`, `cell-resume`, `repo-install`, `cdd-verify`, or `issues-map` — only their space-separated invocable forms. Checked in Go unit tests (`TestHelpCmd_DisplayNamesMatchInvocation`, `TestInvocationName`) and the CI smoke test against the live binary in both a hub-less and a hubbed context (`cn status` requires a hub). |
+
+---
+
+## mock_parity contract (pinned; α/β must fill actual rows in their closeouts)
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-install-MOCKS.md
+  rows:
+    # F1-F4 only — this cell's scope
+  summary:
+    matched: <n>
+    exceeded: <n>
+    missed: 0   # MUST be 0 to converge
+```
+
+---
+
+## α prompt
+
+Implement the fixes per the "Surfaces touched" table above. Build the binary and manually verify each of AC1-AC4 against it (not just unit tests) before calling this done — the bug class here is specifically "looks fixed in isolation, still broken through main.go's actual dispatch path" (e.g. a command with its own `Help()` method that nothing ever calls), so end-to-end verification against the real binary is the load-bearing check, not a substitute for one. Do not touch FSM or installer behavior (issue's own non-goal). Write the `mock_parity` block with real `observed`/`evidence` per row in `alpha-closeout.md`.
+
+## β prompt
+
+Independently rebuild the binary and re-run AC1-AC4 yourself — do not trust α's report. Specifically try: commands whose `NeedsHub` is true (confirm `--help` no longer requires a hub); commands that already had a `Help()` method sitting unused (confirm it's now wired, not replaced by a worse generic fallback); any other command surface that prints `spec.Name` directly to a user (this is exactly how the `cn status` instance of the AC4 bug was found — grep for other call sites, not just `cmd_help.go`). Confirm the CI smoke-test shell script is correct (quoting, exit codes, cleanup) since it runs unattended.

--- a/.cdd/unreleased/612/self-coherence.md
+++ b/.cdd/unreleased/612/self-coherence.md
@@ -1,0 +1,68 @@
+# α self-coherence — cycle #612
+
+## §R1
+
+**Branch:** `cycle/612`, from `main` at the claimed base SHA.
+
+### What I did
+
+Reproduced all four symptoms against the built binary at base SHA (see `gamma-scaffold.md` §"Bug reproduction") before writing any fix, to confirm the issue text against reality rather than trusting it.
+
+**AC1/AC2 (`src/go/cmd/cn/main.go`):** Added a `switch os.Args[1]` block for `--version`/`-V`/`--help`/`-h` immediately after the existing "no args → help" check, before `ResolveCommand` is called (so these two flags never hit the "Unknown command" path). Added a second interception after command resolution (`args := res.Remaining`), checking `args[0] == "--help" || args[0] == "-h"` and calling the new `cli.PrintCommandHelp`, placed *before* the `NeedsHub` gate — this is the actual fix for `doctor`/`status`/`deps`/`dispatch`, whose `--help` previously errored on the hub-requirement check before ever reaching their `Run`.
+
+**Discovered while implementing AC2:** `DispatchCmd`, `CellReturnCmd`, `CellResumeCmd`, `CellFinalizeCmd` each already define a `Help() string` method with detailed usage text — but grep confirms `Run()` in each never calls it, and nothing else in the codebase calls it either. It was dead code. Rather than write new help text for these four, I added a `HelpProvider` interface (`help.go`) and wired `main.go`'s new interception to check for it, so these four commands' existing rich help becomes reachable for free. `RepoInstallCmd` already had *both* a `Help()` method and its own inline `--help` scan inside `Run` — the interface pickup gives it a second, earlier path to the same content (verified byte-identical output), and its own inline check remains as a harmless no-op for the common case (still useful for `--help` appearing anywhere in its arg list, not just position 0).
+
+**Gap found:** `ActivateCmd` had inline `--help` handling inside `Run` but no `Help()` method — meaning the new generic interception in `main.go` would have *regressed* it (short-circuiting before `Run`, falling through to the generic fallback instead of its existing rich `activateHelp` text). Fixed by adding `Help() string` to `ActivateCmd` returning the existing `activateHelp` const — one-line addition, no content duplication.
+
+**AC3 (`src/go/internal/cli/cmd_init.go`):** Added a check at the top of `Run`: if `Args[0]` is flag-shaped (`isFlag`, the existing helper from `cmd_activate.go`), refuse with a clear error naming the flag and do not call `hubinit.Run` at all. In the live binary this code path is mostly a defense-in-depth backstop — `--help`/`-h` specifically never reach it (main.go's generic interception catches them first) — but any *other* unrecognized flag (`--bogus`, etc.) does reach it and is refused here. `hubinit.validHubName` itself is unchanged (it still accepts `-` for legitimate hyphenated hub names like `cn-sigma`) — the fix belongs at the CLI-argv boundary, not the domain layer, matching the existing separation of concerns in this package (`RepoInstallCmd` resolves its own repo root via `gitRepoRoot` rather than pushing git logic into `hubinit`/`restore`).
+
+**AC4 (`dispatch.go`, `cmd_help.go`):** Added `InvocationName(reg, name) string`, reusing the exact collision check `ResolveCommand`'s flat-form reject branch already performs (`GroupMembers(reg, prefix-before-first-hyphen)`). Wired `cmd_help.go`'s three listing loops (kernel/repo-local/package) to use it instead of raw `spec.Name`.
+
+**Not in the original AC text, found by β during review (see `beta-review.md`):** `cmd_status.go`'s `registryToCommandInfo` forwards `spec.Name` unchanged into `hubstatus.CommandInfo`, which `hubstatus.go` prints verbatim — the identical bug, in a second location the issue's own AC4 text didn't name. Fixed with the same `InvocationName` call. `hubstatus` itself is untouched (per its own package doc, it deliberately takes pure data and does not import `cli/` — the fix belongs at the boundary in `cmd_status.go`, which already builds the `CommandInfo` slice and has `Registry` in scope).
+
+### Tests written
+
+- `dispatch_test.go`: `TestInvocationName` (collision vs. no-collision cases, using the existing `newTestRegistry` kata-group fixture).
+- `help_test.go` (new): `TestPrintCommandHelp_UsesHelpProvider`, `TestPrintCommandHelp_GenericFallback`, `TestPrintCommandHelp_GenericFallback_UsesInvocationName`.
+- `cmd_help_test.go` (new): `TestHelpCmd_DisplayNamesMatchInvocation` — asserts both presence of the space form and absence of the hyphenated form.
+- `cmd_init_test.go` (new): `TestInit_RejectsUnrecognizedFlag`, `TestInit_HelpFlagDoesNotScaffold` (the literal cnos#606 C3 repro, run against `InitCmd.Run` directly), `TestInit_AcceptsPositionalHubName` (regression check for the normal path).
+- `.github/workflows/build.yml`: extended the existing "Smoke test" job step with an end-to-end F1-F4 block against the actually-built binary — `--version`/`-V`, `--help`/`-h` on `cn` and all 15 registered commands (including `cn repo install --help`'s documented flags), `cn init --bogus` and `cn init --help` (both asserted to scaffold nothing), and `cn help`/`cn status` display-name checks (both hub-less and hubbed contexts, since `status` requires a hub).
+
+All of `go build ./...`, `go vet ./...`, `go test ./...` (from `src/go`) and the three co-located modules (`cnos.issues/commands/issues-fsm`, `cnos.issues/commands/issues-map`, `cnos.cdd/commands/cdd-verify`) pass clean, no regressions. The dispatch-boundary CI check (cmd_*.go must not import `os`/`net/http`/`encoding/json`/`archive/`/`compress/`/`crypto/`/`path/filepath` directly) was manually re-checked against every changed `cmd_*.go` file — none of the changes introduce a new import of any of those packages.
+
+### mock_parity
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-install-MOCKS.md
+  rows:
+    - id: F1
+      expectation: "cn --version / -V prints the version (exit 0), not \"Unknown command\"."
+      observed: "cn v3.82.0 (exit 0) for both --version and -V, at both top level and via the ldflags-injected version string."
+      evidence: "src/go/cmd/cn/main.go switch block; .github/workflows/build.yml F1 smoke assertion; manually run against /tmp/cn-review by independent β review agent."
+      verdict: match
+      how: "Matches the invariant text exactly — no behavior beyond what F1 asks for."
+    - id: F2
+      expectation: "--help / -h works on cn and every command incl. cn repo install."
+      observed: "cn --help/-h: full command listing, exit 0. All 15 registered kernel commands (doctor, status, deps, build, update, setup, dispatch, cell finalize/return/resume, issues fsm/map, cdd verify, activate, repo install) return exit 0 on --help, including previously-hub-gated ones (doctor/status/deps/dispatch) and previously-silent-no-op ones (build/update/setup). cn repo install --help still documents --release/--index/--packages/--dispatch/--dry-run verbatim."
+      evidence: "src/go/internal/cli/help.go; main.go per-command interception; .github/workflows/build.yml F2 loop; help_test.go; cmd_repo_install.go unchanged (verified byte-identical --help output)."
+      verdict: exceed
+      how: "Exceeds the literal AC text by also fixing 4 commands (dispatch, cell finalize/return/resume) whose Help() text existed but was dead code — not a new capability, just making already-authored content reachable. Safe: no new user-facing surface, purely a bugfix to existing intent."
+    - id: F3
+      expectation: "cn init --help (any unrecognized --flag) refuses with a clear error and scaffolds nothing. Negative: any directory created from a flag (e.g. cn---help/) fails."
+      observed: "cn init --bogus: exit 1, stderr names the flag, no directory created. cn init --help: exit 0 (usage text, per F2's own requirement that --help succeed globally), no directory created — main.go's generic --help interception now catches this before InitCmd.Run is ever reached. cn init myhub: unaffected, still creates cn-myhub/."
+      evidence: "src/go/internal/cli/cmd_init.go isFlag guard; cmd_init_test.go (3 tests); .github/workflows/build.yml F3 block (both --bogus and --help checked against the real binary, asserting no directory of any kind appears)."
+      verdict: match
+      how: "F3's own wording names --help as an example of 'any unrecognized --flag' that must not scaffold; both the --help path (via F2's global interception) and the general unrecognized-flag path (via cmd_init.go's own guard) independently guarantee no stray directory, satisfying the negative clause by two layers rather than one."
+    - id: F4
+      expectation: "cn help display names match real invocation (cn issues fsm, cn cell finalize), or list both forms — no name/invocation mismatch."
+      observed: "cn help now prints 'issues fsm', 'issues map', 'cell return', 'cell resume', 'cell finalize', 'repo install', 'cdd verify' — the space form that actually dispatches each command. The hyphenated internal registry keys no longer appear anywhere in the output."
+      evidence: "src/go/internal/cli/dispatch.go InvocationName; cmd_help.go; dispatch_test.go TestInvocationName; cmd_help_test.go; .github/workflows/build.yml F4 block."
+      verdict: exceed
+      how: "Exceeds the literal AC text (scoped to 'cn help') by also fixing the identical bug in 'cn status' (found during β review, not named in the issue), since it is the same root cause and the same fix (InvocationName) applies cleanly at the same architectural boundary. Safe: cmd_status.go already builds CommandInfo from the Registry it has in scope; no new surface, no behavior change beyond display text."
+  summary:
+    matched: 2
+    exceeded: 2
+    missed: 0
+    exceed_justified: true
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,68 @@ jobs:
         run: |
           ./cn help
 
+      # cnos#612 Mock F (docs/development/design/cn-repo-install-MOCKS.md
+      # §Mock F) — CLI ergonomics for onboarding. Exercises the real binary
+      # end to end, the same way a first-time tenant would (cnos#606 C3).
+      - name: CLI ergonomics smoke test (cnos#612 F1-F4)
+        working-directory: src/go
+        run: |
+          set -euo pipefail
+
+          # F1 — cn --version / -V prints the version, exit 0.
+          ./cn --version | grep -q '^cn v'
+          ./cn -V | grep -q '^cn v'
+
+          # F2 — --help/-h works on cn and every command incl. cn repo install.
+          ./cn --help >/dev/null
+          ./cn -h >/dev/null
+          for c in "doctor" "status" "deps" "build" "update" "setup" "dispatch" \
+                   "cell finalize" "cell return" "cell resume" \
+                   "issues fsm" "issues map" "cdd verify" "activate" "repo install"; do
+            ./cn $c --help >/dev/null || { echo "FAIL: cn $c --help did not exit 0"; exit 1; }
+          done
+          ./cn repo install --help | grep -q -- '--dry-run'
+
+          # F3 — cn init refuses an unrecognized flag; scaffolds nothing.
+          # Covers both the general case (--bogus) and the literal cnos#606
+          # C3 repro (--help previously created a stray "cn---help/" dir).
+          CN_BIN="$PWD/cn"
+          rm -rf /tmp/cn-init-smoke && mkdir -p /tmp/cn-init-smoke
+          cd /tmp/cn-init-smoke
+          if "$CN_BIN" init --bogus >/dev/null 2>&1; then
+            echo "FAIL: cn init --bogus should have failed"; exit 1
+          fi
+          if [ -n "$(ls -A /tmp/cn-init-smoke)" ]; then
+            echo "FAIL: cn init --bogus scaffolded something"; ls -la /tmp/cn-init-smoke; exit 1
+          fi
+          "$CN_BIN" init --help >/dev/null 2>&1  # AC2: exit 0, usage text
+          if [ -d "cn---help" ] || [ -n "$(ls -A /tmp/cn-init-smoke)" ]; then
+            echo "FAIL: cn init --help scaffolded something"; ls -la /tmp/cn-init-smoke; exit 1
+          fi
+          cd - >/dev/null
+          rm -rf /tmp/cn-init-smoke
+
+          # F4 — cn help and cn status display names match real invocation
+          # (space form, not the internal hyphenated registry key).
+          HELP_OUT="$(./cn help)"
+          echo "$HELP_OUT" | grep -q 'issues fsm'
+          echo "$HELP_OUT" | grep -q 'cell finalize'
+          if echo "$HELP_OUT" | grep -qE 'issues-fsm|cell-finalize|cell-return|cell-resume|repo-install|cdd-verify|issues-map'; then
+            echo "FAIL: cn help leaked a non-invocable hyphenated name"; exit 1
+          fi
+
+          rm -rf /tmp/cn-status-smoke && mkdir -p /tmp/cn-status-smoke && cd /tmp/cn-status-smoke
+          "$CN_BIN" init statushub >/dev/null
+          cd cn-statushub
+          STATUS_OUT="$("$CN_BIN" status)"
+          if echo "$STATUS_OUT" | grep -qE 'issues-fsm|cell-finalize|cell-return|cell-resume|repo-install|cdd-verify|issues-map'; then
+            echo "FAIL: cn status leaked a non-invocable hyphenated name"; echo "$STATUS_OUT"; exit 1
+          fi
+          cd - >/dev/null
+          rm -rf /tmp/cn-status-smoke
+
+          echo "PASS: cnos#612 F1-F4"
+
   binary-verify:
     name: Binary verification
     runs-on: ubuntu-latest

--- a/src/go/cmd/cn/main.go
+++ b/src/go/cmd/cn/main.go
@@ -72,6 +72,19 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Top-level --version/-V and --help/-h (cnos#612 AC1/AC2). These are
+	// not registered commands — ResolveCommand has no entry for them and
+	// would otherwise fall through to "Unknown command".
+	switch os.Args[1] {
+	case "--version", "-V":
+		fmt.Fprintf(os.Stdout, "cn v%s\n", version)
+		os.Exit(0)
+	case "--help", "-h":
+		inv := makeInvocation(hubPath, nil)
+		helpCmd.Run(ctx, inv)
+		os.Exit(0)
+	}
+
 	// Resolve the command — supports noun-verb form (cn kata run),
 	// flat form (cn kata-run), and noun-group listing (cn kata).
 	// See docs/architecture/DESIGN-CONSTRAINTS.md §3.1.
@@ -98,6 +111,15 @@ func main() {
 
 	cmd := res.Command
 	args := res.Remaining
+
+	// Per-command --help/-h (cnos#612 AC2). Checked before the hub-
+	// requirement gate below so --help works even on commands that need a
+	// hub to actually run (e.g. "cn doctor --help" previously errored with
+	// "requires a hub" instead of printing usage).
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		cli.PrintCommandHelp(os.Stdout, reg, cmd)
+		os.Exit(0)
+	}
 
 	// Check hub requirement.
 	spec := cmd.Spec()

--- a/src/go/internal/cli/cmd_activate.go
+++ b/src/go/internal/cli/cmd_activate.go
@@ -46,6 +46,13 @@ func (c *ActivateCmd) Spec() CommandSpec {
 	}
 }
 
+// Help implements HelpProvider (cnos#612 AC2) so main.go's generic
+// --help/-h interception, which runs before Run, surfaces this text
+// instead of the generic invocation+summary fallback.
+func (c *ActivateCmd) Help() string {
+	return activateHelp
+}
+
 func (c *ActivateCmd) Run(ctx context.Context, inv Invocation) error {
 	// Parse args: --help/-h, --claude, --codex, and a single positional HUB_DIR.
 	var claudeFlag, codexFlag bool

--- a/src/go/internal/cli/cmd_help.go
+++ b/src/go/internal/cli/cmd_help.go
@@ -64,7 +64,11 @@ func (c *HelpCmd) Run(_ context.Context, inv Invocation) error {
 			if !hasHub && spec.NeedsHub {
 				suffix = "  (requires hub)"
 			}
-			fmt.Fprintf(inv.Stdout, "  %-12s %s%s\n", spec.Name, spec.Summary, suffix)
+			// InvocationName (cnos#612 AC4): display the form that actually
+			// dispatches the command. Hyphenated names shadowed by a noun
+			// group (e.g. "issues-fsm") render as "issues fsm" — the
+			// hyphenated flat token only ever resolves to the group listing.
+			fmt.Fprintf(inv.Stdout, "  %-12s %s%s\n", InvocationName(c.Registry, spec.Name), spec.Summary, suffix)
 		}
 	}
 
@@ -72,7 +76,7 @@ func (c *HelpCmd) Run(_ context.Context, inv Invocation) error {
 		fmt.Fprintf(inv.Stdout, "\nRepo-local commands:\n")
 		for _, cmd := range repoLocalCmds {
 			spec := cmd.Spec()
-			fmt.Fprintf(inv.Stdout, "  %-12s %s\n", spec.Name, spec.Summary)
+			fmt.Fprintf(inv.Stdout, "  %-12s %s\n", InvocationName(c.Registry, spec.Name), spec.Summary)
 		}
 	}
 
@@ -80,7 +84,7 @@ func (c *HelpCmd) Run(_ context.Context, inv Invocation) error {
 		fmt.Fprintf(inv.Stdout, "\nPackage commands:\n")
 		for _, cmd := range packageCmds {
 			spec := cmd.Spec()
-			fmt.Fprintf(inv.Stdout, "  %-12s %s", spec.Name, spec.Summary)
+			fmt.Fprintf(inv.Stdout, "  %-12s %s", InvocationName(c.Registry, spec.Name), spec.Summary)
 			if spec.Package != "" {
 				fmt.Fprintf(inv.Stdout, "  [%s]", spec.Package)
 			}

--- a/src/go/internal/cli/cmd_help_test.go
+++ b/src/go/internal/cli/cmd_help_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// cnos#612 AC4: `cn help` must list every command by the form that
+// actually invokes it. Kernel commands whose name is shadowed by a noun
+// group (e.g. "cell-finalize", sibling to "cell-return"/"cell-resume")
+// are only dispatchable via the space form ("cell finalize") — the
+// hyphenated flat token resolves to the group listing instead (see
+// TestResolveCommandFlatHyphenatedRejected in dispatch_test.go). Before
+// this fix, help printed the hyphenated internal key verbatim.
+func TestHelpCmd_DisplayNamesMatchInvocation(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "help", Summary: "Show available commands", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "cell-return", Summary: "Deliver operator verdict", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "cell-finalize", Summary: "Finalize a cell", Source: SourceKernel}})
+	reg.Register(&stubCmd{spec: CommandSpec{Name: "doctor", Summary: "Validate hub health", Source: SourceKernel}})
+
+	h := &HelpCmd{Registry: reg}
+	var buf bytes.Buffer
+	if err := h.Run(context.Background(), Invocation{Stdout: &buf, Stderr: &buf}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"cell return", "cell finalize", "doctor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help output missing invocable form %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"cell-return", "cell-finalize"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("help output leaked non-invocable hyphenated key %q:\n%s", unwanted, out)
+		}
+	}
+}

--- a/src/go/internal/cli/cmd_init.go
+++ b/src/go/internal/cli/cmd_init.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/usurobor/cnos/src/go/internal/hubinit"
 )
@@ -22,6 +23,17 @@ func (c *InitCmd) Spec() CommandSpec {
 func (c *InitCmd) Run(ctx context.Context, inv Invocation) error {
 	var hubName string
 	if len(inv.Args) > 0 {
+		// cnos#612 AC3: init takes no flags. Before this fix, an
+		// unrecognized "--flag" (e.g. "--help", reaching here whenever a
+		// caller invokes InitCmd.Run directly rather than through main.go's
+		// generic --help interception) was treated as the positional hub
+		// name — validHubName allows '-', so "--help" scaffolded a stray
+		// "cn---help/" directory. Refuse instead of scaffolding.
+		if isFlag(inv.Args[0]) {
+			fmt.Fprintf(inv.Stderr, "✗ cn init: unrecognized flag %q\n\n", inv.Args[0])
+			fmt.Fprintf(inv.Stderr, "Usage: cn init [HUB_NAME]\n\ninit takes no flags; HUB_NAME is an optional positional argument.\n")
+			return fmt.Errorf("init: unrecognized flag %q", inv.Args[0])
+		}
 		hubName = inv.Args[0]
 	}
 	// If no name given, hubinit.Run derives it from cwd.

--- a/src/go/internal/cli/cmd_init_test.go
+++ b/src/go/internal/cli/cmd_init_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// cnos#612 AC3: init must refuse an unrecognized "--flag" instead of
+// treating it as the positional hub name. Before this fix, validHubName
+// allowed '-', so "cn init --help" scaffolded a stray "cn---help/"
+// directory (cnos#606 C3).
+func TestInit_RejectsUnrecognizedFlag(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := &InitCmd{}
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run(context.Background(), Invocation{
+		Args:   []string{"--bogus"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	if err == nil {
+		t.Fatal("expected error for unrecognized flag")
+	}
+	if !strings.Contains(stderr.String(), "--bogus") {
+		t.Errorf("stderr should name the unrecognized flag, got: %q", stderr.String())
+	}
+
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("must not scaffold anything for an unrecognized flag; found: %v", entries)
+	}
+}
+
+// The specific footgun from cnos#606 C3: "--help" is a flag, not a hub
+// name, and must not produce a "cn---help/" directory.
+func TestInit_HelpFlagDoesNotScaffold(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := &InitCmd{}
+	var stdout, stderr bytes.Buffer
+	_ = cmd.Run(context.Background(), Invocation{
+		Args:   []string{"--help"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	if _, err := os.Stat("cn---help"); err == nil {
+		t.Fatal("must not scaffold cn---help/ for the --help flag")
+	}
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("must not scaffold anything for --help; found: %v", entries)
+	}
+}
+
+// Regression: a plain positional hub name must still work.
+func TestInit_AcceptsPositionalHubName(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := &InitCmd{}
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run(context.Background(), Invocation{
+		Args:   []string{"myhub"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v (stderr: %s)", err, stderr.String())
+	}
+	if _, serr := os.Stat("cn-myhub"); serr != nil {
+		t.Errorf("expected cn-myhub/ to be created: %v", serr)
+	}
+}

--- a/src/go/internal/cli/cmd_status.go
+++ b/src/go/internal/cli/cmd_status.go
@@ -42,7 +42,11 @@ func registryToCommandInfo(reg *Registry) []hubstatus.CommandInfo {
 	for _, cmd := range reg.All() {
 		spec := cmd.Spec()
 		cmds = append(cmds, hubstatus.CommandInfo{
-			Name:    spec.Name,
+			// InvocationName (cnos#612 AC4): same fix as cmd_help.go — a
+			// hyphenated name shadowed by a noun group (e.g. "issues-fsm")
+			// is only reachable via the space form ("issues fsm"); status
+			// must not display the non-invocable hyphenated key either.
+			Name:    InvocationName(reg, spec.Name),
 			Summary: spec.Summary,
 			Tier:    tierLabel[spec.Tier],
 			Package: spec.Package,

--- a/src/go/internal/cli/dispatch.go
+++ b/src/go/internal/cli/dispatch.go
@@ -87,6 +87,28 @@ func ResolveCommand(reg *Registry, args []string) Resolution {
 	return Resolution{}
 }
 
+// InvocationName returns the user-facing invocation form of a registered
+// command name.
+//
+// Names whose prefix before the first hyphen collides with a noun group
+// (e.g. "issues-fsm", sibling to "issues-map") are only reachable via the
+// noun-verb space form ("issues fsm") — ResolveCommand's flat-form reject
+// rule (see above) means the literal hyphenated token is never dispatched
+// to the command itself, only to the group listing. Displaying such a name
+// hyphenated (as `cn help` did before cnos#612) shows an invocation that
+// does not actually run the command. Names with no such collision (e.g. a
+// repo-local command with an incidental hyphen in its name) are returned
+// unchanged, since the flat form does dispatch them.
+func InvocationName(reg *Registry, name string) string {
+	if i := strings.IndexByte(name, '-'); i > 0 {
+		prefix := name[:i]
+		if len(GroupMembers(reg, prefix)) > 0 {
+			return prefix + " " + name[i+1:]
+		}
+	}
+	return name
+}
+
 // GroupMembers returns commands whose name starts with prefix+"-".
 // Results are returned in registry order so help output is deterministic.
 func GroupMembers(reg *Registry, prefix string) []Command {

--- a/src/go/internal/cli/dispatch_test.go
+++ b/src/go/internal/cli/dispatch_test.go
@@ -217,6 +217,30 @@ func TestPrintGroup(t *testing.T) {
 	}
 }
 
+// cnos#612 AC4: names shadowed by a noun-group collision (only reachable
+// via the noun-verb space form, per TestResolveCommandFlatHyphenatedRejected
+// above) must render in the space form; names with no such collision are
+// unaffected.
+func TestInvocationName(t *testing.T) {
+	reg := newTestRegistry()
+
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"kata-run", "kata run"},
+		{"kata-list", "kata list"},
+		{"doctor", "doctor"},   // no hyphen at all
+		{"deps", "deps"},       // no hyphen at all
+		{"bogus-thing", "bogus-thing"}, // hyphenated but no sibling group member
+	}
+	for _, c := range cases {
+		if got := InvocationName(reg, c.name); got != c.want {
+			t.Errorf("InvocationName(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 func TestPrintGroupUnknownPrefix(t *testing.T) {
 	reg := newTestRegistry()
 

--- a/src/go/internal/cli/help.go
+++ b/src/go/internal/cli/help.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+)
+
+// HelpProvider is implemented by commands whose --help/-h output is richer
+// than the generic invocation+summary fallback (flag docs, examples, exit
+// codes). Commands that don't implement it get PrintCommandHelp's generic
+// fallback for free — see cnos#612 AC2.
+type HelpProvider interface {
+	Help() string
+}
+
+// PrintCommandHelp writes --help/-h output for cmd to w: the command's own
+// Help() text when it implements HelpProvider, otherwise a generic
+// "Usage: cn <invocation> [args...]" + summary line built from its Spec.
+//
+// Called from main.go before the hub-requirement gate, so --help works
+// even on commands that need a hub to actually run (cnos#612 AC2).
+func PrintCommandHelp(w io.Writer, reg *Registry, cmd Command) {
+	if hp, ok := cmd.(HelpProvider); ok {
+		fmt.Fprint(w, hp.Help())
+		return
+	}
+	spec := cmd.Spec()
+	fmt.Fprintf(w, "Usage: cn %s [args...]\n\n%s\n", InvocationName(reg, spec.Name), spec.Summary)
+}

--- a/src/go/internal/cli/help_test.go
+++ b/src/go/internal/cli/help_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// helpStubCmd is a stubCmd that also implements HelpProvider.
+type helpStubCmd struct {
+	stubCmd
+	help string
+}
+
+func (c *helpStubCmd) Help() string { return c.help }
+
+var _ Command = (*helpStubCmd)(nil)
+var _ HelpProvider = (*helpStubCmd)(nil)
+
+// cnos#612 AC2: a command implementing HelpProvider gets its own Help()
+// text verbatim, not the generic fallback.
+func TestPrintCommandHelp_UsesHelpProvider(t *testing.T) {
+	reg := NewRegistry()
+	cmd := &helpStubCmd{
+		stubCmd: stubCmd{spec: CommandSpec{Name: "widget", Summary: "Do widget things"}},
+		help:    "cn widget - detailed usage\n\nFLAGS:\n  --color\n",
+	}
+	reg.Register(cmd)
+
+	var buf bytes.Buffer
+	PrintCommandHelp(&buf, reg, cmd)
+
+	if buf.String() != cmd.help {
+		t.Errorf("PrintCommandHelp = %q, want the HelpProvider's own text %q", buf.String(), cmd.help)
+	}
+}
+
+// cnos#612 AC2: a command with no custom Help() still prints usable
+// "Usage: cn <invocation> [args...]" text with its summary, exit 0
+// (checked by the caller — PrintCommandHelp never errors).
+func TestPrintCommandHelp_GenericFallback(t *testing.T) {
+	reg := NewRegistry()
+	cmd := &stubCmd{spec: CommandSpec{Name: "doctor", Summary: "Validate hub health"}}
+	reg.Register(cmd)
+
+	var buf bytes.Buffer
+	PrintCommandHelp(&buf, reg, cmd)
+
+	out := buf.String()
+	if !strings.Contains(out, "Usage: cn doctor [args...]") {
+		t.Errorf("generic fallback missing usage line, got: %q", out)
+	}
+	if !strings.Contains(out, "Validate hub health") {
+		t.Errorf("generic fallback missing summary, got: %q", out)
+	}
+}
+
+// The generic fallback's invocation form must match InvocationName, so a
+// hyphenated noun-group command (e.g. "issues-fsm") shows the space form
+// that actually dispatches it, not the internal registry key.
+func TestPrintCommandHelp_GenericFallback_UsesInvocationName(t *testing.T) {
+	reg := newTestRegistry() // has kata-run / kata-list group
+	cmd, ok := reg.Lookup("kata-run")
+	if !ok {
+		t.Fatal("expected kata-run registered in newTestRegistry")
+	}
+
+	var buf bytes.Buffer
+	PrintCommandHelp(&buf, reg, cmd)
+
+	out := buf.String()
+	if !strings.Contains(out, "Usage: cn kata run [args...]") {
+		t.Errorf("generic fallback should use space form for shadowed name, got: %q", out)
+	}
+	if strings.Contains(out, "kata-run") {
+		t.Errorf("generic fallback leaked internal hyphenated key: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes cnos#612 (Mock F, cnos#606 C3 — reported by the first external tenant, `tsc`) and closes the release-blocker the operator flagged against #618's next public binary cut (`install.sh`'s own final verify step runs `cn --version`, which currently exits non-zero).

- **AC1** — `cn --version` / `-V` prints the version, exit 0.
- **AC2** — `--help` / `-h` now works globally and on every registered command, including four (`dispatch`, `cell finalize`, `cell return`, `cell resume`) whose rich `Help()` text existed but was previously dead code never wired to any dispatch path, and `cn repo install --help` (unaffected — still documents `--release`/`--index`/`--packages`/`--dispatch`/`--dry-run` verbatim).
- **AC3** — `cn init` refuses an unrecognized `--flag` instead of treating it as the positional hub name; fixes the `cn---help/` stray-directory footgun.
- **AC4** — `cn help` (and `cn status`, found during review — same bug, not named in the issue's own AC text) now display the space-separated form that actually invokes each command (`issues fsm`, `cell finalize`, ...) instead of a non-dispatchable internal registry key.

No FSM or installer behavior change (issue's own non-goals).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` (src/go) — clean
- [x] Co-located modules (`issues-fsm`, `issues-map`, `cdd-verify`) — clean
- [x] New unit tests: `TestInvocationName`, `TestPrintCommandHelp_*`, `TestHelpCmd_DisplayNamesMatchInvocation`, `TestInit_*`
- [x] New CI smoke-test step (`.github/workflows/build.yml`) exercises AC1-AC4 end to end against the real built binary
- [x] Manually verified against the built binary (twice — pre/post a β-found gap in `cn status`)
- [x] Independent β review (adversarial, rebuilt the binary separately) — converged after one blocking finding, fixed same round

Refs #612

🤖 Generated with cds-dispatch (cnos.cds δ cell-runtime)