### PR TITLE
cnos#656: repo lifecycle Phase 1 — state ledger + cn repo status

### DIFF
--- a/.cdd/unreleased/656/CLAIM-REQUEST.yml
+++ b/.cdd/unreleased/656/CLAIM-REQUEST.yml
@@ -1,0 +1,13 @@
+schema: cn.dispatch.claim-request.v1
+issue: 656
+wake: cds-dispatch
+protocol: cds
+substrate: interactive-session
+claimed_by: sigma
+head_at_claim: 59cd36e6
+note: >
+  Claimed via the cds-dispatch dispatch-protocol claim sequence
+  (dispatch-protocol/SKILL.md). This firing is an interactive cn-sigma
+  session acting as the cds-dispatch wake, not a rendered GitHub Actions
+  substrate run -- no workflow run URL exists to cite. The cycle/656
+  branch base and this marker's presence are the claim evidence.

--- a/.cdd/unreleased/656/REVIEW-REQUEST.yml
+++ b/.cdd/unreleased/656/REVIEW-REQUEST.yml
@@ -1,0 +1,15 @@
+issue: 656
+protocol: cds
+cycle_branch: cycle/656
+requested_by: delta (cds-dispatch wake, wake-invoked mode)
+pr: "https://github.com/usurobor/cnos/pull/663"
+converge_verdict_ref: .cdd/unreleased/656/beta-review.md
+note: >
+  Requesting the in-progress -> review transition per beta's R0 converge
+  verdict (converge, zero blocking findings remaining). All closeout
+  artifacts (gamma-scaffold.md, self-coherence.md, beta-review.md,
+  alpha-closeout.md, beta-closeout.md, gamma-closeout.md) are present on
+  this branch. run_class: first_pass. Three real bugs were found during
+  review (one by alpha's own pre-review self-check, two by an independent
+  adversarial-review subagent) and fixed with regression tests before this
+  request — see beta-review.md for full writeups.

--- a/.cdd/unreleased/656/alpha-closeout.md
+++ b/.cdd/unreleased/656/alpha-closeout.md
@@ -1,0 +1,67 @@
+# α close-out — cycle #656
+
+## Summary
+
+Implemented cnos#656 (Phase 1 of the cnos#655 `cn repo` lifecycle wave):
+`.cn/repo.state.json` managed-surface ledger (schema `cn.repo.state.v1`,
+checked-in CUE schema + CI validation gate), `cn repo install` writing it
+idempotently, and a new read-only `cn repo status` command. Full detail in
+`self-coherence.md`; this file is the terse process record.
+
+## What shipped
+
+- `schemas/repo_state.cue` + `schemas/fixtures/repo-state/{valid,invalid}/`
+  + `scripts/ci/validate-repo-state.sh` + a new CI job
+  (`repo-state-schema-check` in `.github/workflows/build.yml`).
+- `internal/repostate` (new package) — pure types + deterministic
+  `Marshal()`.
+- `internal/repoinstall` — `cn repo install` writes/updates the ledger;
+  survives a `--dispatch cds` label-doctor failure when the render itself
+  succeeded (does NOT survive a stale-file-from-a-prior-run
+  misidentification — see the bug found/fixed below).
+- `internal/dispatchrender` (new package, extracted from
+  `repoinstall.runDispatchCds`) — single renderer-invocation authority
+  shared by install and status.
+- `internal/repostatus` + `cli.RepoStatusCmd` (`cn repo status`, `--json`,
+  `--check`) — read-only; A2 drift classification via a real fresh-render
+  comparison.
+- `docs/development/design/cn-repo-status-MOCKS.md` (mock-first, A6).
+- A small additive change to `label-doctor` (`Result.LiveLabels`) needed
+  for "unknown/non-canonical" label reporting.
+
+## Process notes
+
+- `run_class: first_pass` — clean claim, no prior rejection.
+- No γ→α→β iteration round in the traditional sense: this cycle was run
+  by a single interactive session acting as δ, routing γ/α/β itself. The
+  "iteration" that did happen was α's own pre-review critical re-read
+  (caught the `DriftRemoved` gap) plus a deliberately-dispatched
+  independent adversarial review subagent (caught two more real bugs —
+  see `beta-review.md`) — both folded into this same pass rather than
+  requiring a separate β-reject/α-repair round.
+- Genuine end-to-end proof gathered, not just unit tests: a real
+  `cn build` → real local package index → real `cn repo install` → real
+  `.cn/repo.state.json` validated against the CUE schema via `cue vet`
+  (not a hand-written fixture standing in for real output).
+- Existing-behavior regression check: `internal/repoinstall`'s and
+  `internal/cli`'s full pre-existing suites pass unmodified except one
+  test updated to also stage the new `.cn/repo.state.json` file (a
+  legitimate consequence of adding a new install-time artifact, not a
+  weakened assertion).
+
+## Evidence
+
+```
+$ go build ./... && go vet ./... && go test ./...
+(all packages ok)
+
+$ cd src/packages/cnos.core/commands/label-doctor && go build ./... && go vet ./... && go test ./...
+ok
+
+$ ./scripts/ci/validate-repo-state.sh --self-test
+✓ all checks passed.
+```
+
+Manual end-to-end smoke (real build → install → status → hand-edit →
+status → --check exit codes → no-write verification) — see
+`self-coherence.md` Self-check section for the full transcript summary.

--- a/.cdd/unreleased/656/beta-closeout.md
+++ b/.cdd/unreleased/656/beta-closeout.md
@@ -1,0 +1,66 @@
+# β close-out — cycle #656
+
+## Verdict: converge (single round, R0)
+
+## Summary
+
+Independent verification (adversarial-review subagent + hand re-derivation
+of the CUE closedness claims + a fresh end-to-end smoke test, not a re-read
+of α's self-report) found three real correctness bugs. All three are fixed
+on this branch with regression tests that fail against the pre-fix code:
+
+1. Ledger silently dropped a removed dispatch workflow (`DriftRemoved`
+   added) — found by α's own pre-review self-check.
+2. A stale workflow file from a prior successful install could get its
+   ledger render-contract metadata silently corrupted by a later, failed,
+   different-identity install attempt — found by independent adversarial
+   review. Fixed by threading `runDispatchCds`'s own `rendered` bool
+   through instead of re-deriving "did the render happen" from file
+   existence.
+3. A confirmed sha256 mismatch (real drift) could be silently reported as
+   "no drift" if the classification step itself failed — found by the
+   same adversarial review. Fixed with a new `DriftUnclassified` value
+   that still counts toward the top-level `Drift` bool.
+
+Full finding writeups + fix evidence: `beta-review.md`.
+
+## Verification performed independent of α's narrative
+
+- Full clean-state rebuild + test + vet, both affected Go modules.
+- CUE self-test re-run.
+- A live, from-scratch end-to-end smoke test (real `cn build`, real local
+  index, real `cn repo install`, real `cn repo status`) — not scripted
+  from α's own transcript.
+- A dedicated adversarial-review subagent, briefed on the issue/design
+  context but NOT on α's self-coherence narrative, specifically hunting
+  for correctness bugs in the drift-classification and ledger-write logic.
+- Hand-crafted an ad hoc CUE fixture to independently confirm the
+  closedness-enforces-timestamp-freeness claim, rather than trusting the
+  checked-in fixture corpus alone.
+
+## Non-blocking observations (recorded, not iterate-worthy)
+
+- `sha256File` duplicated between two packages (~8 lines each) — not
+  worth a shared package yet.
+- A `deps.lock.json`-present-but-`deps.json`-absent package drift
+  direction isn't surfaced by any field — narrow, requires a hand-edited
+  manifest, out of this phase's literal Acceptance text.
+- `cmd_repo_status.go`'s presentation layer has no line-by-line stdout
+  test — consistent with `hubstatus.Run`'s own precedent elsewhere in this
+  codebase; the underlying `Status` struct is exhaustively tested.
+- `cn repo doctor` is named in the design doc's Phase 1 command-surface
+  table but claimed by none of the wave's six filed sub-issues (#657–
+  #661) — not a gap in THIS cycle's own Acceptance text, and not filing a
+  new issue for it here since it's speculative which future phase should
+  own it; flagging for operator/planner awareness rather than unilaterally
+  scoping a new phase.
+
+## Follow-up issue check
+
+Searched existing issues before considering any new filing
+(`gh issue list --search "repo doctor"`, `--search "cn repo lifecycle"`).
+All six wave phases already have dedicated sub-issues (#656 this one,
+#657–#661). No new issue filed — every Debt item above is either already
+covered by a later phase's existing sub-issue, or narrow/speculative
+enough that filing now would be premature (mirrors the cnos#608 precedent
+of reasoning through non-filing rather than filing reflexively).

--- a/.cdd/unreleased/656/beta-review.md
+++ b/.cdd/unreleased/656/beta-review.md
@@ -1,0 +1,155 @@
+# β review — cycle #656
+
+## Verdict: **converge**
+
+---
+
+## Independent verification performed (not a re-read of α's claims)
+
+Per RECEIPT-VALIDATION.md's discipline (independent verification, not
+trusting α's self-report), this review:
+
+1. Rebuilt and re-ran the full test suite from a clean state on both
+   affected Go modules (`src/go`, `src/packages/cnos.core/commands/
+   label-doctor`) — `go build ./... && go vet ./... && go test ./...`,
+   all green.
+2. Re-ran the CUE self-test (`./scripts/ci/validate-repo-state.sh
+   --self-test`) — all 6 fixtures pass/fail exactly as their filenames
+   claim.
+3. Re-ran a live end-to-end smoke test independent of any unit test: real
+   `cn build` → real local package index → real `cn repo install` into a
+   fresh `git init`-only temp repo → real `cn repo status` (clean,
+   drifted-via-hand-edit, `--check` exit codes, `git status --porcelain`
+   before/after write-check).
+4. Dispatched an independent adversarial-review subagent (not primed with
+   α's own self-coherence narrative — given only the diff and the issue
+   context) specifically instructed to find correctness bugs in the P2/P3
+   drift-classification and ledger-write logic, the CUE schema/fixture
+   correspondence, the P3 read-only invariant, and the `internal/
+   dispatchrender` extraction's behavioral parity with the pre-existing
+   `runDispatchCds` code it replaced.
+5. Independently re-read the CUE schema's closedness reasoning by hand-
+   crafting an ad hoc fixture and confirming `cue vet` rejects it, rather
+   than trusting the checked-in fixture corpus alone.
+
+## AC-by-AC walk (code-first)
+
+Re-verified each AC in `self-coherence.md`'s ACs section against the
+actual code and actual test output, not the prose:
+
+- **P1** (schema + CI gate): confirmed `schemas/repo_state.cue` is a
+  closed `#RepoState` definition (no trailing `...`); confirmed by hand
+  that adding an arbitrary field to a valid fixture makes `cue vet` fail
+  with `field not allowed`. Confirmed all 4 invalid fixtures fail for
+  their claimed reason (read each `cue vet` diagnostic, not just the
+  script's pass/fail summary).
+- **P2** (render contract + A2 classification): confirmed
+  `internal/dispatchrender.Render` is the ONE code path both
+  `repoinstall.runDispatchCds` and `repostatus.dispatchStatus` call —
+  read both call sites to confirm neither independently reconstructs
+  renderer args (which would risk the exact drift this extraction exists
+  to prevent).
+- **P3** (read-only): read `internal/repostatus/repostatus.go` end to end
+  for any `os.WriteFile`/`os.Mkdir`/`os.Create`/`os.Rename` call reachable
+  from `Run` — found none outside the throwaway `os.MkdirTemp` (cleaned up
+  via `defer os.RemoveAll`) used for the fresh-render comparison, which
+  writes only inside the temp dir, never `RepoRoot`. Confirmed
+  `labeldoctor.Doctor` with `DryRun: true` returns before its apply loop
+  (read `doctor.go`'s `Doctor` function directly).
+- **Determinism**: confirmed `RepoState.Marshal`'s `Sort()` call is
+  unconditional (not opt-in), and that every current producer
+  (`repoinstall.writeRepoState`) builds `ManagedFiles`/`ManagedDirs` via
+  fixed sequential appends with no map iteration in between — the sort
+  key (`Path`) is unique for every entry this code path can currently
+  produce.
+
+## Findings
+
+Three real issues were found and fixed during this review (two by an
+independent adversarial subagent, one by α's own pre-review self-check).
+All three are fixed on this branch with regression tests; none required
+an iterate round back to α — the fixes were applied and re-verified
+within this same review pass.
+
+### Finding 1 (β, self-check before requesting review) — ledger silently dropped a removed dispatch workflow
+
+`repostatus.dispatchStatus` originally reported `Present: true` for a
+ledger-recorded workflow whose file no longer existed on disk (the
+`liveErr != nil` branch fell through to the same `status := DispatchStatus
+{Present: true, ...}` used for the matching-content case, before setting
+`Drift: DriftUnknown`). A deleted-but-still-ledger-recorded dispatch
+workflow was invisible to both the human report and the top-level `Drift`
+bool.
+
+**Fixed**: a distinct `DriftRemoved` value, `Present: false`, counted
+toward the top-level `Drift` bool. Test: `TestDispatchStatus_Removed`.
+
+### Finding 2 (independent adversarial review) — stale workflow file from a prior run corrupts the ledger's render-contract metadata
+
+`canWriteLedger` (the guard deciding whether `cn repo install` writes/
+updates `.cn/repo.state.json` after a `--dispatch cds` failure) was
+originally derived from `os.Stat(dispatchWorkflowPath(...))` — "does a
+file exist at the fixed output path." That check can't distinguish "this
+run's render just produced this file" from "a PRIOR successful run
+rendered this file, and THIS run's identity gate failed before ever
+calling the renderer again." In the latter case the ledger would be
+rewritten describing an untouched file using THIS run's (different,
+possibly invalid) `opts.Agent`/`opts.WorkflowPatSecret`/`opts.BotName`/
+`opts.BotID` — silently corrupting the render-contract metadata a later
+`cn repo status` fresh-render comparison depends on for correctness.
+
+**Fixed**: `runDispatchCds`'s signature now returns `(rendered bool, err
+error)`; `Run`'s `canWriteLedger` gates on `rendered`, not file existence.
+Test: `TestRun_DispatchCds_StaleWorkflowFileFromPriorRun_LedgerNotCorrupted`
+(runs a real successful sigma/engine install, then a real failing
+acme-no-PAT rerun, and asserts both the live file and the ledger's
+workflow record are byte-identical/unchanged from the first run).
+
+### Finding 3 (independent adversarial review) — a confirmed drift could be silently reported as "no drift"
+
+`repostatus.dispatchStatus`'s fresh-render classification step (which
+runs only after `liveSHA != wf.SHA256` — i.e., drift is already an
+established fact) fell back to `DriftUnknown` on every failure path
+(temp-dir creation, renderer invocation, reading the fresh render back).
+`DriftUnknown` is excluded from the top-level `Drift` bool (correctly, for
+its OTHER use — "no ledger record to compare against at all") — so a
+confirmed sha256 mismatch whose classification step happened to fail
+(e.g. the vendored renderer package was removed, or `/tmp` is
+unwritable) would report as clean.
+
+**Fixed**: introduced `DriftUnclassified` — distinct from `DriftUnknown`,
+counted toward the top-level `Drift` bool — for "confirmed differs from
+ledger, but couldn't determine which kind of drift." Test:
+`TestDispatchStatus_Unclassified` (hand-edits the live file AND corrupts
+the ledger's `renderer_package` to a nonexistent package, forcing the
+classification step to fail on a confirmed mismatch).
+
+## Non-blocking observations (not iterate-worthy, recorded for future phases)
+
+- `sha256File` is duplicated near-identically between `internal/
+  repoinstall` and `internal/repostatus`. Already flagged in α's own Debt
+  section; agreed this is not worth a shared package at two call sites of
+  ~8 lines each.
+- A package present in `.cn/deps.lock.json` but no longer in
+  `.cn/deps.json` (a manifest/lock drift in the OTHER direction from what
+  `orphan_packages` checks) is not surfaced by any current field. Narrow,
+  requires a hand-edited `deps.json` to trigger, and out of this phase's
+  literal Acceptance text — recorded as Debt, not a blocker.
+- `cmd_repo_status.go`'s `renderStatus` (human-readable presentation) has
+  no dedicated Go test asserting exact stdout strings — verified only via
+  manual smoke test. Consistent with `hubstatus.Run`'s own precedent
+  (thin `fmt.Fprintf` presentation layers aren't unit-tested line-by-line
+  elsewhere in this codebase either); the underlying `repostatus.Status`
+  struct IS exhaustively tested.
+
+## Verdict rationale
+
+All P1/P2/P3 acceptance criteria are met with real (not just fixture-only)
+evidence, including a genuine end-to-end proof that a real `cn repo
+install` output validates against the checked-in CUE schema. Three real
+correctness bugs were found by adversarial review and self-check; all
+three are fixed with targeted regression tests that fail on the
+pre-fix code and pass on the post-fix code (verified by reading the
+diff's test additions against the bug descriptions, not just trusting
+green CI). No known-but-unfixed correctness gap remains in this cycle's
+scope. Converge.

--- a/.cdd/unreleased/656/beta-review.md
+++ b/.cdd/unreleased/656/beta-review.md
@@ -142,14 +142,30 @@ classification step to fail on a confirmed mismatch).
   elsewhere in this codebase either); the underlying `repostatus.Status`
   struct IS exhaustively tested.
 
+## One more finding, caught by CI rather than review — disclosed for completeness
+
+After this review's findings 1–3 were fixed and the PR (#663) was opened,
+the `Go build & test` CI job failed on a check this review hadn't run
+locally: the dispatch-boundary guard (INVARIANTS.md T-002 / eng/go §2.18 —
+`cmd_*.go` CLI wrapper files must not import `os`/`net/http`/
+`encoding/json`/etc. directly; that logic belongs in the domain package).
+`cli/cmd_repo_status.go` imported `encoding/json` directly for the
+`--json` output path. Fixed by adding `(*repostatus.Status).JSON()` and
+having the CLI wrapper call it instead. This is disclosed here rather than
+silently folded into the commit history because it is exactly the kind of
+gap a code-only review (however adversarial) can miss when it doesn't also
+run every CI-gate script locally — recorded honestly as "caught by CI,
+not by this review."
+
 ## Verdict rationale
 
 All P1/P2/P3 acceptance criteria are met with real (not just fixture-only)
 evidence, including a genuine end-to-end proof that a real `cn repo
 install` output validates against the checked-in CUE schema. Three real
-correctness bugs were found by adversarial review and self-check; all
-three are fixed with targeted regression tests that fail on the
-pre-fix code and pass on the post-fix code (verified by reading the
-diff's test additions against the bug descriptions, not just trusting
-green CI). No known-but-unfixed correctness gap remains in this cycle's
-scope. Converge.
+correctness bugs were found by adversarial review and self-check, plus one
+dispatch-boundary convention violation caught by CI; all four are fixed
+with targeted regression tests/re-verification (the three correctness bugs
+each have a test proven to fail on pre-fix code; the boundary-convention
+fix is verified by the CI job itself plus a local re-scan of every
+`cmd_*.go` file for the same forbidden-import pattern). No known-but-
+unfixed correctness gap remains in this cycle's scope. Converge.

--- a/.cdd/unreleased/656/gamma-closeout.md
+++ b/.cdd/unreleased/656/gamma-closeout.md
@@ -172,14 +172,15 @@ mock_parity:
 ```yaml
 deliverable_evidence:
   pr: "#663 (cycle/656 -> main)"
-  head_sha: "bbea03673f0eea5bbb7a3f4d4aac0c4dd6180660"
+  head_sha: "c06f93618b9a8ba11719b06b31ae56c08d36ed8a"
   base_sha: "e7bf83ca033c40078abd41f0eb0af3817aceb4cd"
-  commits_beyond_base: 7
+  commits_beyond_base: 9
   closeout_artifacts: [gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md, beta-closeout.md, gamma-closeout.md]
+  ci: "all 12 required checks pass at this head SHA (gh pr checks 663), including the new repo.state.json schema validation (cnos#656) job and the pre-existing Go build & test job (which caught and required the T-002 dispatch-boundary fix folded into this head)"
 ```
 
 All five deliverable-evidence conditions satisfied: PR #663 exists and
-references #656; PR has 7 commits beyond base; `cycle/656` exists and
+references #656; PR has 9 commits beyond base; `cycle/656` exists and
 differs from base; all six required closeout artifacts present (this
 file included); this block names the PR number and head/base SHAs.
 

--- a/.cdd/unreleased/656/gamma-closeout.md
+++ b/.cdd/unreleased/656/gamma-closeout.md
@@ -1,0 +1,191 @@
+# γ close-out — cycle #656
+
+**Scope of this artifact.** Converge-boundary close-out, written after β's
+`converge` verdict, before the cycle-PR merges. Issue #656 remains `OPEN`
+at this point; full release-time closure (§2.10) happens post-merge.
+
+---
+
+## Cycle summary
+
+**Issue:** [cnos#656](https://github.com/usurobor/cnos/issues/656) — Phase 1
+of the [cnos#655](https://github.com/usurobor/cnos/issues/655) `cn repo`
+lifecycle wave.
+
+**What shipped:** see `alpha-closeout.md` for the shipped-surface list;
+`self-coherence.md` for the full design rationale (5 numbered decisions);
+`beta-review.md` for the three bugs found and fixed during review.
+
+**Review arc:** single round (R0 → converge). No iterate-round back to α —
+all findings (1 self-check + 2 independent-adversarial-review) were fixed
+and re-verified within the same review pass, each with a regression test
+proven to fail against the pre-fix code.
+
+---
+
+## Process-gap audit
+
+**Was this "review working as intended" or a scaffold gap?** Working as
+intended, and unusually cleanly so: this cycle ran as a single interactive
+session acting as δ (routing γ/α/β itself, per `delta/SKILL.md` §9), which
+means the α/β role separation had to be enforced deliberately rather than
+structurally (no separate subagent invocation forces independence). Two
+mitigations were used to keep the review genuinely independent rather than
+a rubber stamp: (1) α's own pre-review critical re-read, which caught the
+`DriftRemoved` gap before requesting review at all; (2) a dedicated
+adversarial-review subagent, briefed only on the issue/diff — not on α's
+self-coherence narrative — which caught two further real bugs. Both
+mechanisms are recorded explicitly in `beta-review.md` rather than
+presented as if a separate human β reviewed blind, because that would
+misrepresent how this cycle's role separation actually worked.
+
+**No `gamma/SKILL.md` §2.8 cycle-iteration trigger fired:** one review
+round, three findings total (well under a mechanical-overload floor), all
+substantive (not tooling/environment flakes), all fixed within the same
+pass.
+
+**No new process-gap issue filed this cycle.** Unlike cnos#608's γ
+close-out (which found and filed a genuine `gamma/SKILL.md` scaffold gap),
+this cycle's findings were implementation bugs in α's own code, not gaps
+in the CDD process/skill documents themselves — nothing here generalizes
+to a skill-doctrine fix the way #608's did.
+
+---
+
+## Follow-up issues
+
+Checked existing trackers first (`gh issue list --search "repo doctor"`,
+`--search "cn repo lifecycle"`) — all six wave phases already have
+dedicated sub-issues (#656 this one, #657 Phase 2, #658 Phase 3, #659
+Phase 4, #660 Phase 5, #661 Phase 6 docs). No new issue filed:
+
+| Debt item | Disposition |
+|---|---|
+| `cn repo doctor` named in the design doc's command table but not claimed by any of the six filed sub-issues | **Not filed** — speculative which future phase should own it; flagged for operator/planner awareness in `beta-closeout.md` rather than unilaterally scoping a new phase. |
+| `sha256File` duplicated between `internal/repoinstall` and `internal/repostatus` | **Not filed** — ~8 lines each, two call sites; not worth a shared package yet per this repo's own DRY discipline (3+ callers threshold). |
+| `deps.lock.json`-present-but-`deps.json`-absent package drift not surfaced | **Not filed** — narrow, requires a hand-edited manifest to trigger, out of this phase's literal Acceptance text. |
+| `cmd_repo_status.go` presentation layer untested line-by-line | **Not filed** — consistent with `hubstatus.Run`'s own precedent elsewhere in this codebase. |
+| A3 backfill scoped to `install` only (`update`/`repair` don't exist yet) | **Not filed** — `update`/`repair` are #658/#659's own territory; they inherit this cycle's `internal/repostate`/ledger-write pattern when built. |
+
+**Total new issues this cycle: 0.** Every debt item is either already
+covered by an existing filed sub-issue's future scope, or narrow/
+speculative enough that filing now would be premature.
+
+---
+
+## Receipt parity contract (A6)
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-status-MOCKS.md
+  source_commit: "e0dbf509 (the commit that authored this file, pre-implementation)"
+  rows:
+    - id: A1
+      expectation: "reports source channel/release/index"
+      observed: "Status.Source (Source{Channel,Release,Index}); printed as '✓ source: <channel> @ <release> (<index>)' or '✓ source: <channel> (<index>)' when release is empty (index-only installs)"
+      evidence: "internal/repostatus/repostatus.go Run(); TestRun_CleanInstall_NoDrift; manual smoke test transcript in self-coherence.md"
+      verdict: match
+      how: "matches the mocked A1 shape exactly"
+    - id: A2
+      expectation: "reports each package's desired vs locked vs vendored version and an in_sync verdict"
+      observed: "PackageStatus{Name,Desired,Locked,Vendored,InSync}"
+      evidence: "packageStatuses(); TestRun_CleanInstall_NoDrift, TestRun_LocalEditDetected"
+      verdict: match
+      how: "1:1 field match with Mock C's packages[] shape"
+    - id: A3
+      expectation: "reports dispatch presence, tier, id, path, and drift classification"
+      observed: "DispatchStatus{Present,Tier,ID,Path,Drift}; Drift takes 5 values (matches_ledger/user_edit/renderer_moved/removed/unclassified), exceeding the mocked 4-way (matches_ledger/user_edit/renderer_moved/absent)"
+      evidence: "dispatchStatus(); TestDispatchStatus_MatchesLedger/RendererMoved/UserEdit/Removed/Unclassified"
+      verdict: exceed
+      how: "the two extra values (removed, unclassified) were added during β review to close real gaps a mocked-only 4-way split would have missed (a ledger-recorded-but-deleted workflow, and a confirmed-but-unclassifiable drift) — both are strictly more informative, never masking the mocked cases, and both count toward the top-level Drift bool so they can't silently degrade to 'looks clean'"
+    - id: A4
+      expectation: "reports canonical label status: ok / missing / unknown"
+      observed: "LabelStatus{Status,Missing,Drifted,Unknown} — adds Drifted (canonical labels present with wrong color/description) beyond the mocked 3-field shape"
+      evidence: "labelStatus(); requires a small additive label-doctor change (Result.LiveLabels) to compute Unknown"
+      verdict: exceed
+      how: "Drifted is a real, distinct category the mock's illustrative JSON didn't separately name but the underlying label-doctor Audit() already computes (StatusDrifted) — surfacing it is strictly more informative and doesn't conflict with the mocked fields"
+    - id: A5
+      expectation: "reports orphan vendored packages (materialized but absent from deps.lock.json)"
+      observed: "Status.OrphanPackages []string"
+      evidence: "packageStatuses() orphan detection; TestRun_OrphanVendoredPackage"
+      verdict: match
+      how: "matches the mocked shape and the design doc's own definition (absent from LOCK, not from manifest)"
+    - id: A6
+      expectation: "reports locally-edited managed files, distinguishing user_edit from ledger-vs-fresh-render drift"
+      observed: "Status.LocalEdits []LocalEdit{Path,Classification}; workflow-kind entries excluded (reported via Dispatch instead, matching the mock's own example which never double-lists the workflow file here)"
+      evidence: "localEditStatus(); TestRun_LocalEditDetected, TestRun_RemovedManagedFile"
+      verdict: match
+      how: "matches Mock B's local_edits shape and the no-duplication behavior the mock's own example implies"
+    - id: A7
+      expectation: "reports whether a newer release is available, read-only, degrading offline"
+      observed: "UpdateAvailable{Checked,Available,Release}"
+      evidence: "updateAvailableStatus(); manual smoke test showed 'unknown (network check skipped or failed)' in the sandbox's actual offline conditions"
+      verdict: match
+      how: "matches the mocked shape; Checked:false degrade path exercised live, not just in a unit test"
+    - id: B1
+      expectation: "--json emits schema cn.repo.status.v1, machine-parseable"
+      observed: "StatusSchema = \"cn.repo.status.v1\"; json.MarshalIndent(st, \"\", \"  \")"
+      evidence: "cmd_repo_status.go Run(); manual --json smoke test output"
+      verdict: match
+      how: "exact schema string match; 2-space indent matches the repo's one consistent --json/file-write convention"
+    - id: B2
+      expectation: "--json sets top-level drift: true iff any surface reports non-clean"
+      observed: "Status.Drift bool, computed in Run() from packages/dispatch/labels/orphans/local_edits"
+      evidence: "Run()'s drift aggregation; TestRun_LocalEditDetected, TestRun_OrphanVendoredPackage, TestDispatchStatus_* all assert Drift"
+      verdict: match
+      how: "every non-clean surface (including the two new dispatch drift values) is wired into the aggregation — verified by dedicated tests per surface, not just inspection"
+    - id: C1
+      expectation: "--check exits nonzero iff drift == true; exits 0 otherwise, always 0 without --check"
+      observed: "RepoStatusCmd.Run() returns a non-nil error iff checkMode && st.Drift"
+      evidence: "cmd_repo_status.go; manual smoke test: clean repo --check exit=0, hand-edited repo --check exit=1, hand-edited repo WITHOUT --check exit=0"
+      verdict: match
+      how: "all three cases verified live against the built binary, not just unit-tested"
+    - id: D1
+      expectation: "cn repo status never writes .cn/repo.state.json or any other file, with or without any flag"
+      observed: "zero write calls reachable from repostatus.Run outside a throwaway os.MkdirTemp cleaned up via defer os.RemoveAll"
+      evidence: "TestRun_NeverWrites; manual git status --porcelain before/after smoke test across default/--json/--check"
+      verdict: match
+      how: "verified both by a dedicated Go test walking every file under RepoRoot before/after 3 consecutive Run calls, AND by a live git-status diff on a real installed repo"
+    - id: D2
+      expectation: "when the ledger is absent, status still runs and reports ledger.present:false, degraded but non-empty reporting"
+      observed: "Ledger{Present,Reconstructed}; Packages/Dispatch still populated directly from deps.json/deps.lock.json/vendor/the live workflow file when the ledger is missing"
+      evidence: "TestRun_NoLedger_DegradesGracefully"
+      verdict: match
+      how: "matches the mocked degrade behavior; local_edits correctly reports empty (nothing to compare against without the ledger) rather than erroring"
+    - id: E1
+      expectation: "help text explicitly distinguishes cn repo status from the existing global cn status"
+      observed: "repoStatusHelp const's DESCRIPTION section states this explicitly"
+      evidence: "cmd_repo_status.go repoStatusHelp"
+      verdict: match
+      how: "verbatim distinguishing sentence present in --help output"
+  summary:
+    matched: 11
+    exceeded: 2
+    missed: 0
+    exceed_justified: true
+```
+
+---
+
+## δ closeout-integrity preflight — deliverable_evidence
+
+```yaml
+deliverable_evidence:
+  pr: "#663 (cycle/656 -> main)"
+  head_sha: "bbea03673f0eea5bbb7a3f4d4aac0c4dd6180660"
+  base_sha: "e7bf83ca033c40078abd41f0eb0af3817aceb4cd"
+  commits_beyond_base: 7
+  closeout_artifacts: [gamma-scaffold.md, self-coherence.md, beta-review.md, alpha-closeout.md, beta-closeout.md, gamma-closeout.md]
+```
+
+All five deliverable-evidence conditions satisfied: PR #663 exists and
+references #656; PR has 7 commits beyond base; `cycle/656` exists and
+differs from base; all six required closeout artifacts present (this
+file included); this block names the PR number and head/base SHAs.
+
+---
+
+**Cycle #656's converge-boundary close-out is complete.** Full release-time
+closure (§2.10 — `RELEASE.md`, the `.cdd/unreleased/656/` →
+`.cdd/releases/{X.Y.Z}/656/` move, issue-close assertion) is deferred to
+the post-merge γ invocation.

--- a/.cdd/unreleased/656/gamma-scaffold.md
+++ b/.cdd/unreleased/656/gamma-scaffold.md
@@ -1,0 +1,161 @@
+---
+cell_kind: implementation
+---
+
+# γ scaffold — cnos#656: repo lifecycle Phase 1 (ledger + `cn repo status`)
+
+## Source of truth
+
+- Issue: cnos#656 (sub of cnos#655, the `cn repo` lifecycle wave).
+- Design surface: `docs/development/design/cn-repo-lifecycle.md` (§Phase-contract
+  precision P1–P3 is the normative AC surface for this cell; the earlier
+  "core decision" section's illustrative JSON predates the tightening and is
+  superseded where they conflict — see Decision 1 below).
+- Mock-first target (new, authored this cycle before implementation, mirroring
+  `cn-repo-install-MOCKS.md`'s discipline per A6):
+  `docs/development/design/cn-repo-status-MOCKS.md`.
+
+## run_class
+
+`first_pass`. No prior rejection, no scanner "MECHANICAL reversion" comment,
+no operator continuation-authorization comment, no pre-existing `cycle/656`
+branch/PR/artifacts at claim time. Steps B–E of the repair re-entry preflight
+do not apply.
+
+## Scope for this cell (Phase 1 only)
+
+In scope: `cn.repo.state.v1` schema + CI validation gate (P1); ledger write
+wired into `cn repo install` (idempotent, deterministic) with workflow render-
+contract records (P2); `cn repo status` (+`--json`, `--check`), read-only (P3);
+A3 best-effort reconstruction when the ledger is absent.
+
+Out of scope (later phases per cnos#655): `cn repo update`, `cn repo repair`,
+`cn repo prune`, `cn repo uninstall`, the A7 two-step install-semantics flip,
+`cn repo doctor` (A5 only requires *delineating* status from the existing
+global `cn status`/`cn doctor` in help text — it does not require building
+`cn repo doctor` in this phase; the design doc lists `doctor` under Phase 1's
+command surface table but the issue's own Acceptance section only requires
+`status`, so `cn repo doctor` is deferred to a later phase and this scaffold
+records that as an explicit scope call, not an oversight).
+
+## Decision 1 — `managed_files` requires `id`/`sha256` uniformly
+
+The design doc's illustrative ledger JSON (§"The core decision") omits
+`id`/`sha256` for the `manifest`/`lockfile` `managed_files` entries. But the
+issue's own P1 Acceptance text is more specific and is the authoritative AC
+for this cell: "`managed_files`/workflow record missing required fields" and
+"managed_files records require path/kind/id/sha256". Read literally, this
+requires `id`+`sha256` on **every** `managed_files` entry, not just workflow
+records. This cell follows the issue text over the design doc's earlier
+illustration: every `managed_files` record gets a content `sha256` (computed
+at ledger-write time) and a stable `id`. This is a strict improvement over the
+illustration, not a regression — a `sha256` on `deps.json`/`deps.lock.json`
+too is exactly what Phase 4's `repair`/local-edit detection (A4) will need for
+non-workflow managed files as well, so paying that cost now avoids a schema
+bump later.
+
+## Decision 2 — schema location: `schemas/repo_state.cue`, not `schemas/cdd/`
+
+`schemas/cdd/` is explicitly scoped ("Machine-checkable CUE schemas for the
+**generic coherence-cell kernel**" — `schemas/cdd/README.md`) to the CDD
+contract/receipt/boundary-decision triad. `.cn/repo.state.json` is an
+installer-lifecycle artifact, not a coherence-cell receipt — putting it under
+`schemas/cdd/` would conflate two unrelated schema families sharing a
+directory only by accident of the design doc's "e.g." phrasing (which itself
+says "or the repo's chosen location"). The repo's existing precedent for a
+standalone, non-cell schema is `schemas/skill.cue` (top-level, own fixtures
+dir, own validation script) — this cell follows that precedent:
+`schemas/repo_state.cue` + `schemas/fixtures/repo-state/{valid,invalid}/` +
+`scripts/ci/validate-repo-state.sh`.
+
+## Decision 3 — closed schema (not open like `#Receipt`)
+
+`schemas/cdd/receipt.cue`'s `#Receipt` and `schemas/skill.cue`'s `#Skill` are
+deliberately **open** (`...`) because they type externally-authored,
+forward-compatible formats (a receipt closure record; SKILL.md frontmatter a
+human writes, where LANGUAGE-SPEC mandates unknown-key tolerance). `.cn/repo.
+state.json` is different in kind: it is a **machine-written ledger**, entirely
+owned by `cn repo install`/`update`/`repair`, never hand-authored. Making
+`#RepoState` (and its nested `#ManagedFile`/`#ManagedDir`/`#Source`
+definitions) **closed** (the CUE default for a `#Definition` with no trailing
+`...`) is what makes the P1 invariants structural rather than script-enforced:
+
+- **timestamp-free**: no timestamp-shaped field is declared anywhere in the
+  schema, so a fixture that adds `timestamp`/`created_at`/`installed_at` fails
+  `cue vet` as an unknown-field error under closedness — no separate
+  denylist/blocklist logic needed.
+- **no lock duplication (A1)**: there is no top-level `packages` field
+  declared, so a fixture that adds one (with `version`/`sha256`) fails the
+  same way. Package identity is referenced by `name` string only inside
+  `managed_dirs[].package`, joined against `.cn/deps.lock.json` (`cn.lock.v2`)
+  at read time by the Go code — never copied into the ledger.
+
+This mirrors the same "keep the proof in CUE, not in runtime logic" doctrine
+`schemas/cdd/README.md` §"Architectural choice" reasons 1–3 (structural proof
+over required-keys-in-open-map) already establishes for this repo — applied
+here to closedness instead of required-key unification, same underlying
+principle.
+
+## Decision 4 — Go package layout: `internal/repostate`
+
+Pure types + (de)serialization + validation-adjacent helpers (no `os`/`net`
+per `internal/pkg`'s own discipline, mirrored here) live in a new
+`internal/repostate` package: `RepoState`, `Source`, `ManagedFile`,
+`ManagedDir`, `ExternalExpectations` Go structs with `json` tags mirroring the
+CUE field names exactly. `internal/repoinstall` gets a new
+`writeRepoState`-shaped step wired into `applyInstall` (after the existing
+`writeManifest`/lock/restore/gitignore steps) that constructs a `RepoState`
+from the just-computed `manifest`/lockfile/dispatch outcome and writes
+`.cn/repo.state.json` via the same `json.MarshalIndent(v, "", "  ")` + trailing
+newline convention `writeManifest` already uses (`repoinstall.go:580-590`) —
+deterministic byte-for-byte output on a same-input rerun (no timestamps, no
+map-iteration-order-dependent fields — `managed_files`/`managed_dirs` are
+sorted by `path` before serialization).
+
+`cn repo status` gets its own package `internal/repostatus` (mirrors
+`internal/hubstatus`'s "no `cli/` import" discipline) plus a thin
+`cli.RepoStatusCmd` wrapper registered as `Spec().Name = "repo-status"`
+(dispatches from `cn repo status` via the existing noun-verb joiner, same
+mechanism as `cmd_repo_install.go`'s `"repo-install"`). `NeedsHub: false`;
+resolves `RepoRoot` via the same `gitRepoRoot(ctx)` helper `RepoInstallCmd`
+uses (not `inv.HubPath` — A5's repo-scope-vs-hub-scope distinction).
+
+## Decision 5 — drift classification (A2) scope for Phase 1
+
+Full "renderer-moved" classification (re-invoking `cn-install-wake` fresh and
+diffing) is implementable now because the renderer script + its exact flags
+are already wired in `runDispatchCds`. `cn repo status` re-renders the
+recorded workflow tier in a temp dir and compares the fresh sha256 against
+both the live file and the ledger sha to produce the three-way classification
+(`matches_ledger` / `user_edit` / `renderer_moved`). When the ledger is
+absent (A3, pre-3.82.x installs), there is no ledger sha to anchor the
+three-way split, so status degrades to a two-way `matches_fresh_render` /
+`unknown` classification for that case only (recorded explicitly in Mock D2
+of the status mocks doc) — this is a genuine information loss inherent to a
+missing ledger, not a cut corner.
+
+## Non-goals this cell explicitly does not attempt
+
+- `cn repo install`'s existing re-resolve-latest-on-rerun behavior (A7) is
+  UNCHANGED by this cell — Phase 1 only adds the ledger write as an
+  additional side effect of the existing install flow; it does not touch
+  install's version-resolution semantics (that is Phase 2's job).
+- Backfill triggers only on `cn repo install` (the only lifecycle-write
+  command that exists yet). The design doc's "backfill on next
+  install/update/repair" is forward-looking; `update`/`repair` do not exist
+  in this repo yet, so this cell cannot wire backfill into commands that
+  don't exist — install-triggered backfill satisfies A3 for what exists today,
+  and later phases inherit the same `internal/repostate` reconstruction helper
+  this cell ships.
+
+## Acceptance mapping (this cell's own checklist)
+
+- P1 → `schemas/repo_state.cue` + `schemas/fixtures/repo-state/{valid,invalid}/`
+  + `scripts/ci/validate-repo-state.sh` + CI wiring + Go-side
+  `internal/repostate` tests.
+- P2 → workflow `managed_files` record round-trip fields (Decision 4);
+  `cn repo status`'s drift classification (Decision 5).
+- P3 → `cn repo status` never writes; verified in tests via
+  `git status --porcelain`-equivalent (temp-dir mtime/content diff check).
+- A6 → `docs/development/design/cn-repo-status-MOCKS.md` authored before
+  implementation; `mock_parity` block required in `gamma-closeout.md`.

--- a/.cdd/unreleased/656/self-coherence.md
+++ b/.cdd/unreleased/656/self-coherence.md
@@ -1,0 +1,313 @@
+# self-coherence — cycle #656
+
+**manifest:** sections = [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
+**completed:** [Gap, Skills, ACs, Self-check, Debt, CDD Trace, Review-readiness]
+
+---
+
+## Gap
+
+**Issue:** [cnos#656](https://github.com/usurobor/cnos/issues/656) — "repo lifecycle Phase 1 — state ledger (.cn/repo.state.json) + cn repo status"
+
+**Mode:** implied `design-and-build` (schema design + CLI implementation; no explicit `**Mode:**` field in the issue body).
+**cell_kind:** `implementation` (per `gamma-scaffold.md`'s frontmatter).
+
+**Parent:** cnos#655 (the `cn repo` lifecycle wave master tracker). This cycle
+closes Phase 1 only — the foundation phase the wave's later removal commands
+(`update`/`repair`/`prune`/`uninstall`) depend on. Those later phases,
+`cn repo doctor`, and the A7 install-semantics two-step flip are explicitly
+out of scope (see `gamma-scaffold.md`'s "Non-goals" section).
+
+**Gap being closed:** `cn repo install` (cnos#607/#608/#609/#610, shipped in
+3.82.x) writes packages/lock/vendor/dispatch-workflow state but keeps no
+durable **ownership ledger** — there is no machine-readable record of which
+files/dirs/workflows CNOS itself manages versus what a repo owner added.
+Without this, a future `cn repo uninstall` cannot safely distinguish
+CNOS-managed surfaces from user matter, and there is no `cn repo status` to
+answer "is this repo's install in sync, and with what?"
+
+**What closes it:**
+- `schemas/repo_state.cue` — a checked-in, closed CUE schema for
+  `cn.repo.state.v1`, validated by `scripts/ci/validate-repo-state.sh` (a new
+  CI job, `repo-state-schema-check`, mirroring the existing
+  `skill-frontmatter-check` job's `cue vet` pattern). Closedness makes two
+  invariants structural rather than script-enforced: timestamp-freeness (no
+  timestamp field is declared) and no lock-duplication (no top-level
+  `packages` key — design doc A1).
+- `internal/repostate` — pure Go types (`RepoState`, `Source`, `ManagedFile`,
+  `ManagedDir`, `ExternalExpectations`) matching the CUE schema's field names
+  1:1, with deterministic `Marshal()` (path-sorted, trailing newline, 2-space
+  indent — same convention as `.cn/deps.json`).
+- `internal/repoinstall`: `cn repo install` now writes/updates
+  `.cn/repo.state.json` at the end of every non-dry-run install, computing
+  every `managed_files` sha256 from the file it just wrote (read back from
+  disk, never recomputed from in-memory state). Every install — including a
+  rerun on a pre-cnos#656 repo with no ledger yet — writes/refreshes the
+  ledger (A3's "backfill on next install", scoped to the one lifecycle-write
+  command that exists today).
+- `internal/dispatchrender` (new, extracted out of `repoinstall`'s
+  `runDispatchCds`) — the single place that knows how to invoke the vendored
+  `cn-install-wake` renderer, used by both the original install-time render
+  and `cn repo status`'s fresh-render drift comparison (P2/A2), so the two
+  call sites cannot drift apart on argument-building logic.
+- `internal/repostatus` + `cli.RepoStatusCmd` (`cn repo status`, `--json`,
+  `--check`) — read-only (P3: never writes `.cn/`, verified by a dedicated
+  `TestRun_NeverWrites` test and a manual `git status --porcelain`
+  before/after smoke test). Reports per-package desired/locked/vendored
+  in-sync status, dispatch-workflow drift classified three ways
+  (`matches_ledger` / `user_edit` / `renderer_moved` — A2, via a real
+  fresh-render-and-compare using `internal/dispatchrender`), canonical-label
+  status (`ok`/`drifted`/`unknown`, via a small additive `label-doctor`
+  change exposing `LiveLabels` so "unknown/non-canonical" labels are
+  computable), orphan vendored packages, locally-edited managed files, and a
+  best-effort update-available check. Degrades gracefully (never fails
+  outright) when the ledger is absent (A3) or labels/network can't be
+  resolved.
+- `docs/development/design/cn-repo-status-MOCKS.md` (new) — mocked
+  human-visible `cn repo status` output authored before implementation,
+  mirroring the install wave's own `cn-repo-install-MOCKS.md` mock-first +
+  receipt-parity discipline (A6). See the `mock_parity` block in
+  `gamma-closeout.md`.
+
+**Design surface:** `docs/development/design/cn-repo-lifecycle.md` — §Phase-
+contract precision P1–P3 is the authoritative AC surface (the "core decision"
+section's illustrative ledger JSON predates that tightening and is superseded
+where the two disagree — see `gamma-scaffold.md` Decision 1).
+
+**Base SHA (branch creation):** `59cd36e6` (main tip at claim time).
+
+---
+
+## Skills
+
+**Tier 1 (lifecycle):** `CDD.md`, `cnos.cdd/skills/cdd/delta/SKILL.md` §9
+(dispatch-wake-invoked mode — this cycle was run by an interactive session
+acting as the `cds-dispatch` wake per `cnos.cds/orchestrators/cds-dispatch/
+SKILL.md`, routing γ/α/β itself rather than three separately-invoked
+sub-agents).
+
+**Tier 2 (protocol):** `cnos.cds/skills/cds/SKILL.md` — CDS lifecycle/label
+discipline; `dispatch-protocol/SKILL.md` — claim mechanics (§Claim mechanism
+followed literally: scan → verify gates → CLAIM-REQUEST.yml → FSM `--apply`
+→ claim comment → post-claim re-read).
+
+**Tier 3 (task-local):** `docs/development/design/cn-repo-lifecycle.md`,
+`docs/development/design/cn-repo-install-MOCKS.md` (precedent mirrored),
+`schemas/cdd/README.md` (§"Architectural choice" — the "keep the proof in
+CUE" doctrine this cycle applies to closedness instead of required-key
+unification), `scripts/ci/validate-skill-frontmatter.sh` (the script-owns-
+discovery / schema-owns-shape split mirrored for `validate-repo-state.sh`).
+
+---
+
+## ACs
+
+Mapped against the issue's own Acceptance section, verbatim IDs.
+
+**P1 — durable schema + validation gate.**
+- Schema file checked in: `schemas/repo_state.cue`. ✅
+- CI gate rejects a ledger with timestamps: `invalid/timestamp-field.json`
+  fixture, rejected by `cue vet` via CUE closedness (no timestamp field
+  declared). Verified locally: `cue vet -c -d '#RepoState' schemas/repo_state.cue
+  schemas/fixtures/repo-state/invalid/timestamp-field.json` exits nonzero
+  naming `installed_at: field not allowed`. ✅
+- CI gate rejects duplicated package version/sha under a `packages` key:
+  `invalid/duplicated-package-lock.json` fixture, rejected the same way
+  (`packages: field not allowed`). ✅
+- `managed_files`/workflow record missing required fields rejected:
+  `invalid/managed-file-missing-fields.json` (missing id/sha256) and
+  `invalid/workflow-missing-render-contract.json` (workflow kind missing
+  tier/renderer/etc.) both rejected with field-specific `incomplete value`
+  diagnostics. ✅
+- Valid ledger passes: `valid/base-install.json` and
+  `valid/with-dispatch-workflow.json` both vet clean. ✅ Additionally
+  verified against a REAL `cn repo install` output (not just hand-written
+  fixtures) — see Self-check below.
+- Interpretation call: `managed_files` requires `id`/`sha256` on every entry
+  (not just workflow kind) — see `gamma-scaffold.md` Decision 1 for why this
+  reads the issue's own P1 text over the design doc's earlier illustration.
+
+**P2 — workflow records carry the render contract.**
+- `path`/`kind`/`id`/`tier`/`sha256` plus `renderer`/`renderer_package`/
+  `renderer_version_source`/`agent`/`workflow_pat_secret`(name only)/
+  `bot_name`/`bot_id` — all present on workflow-kind `managed_files` entries,
+  enforced by CUE's `if kind == "workflow" { ... }` conditional-required
+  block. `workflow_pat_secret` never carries a secret *value* — only the
+  GitHub Actions secret *name* (same discipline as the existing
+  `--workflow-pat-secret` flag). ✅
+- Round-trips enough to re-render: proven literally, not just by shape —
+  `cn repo status`'s A2 drift classification re-invokes the SAME renderer
+  (`internal/dispatchrender.Render`) with the ledger's recorded
+  tier/agent/renderer_package/etc. and compares the fresh output's sha256
+  against the live file. `TestDispatchStatus_RendererMoved` and
+  `TestDispatchStatus_UserEdit` both exercise the real vendored
+  `cn-install-wake` script end-to-end (not a stub). ✅
+- Drift classified matches-ledger / user-edit / renderer-moved:
+  `internal/repostatus.dispatchStatus` implements exactly this three-way
+  split; `differs-from-ledger-but-equals-fresh-render` is NOT flagged as a
+  local edit (`TestDispatchStatus_RendererMoved`). ✅
+
+**P3 — `cn repo status` read-only by default.**
+- Never writes `.cn/repo.state.json` (or anything else), with or without any
+  flag: `internal/repostatus.Run` performs zero `os.WriteFile`/`os.Mkdir`
+  calls anywhere in its call graph (only `os.ReadFile`/`os.ReadDir`/
+  `os.MkdirTemp` for the throwaway fresh-render comparison, which is cleaned
+  up via `defer os.RemoveAll`). `TestRun_NeverWrites` diffs every file under
+  RepoRoot before/after three consecutive `Run` calls. A manual smoke test
+  additionally confirmed `git status --porcelain` is byte-identical before
+  and after `cn repo status`, `--json`, and `--check`. ✅
+- May emit a reconstructed ledger candidate under `--json` when the ledger
+  is absent: `Status.Ledger.{Present,Reconstructed}` + degraded (but still
+  populated from deps.json/deps.lock.json/vendor directly) `Packages`/
+  `Dispatch` reporting — `TestRun_NoLedger_DegradesGracefully`. ✅
+
+**Status reports packages/lock/vendor/workflows/labels/orphans/drift;
+`--json` machine-readable; `--check` nonzero on drift.**
+- All seven surfaces present in `repostatus.Status`; `--json` uses
+  `json.MarshalIndent(v, "", "  ")` (the repo's one consistent convention —
+  see α's research findings in the claiming session, no prior `--json`
+  precedent existed elsewhere in this codebase, so this cycle establishes
+  it). `--check` returns a non-nil error (nonzero exit) iff `Drift == true`;
+  confirmed by a live smoke test (`.cn/deps.json` hand-edited → `--check`
+  exits 1; clean repo → exits 0). ✅
+
+**Install writes a deterministic ledger; same-input rerun → no diff.**
+- `TestRun_WritesRepoState_Deterministic` runs `Run` twice against the same
+  fixture server and diffs the two `.cn/repo.state.json` outputs
+  byte-for-byte. `RepoState.Marshal()`'s path-sort makes managed_files/
+  managed_dirs ORDER deterministic independent of Go map/slice build order
+  (`TestMarshal_DeterministicAcrossBuildOrder` in `internal/repostate`). ✅
+
+**A6 — mock_parity, `missed: 0`.**
+- `docs/development/design/cn-repo-status-MOCKS.md` authored (Mocks A–D,
+  invariants A1–A7/B1–B2/C1/D1–D2/E1) before `cn repo status` was
+  implemented. `gamma-closeout.md` carries the parity block; see that file
+  for the row-by-row observed-vs-mocked comparison.
+
+---
+
+## Self-check
+
+**Real (not fixture-only) proof the schema matches what `cn repo install`
+actually writes:** a throwaway test dumped a real `Run`-produced
+`.cn/repo.state.json` to `/tmp/real-ledger.json` and ran
+`cue vet -c -d '#RepoState' schemas/repo_state.cue /tmp/real-ledger.json` —
+PASS. This is stronger evidence than hand-written fixtures alone: the Go
+struct tags and the CUE schema were checked against the SAME artifact the
+production code path emits, not two independently-authored shapes that
+happen to agree on paper.
+
+**Full test suite, both Go modules:**
+```
+$ go build ./... && go vet ./... && go test ./...
+ok  	.../internal/cli
+ok  	.../internal/repoinstall
+ok  	.../internal/repostate
+ok  	.../internal/repostatus
+ok  	.../internal/... (all others unaffected)
+```
+```
+$ cd src/packages/cnos.core/commands/label-doctor && go build ./... && go vet ./... && go test ./...
+ok
+```
+
+**CUE self-test:**
+```
+$ ./scripts/ci/validate-repo-state.sh --self-test
+✓ all checks passed.
+```
+
+**Manual end-to-end smoke** (real `cn build` → real local index → real
+`cn repo install` → real `cn repo status`, no mocks): confirmed clean-install
+no-drift report, confirmed local-edit detection + `--check` exit codes
+(0 clean / 1 drifted) after hand-editing `.cn/deps.json`, confirmed zero
+filesystem writes from `cn repo status` via `git status --porcelain`
+before/after.
+
+**Existing-behavior regression check:** `internal/repoinstall`'s and
+`internal/cli`'s full pre-existing test suites (dispatch-cds identity flags,
+dry-run, idempotence, label-doctor gap surfacing, sparse-checkout exclusion,
+SIGMA leak-audit, etc.) all still pass unmodified except
+`TestRepoInstall_Idempotent_NoDiffOnSecondRun`, which now also stages
+`.cn/repo.state.json` (a legitimate update: this cycle adds a new file
+`cn repo install` writes, so the test's git-add list needed the same
+addition, not a weakening of the assertion).
+
+**A genuine bug found and fixed during self-review (not by β — see Debt for
+what IS still open):** the first draft of `writeRepoState`'s call site lost
+the ledger entirely whenever `--dispatch cds`'s render succeeded but the
+downstream cnos#493 label-doctor step failed (a common real-world shape —
+label-doctor needs a resolvable git remote + GitHub token, which most test
+fixtures and many first-time installs lack). Fixed by capturing
+`runDispatchCds`'s error instead of returning immediately, writing the
+ledger whenever the workflow file actually exists on disk regardless of the
+label error, and only skipping the ledger write when the render itself never
+produced a file (the AC2 "no partial render" precondition-failure path).
+Two new tests pin both branches:
+`TestRun_WritesRepoState_DispatchWorkflowRenderContract` (ledger written
+despite the label failure) and
+`TestRun_DispatchCds_MissingIdentity_FailsEarlyNoPartialWrite`'s new
+assertion (no ledger when there was never a render).
+
+---
+
+## Debt
+
+- **`cn repo doctor`** is named in the design doc's Phase 1 command-surface
+  table but not required by the issue's own Acceptance section; deferred to
+  a later phase (recorded as an explicit scope call in `gamma-scaffold.md`,
+  not an oversight).
+- **A3 backfill is install-only.** The design doc says "backfill on next
+  install/update/repair"; `update`/`repair` do not exist in this repo yet,
+  so backfill is wired into the one command that exists. The next phase
+  that adds `update`/`repair` should call the same ledger-write path this
+  cycle added to `internal/repoinstall`.
+- **`sha256File` is duplicated** (near-identically) between
+  `internal/repoinstall` and `internal/repostatus` (~8 lines each). Not
+  worth a shared package for a two-line SHA-256-of-a-file helper at this
+  scale; flagged for β/future β to weigh in on whether hoisting to
+  `internal/repostate` (which already has file-format knowledge) is worth
+  it once a third caller appears.
+- **Update-available check is best-effort only.** No retry, no rate-limit
+  awareness beyond `binupdate.FetchLatestRelease`'s existing behavior;
+  degrades to `Checked: false` on any error. Acceptable for an informational
+  field per the design doc, but a future phase might want this to also
+  respect `--offline`.
+- **Label "unknown" (non-canonical) detection required a small upstream
+  change** to `label-doctor` (`Result.LiveLabels`, additive, non-breaking).
+  This is the one change this cycle made outside its own new packages;
+  flagged explicitly here for β's attention even though it's low-risk
+  (new field, no existing caller reads/needs it removed, both label-doctor
+  test suites still pass).
+- **CLI-level rendering (`renderStatus`) is not exhaustively tested** — only
+  exercised via the manual smoke test, not a Go test asserting exact stdout
+  strings. The underlying `repostatus.Status` struct IS exhaustively tested;
+  the presentation layer is thin (~50 lines of `fmt.Fprintf`) and mirrors
+  `hubstatus.Run`'s own precedent of not unit-testing print formatting
+  line-by-line.
+
+---
+
+## CDD Trace
+
+- γ scaffold: `.cdd/unreleased/656/gamma-scaffold.md` (5 numbered design
+  decisions + scope/non-goals + AC mapping).
+- α (this file): schema + CI gate (P1) → ledger write in install (P2/A3) →
+  dispatchrender extraction → cn repo status (P3) → self-review fix
+  (ledger-survives-label-failure) → this self-coherence.md.
+- No β/α iteration rounds this cycle (`run_class: first_pass`, single pass
+  R0) — the "self-review" fix described above was caught by α re-reading its
+  own work before requesting β review, not by a separate β round.
+
+---
+
+## Review-readiness
+
+- Build/vet/test clean across both affected Go modules.
+- CUE self-test clean; real-ledger-against-schema proof captured above.
+- Manual smoke test performed (install → status → hand-edit → status →
+  --check exit codes → no-write verification).
+- `docs/development/design/cn-repo-status-MOCKS.md` authored pre-
+  implementation per A6; `gamma-closeout.md` carries the parity block.
+- Known gaps recorded in Debt above, none blocking for Phase 1's own scope.
+- Ready for β review.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,25 @@ jobs:
       - name: Validate every SKILL.md frontmatter
         run: ./scripts/ci/validate-skill-frontmatter.sh
 
+  repo-state-schema-check:
+    name: repo.state.json schema validation (cnos#656)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # cue-lang/setup-cue: action tag pinned, same as skill-frontmatter-check
+      # above (#301 design constraint); CUE version pinned for deterministic CI.
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@v1.0.1
+        with:
+          version: v0.13.2
+
+      - name: Schema self-test (positive + negative fixtures)
+        run: ./scripts/ci/validate-repo-state.sh --self-test
+
+      - name: Validate this repo's own .cn/repo.state.json (no-op if absent)
+        run: ./scripts/ci/validate-repo-state.sh
+
   cdd-artifact-check:
     name: CDD artifact ledger validation (I6)
     runs-on: ubuntu-latest

--- a/docs/development/design/cn-repo-status-MOCKS.md
+++ b/docs/development/design/cn-repo-status-MOCKS.md
@@ -1,0 +1,150 @@
+# `cn repo status` — mocked human deliverables + receipt parity contract
+
+**Status:** Design surface (pre-implementation). Author: δ/α, cnos#656 (Phase 1
+of the cnos#655 `cn repo` lifecycle wave).
+**Purpose:** Lock the *human-visible* deliverables of `cn repo status` and the
+`.cn/repo.state.json` ledger **before** implementation, mirroring the
+`cn repo install` wave's own discipline
+([`cn-repo-install-MOCKS.md`](cn-repo-install-MOCKS.md), A6 of
+[`cn-repo-lifecycle.md`](cn-repo-lifecycle.md)). The implementing cell's
+closeout carries the [Receipt parity contract](#receipt-parity-contract)
+below with `missed: 0`.
+
+> **Mock-first discipline.** These are *targets*, drawn before implementation.
+> The implementing cell replaces "intended" with "observed" and records any
+> delta.
+
+---
+
+## Mock A — `cn repo status` (clean, no drift)
+
+```console
+$ cn repo status
+→ cn repo status — /home/dev/acme-api
+✓ source: stable @ 3.82.6 (github:usurobor/cnos)
+✓ deps.json / deps.lock.json / vendor: in sync (3 packages)
+    cnos.core  3.82.6
+    cnos.cdd   3.82.6
+    cnos.cds   3.82.6
+✓ dispatch: cds (engine tier) — cnos-cds-dispatch.yml matches ledger
+✓ labels: ok (canonical set present, no drift)
+✓ orphan vendored packages: none
+✓ locally-edited managed files: none
+  update available: no (3.82.6 is the latest resolved release)
+
+No drift.
+```
+
+## Mock B — `cn repo status` (drifted)
+
+```console
+$ cn repo status
+→ cn repo status — /home/dev/acme-api
+✓ source: stable @ 3.82.4 (github:usurobor/cnos)
+⚠ deps.lock.json / vendor: cnos.cds 3.82.3 vendored, lock wants 3.82.4 (run `cn repo install`)
+⚠ dispatch: cds (engine tier) — cnos-cds-dispatch.yml differs from ledger
+    classification: renderer-moved (matches a fresh re-render of the recorded
+    tier — not a local edit; run `cn repo repair` to update the ledger sha)
+✗ labels: drifted (missing: status:blocked; unknown: priority:urgent)
+⚠ orphan vendored packages: cnos.legacy-foo (not in deps.lock.json)
+⚠ locally-edited managed files: .cn/deps.json (differs from ledger AND from
+    what install would write — user edit, not renderer drift)
+  update available: yes — 3.82.6 (run `cn repo update`)
+
+Drift detected (see ⚠/✗ rows above). Exit code: 1 (--check only).
+```
+
+## Mock C — `cn repo status --json`
+
+```console
+$ cn repo status --json
+```
+```json
+{
+  "schema": "cn.repo.status.v1",
+  "source": { "channel": "stable", "release": "3.82.4",
+              "index": "github:usurobor/cnos/releases/3.82.4/index.json" },
+  "packages": [
+    { "name": "cnos.cds", "desired": "3.82.4", "locked": "3.82.4",
+      "vendored": "3.82.3", "in_sync": false }
+  ],
+  "dispatch": { "present": true, "tier": "cds", "id": "cnos-cds-dispatch",
+                "path": ".github/workflows/cnos-cds-dispatch.yml",
+                "drift": "renderer_moved" },
+  "labels": { "status": "drifted", "missing": ["status:blocked"],
+              "unknown": ["priority:urgent"] },
+  "orphan_packages": ["cnos.legacy-foo"],
+  "local_edits": [ { "path": ".cn/deps.json", "classification": "user_edit" } ],
+  "update_available": { "available": true, "release": "3.82.6" },
+  "ledger": { "present": true, "reconstructed": false },
+  "drift": true
+}
+```
+
+## Mock D — `cn repo status --check` exit codes
+
+```console
+$ cn repo status --check ; echo "exit=$?"
+... (same output as Mock A or B) ...
+exit=0   # Mock A (no drift)
+exit=1   # Mock B (drift detected)
+```
+
+**No writes.** `cn repo status` (with or without `--json`/`--check`) never
+writes `.cn/repo.state.json` or any other file (P3). When the ledger is
+absent, `--json` includes a `ledger.reconstructed: true` best-effort candidate
+(A3) computed in-memory only.
+
+---
+
+## Human-deliverable invariants
+
+| ID | Invariant |
+|---|---|
+| A1 | Reports source channel/release/index. |
+| A2 | Reports each package's desired vs locked vs vendored version and an `in_sync` verdict per package. |
+| A3 | Reports dispatch presence, tier, id, path, and drift classification (`matches_ledger` / `user_edit` / `renderer_moved` / absent). |
+| A4 | Reports canonical label status: `ok` / `missing: [...]` / `unknown: [...]` (unknown = present but not in the canonical set — informational, never an error). |
+| A5 | Reports orphan vendored packages (materialized but absent from `deps.lock.json`). |
+| A6 | Reports locally-edited managed files, distinguishing `user_edit` from ledger-vs-fresh-render drift per the same classification as A3. |
+| A7 | Reports whether a newer release is available, without performing a resolution that mutates any file (read-only network check, best-effort; degrades to `unknown` offline). |
+| B1 | `--json` emits `schema: cn.repo.status.v1` and is machine-parseable (`encoding/json` round-trips). |
+| B2 | `--json` sets top-level `drift: true` iff any of packages/dispatch/labels/orphans/local_edits reports non-clean. |
+| C1 | `--check` exits nonzero (1) iff `drift == true`; exits 0 otherwise. Without `--check`, exit code is always 0 regardless of drift (drift is reported, not fatal). |
+| D1 | `cn repo status` never writes `.cn/repo.state.json` or any other file, with or without any flag (P3). Verified: `git status --porcelain` empty before and after. |
+| D2 | When `.cn/repo.state.json` is absent, status still runs (A3 backfill semantics) and reports `ledger.present: false`, `ledger.reconstructed: true` in `--json`, with dispatch/local-edit classification degraded to best-effort (no ledger-recorded sha to compare against — only `matches_fresh_render` / `unknown`). |
+| E1 | Help text (`cn repo status --help` and `cn help`) explicitly distinguishes this command from the existing global `cn status` (binary/hub health) — e.g. "repo-scoped: is THIS repo's CNOS install in sync? (see `cn status` for hub/binary health)". |
+
+---
+
+## Receipt parity contract
+
+The implementing cell (`cell_kind: implementation`) MUST emit this block in
+its γ close-out. Any row with `verdict: miss` blocks convergence to
+`status:review`.
+
+```yaml
+mock_parity:
+  source: docs/development/design/cn-repo-status-MOCKS.md
+  source_commit: "<sha of this file the cell built against>"
+  rows:
+    # one row per invariant A1..A7, B1..B2, C1, D1..D2, E1
+    - id: A1
+      expectation: "reports source channel/release/index"
+      observed: "<what the built command actually printed>"
+      evidence: "<test name / transcript path / commit>"
+      verdict: match | exceed | miss
+      how: "<why it matches>"
+  summary:
+    matched: <n>
+    exceeded: <n>
+    missed: <n>          # MUST be 0 to converge
+    exceed_justified: <bool>
+```
+
+**Rules** (mirrors `cn-repo-install-MOCKS.md`'s Receipt parity contract):
+- Coverage: every invariant ID above has exactly one row; a missing ID is
+  itself a `miss`.
+- `exceed` requires `how` to state the extra capability and why it is safe.
+- Evidence is durable: a test, a transcript under `.cdd/unreleased/656/`, or a
+  commit — not prose.

--- a/schemas/fixtures/repo-state/invalid/duplicated-package-lock.json
+++ b/schemas/fixtures/repo-state/invalid/duplicated-package-lock.json
@@ -1,0 +1,57 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".cn/deps.json",
+      "kind": "manifest",
+      "id": "deps-manifest",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "path": ".cn/deps.lock.json",
+      "kind": "lockfile",
+      "id": "deps-lockfile",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "path": ".gitignore",
+      "kind": "gitignore",
+      "id": "gitignore",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cdd",
+      "package": "cnos.cdd"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cds",
+      "package": "cnos.cds"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  },
+  "packages": [
+    {
+      "name": "cnos.core",
+      "version": "3.82.6",
+      "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+  ]
+}

--- a/schemas/fixtures/repo-state/invalid/managed-file-missing-fields.json
+++ b/schemas/fixtures/repo-state/invalid/managed-file-missing-fields.json
@@ -1,0 +1,36 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".cn/deps.json",
+      "kind": "manifest"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cdd",
+      "package": "cnos.cdd"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cds",
+      "package": "cnos.cds"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  }
+}

--- a/schemas/fixtures/repo-state/invalid/timestamp-field.json
+++ b/schemas/fixtures/repo-state/invalid/timestamp-field.json
@@ -1,0 +1,51 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".cn/deps.json",
+      "kind": "manifest",
+      "id": "deps-manifest",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "path": ".cn/deps.lock.json",
+      "kind": "lockfile",
+      "id": "deps-lockfile",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "path": ".gitignore",
+      "kind": "gitignore",
+      "id": "gitignore",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cdd",
+      "package": "cnos.cdd"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cds",
+      "package": "cnos.cds"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  },
+  "installed_at": "2026-07-10T00:00:00Z"
+}

--- a/schemas/fixtures/repo-state/invalid/workflow-missing-render-contract.json
+++ b/schemas/fixtures/repo-state/invalid/workflow-missing-render-contract.json
@@ -1,0 +1,38 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".github/workflows/cnos-cds-dispatch.yml",
+      "kind": "workflow",
+      "id": "cnos-cds-dispatch",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cdd",
+      "package": "cnos.cdd"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cds",
+      "package": "cnos.cds"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  }
+}

--- a/schemas/fixtures/repo-state/valid/base-install.json
+++ b/schemas/fixtures/repo-state/valid/base-install.json
@@ -1,0 +1,50 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".cn/deps.json",
+      "kind": "manifest",
+      "id": "deps-manifest",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "path": ".cn/deps.lock.json",
+      "kind": "lockfile",
+      "id": "deps-lockfile",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "path": ".gitignore",
+      "kind": "gitignore",
+      "id": "gitignore",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cdd",
+      "package": "cnos.cdd"
+    },
+    {
+      "path": ".cn/vendor/packages/cnos.cds",
+      "package": "cnos.cds"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  }
+}

--- a/schemas/fixtures/repo-state/valid/with-dispatch-workflow.json
+++ b/schemas/fixtures/repo-state/valid/with-dispatch-workflow.json
@@ -1,0 +1,50 @@
+{
+  "schema": "cn.repo.state.v1",
+  "profile": "cds",
+  "source": {
+    "channel": "stable",
+    "release": "3.82.6",
+    "index": "github:usurobor/cnos/releases/3.82.6/index.json"
+  },
+  "managed_files": [
+    {
+      "path": ".cn/deps.json",
+      "kind": "manifest",
+      "id": "deps-manifest",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "path": ".cn/deps.lock.json",
+      "kind": "lockfile",
+      "id": "deps-lockfile",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "path": ".github/workflows/cnos-cds-dispatch.yml",
+      "kind": "workflow",
+      "id": "cnos-cds-dispatch",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "tier": "agent",
+      "renderer": "cnos.core/install-wake",
+      "renderer_package": "cnos.core",
+      "renderer_version_source": "lock",
+      "agent": "sigma",
+      "workflow_pat_secret": "SIGMA_WORKFLOW_PAT",
+      "bot_name": "sigma@cnos.cn-sigma.cnos",
+      "bot_id": "41898282"
+    }
+  ],
+  "managed_dirs": [
+    {
+      "path": ".cn/vendor/packages/cnos.core",
+      "package": "cnos.core"
+    }
+  ],
+  "external_expectations": {
+    "labels": {
+      "mode": "ensure",
+      "source": "cnos.core/labels.json",
+      "delete_on_uninstall": false
+    }
+  }
+}

--- a/schemas/repo_state.cue
+++ b/schemas/repo_state.cue
@@ -1,0 +1,90 @@
+// schemas/repo_state.cue — CUE schema for `.cn/repo.state.json` (cnos#656,
+// Phase 1 of the cnos#655 `cn repo` lifecycle wave).
+//
+// Types the managed-surface ownership ledger `cn repo install` writes and
+// `cn repo status`/`doctor`/`uninstall` read. Design surface:
+// docs/development/design/cn-repo-lifecycle.md (§Phase-contract precision
+// P1-P3 is the normative AC surface this schema satisfies).
+//
+// Validated by scripts/ci/validate-repo-state.sh, mirroring
+// scripts/ci/validate-skill-frontmatter.sh's schema-owns-shape /
+// script-owns-discovery split for schemas/skill.cue.
+//
+// Unlike schemas/cdd/receipt.cue's #Receipt or schemas/skill.cue's #Skill
+// (both deliberately OPEN — they type externally-authored, forward-compatible
+// formats), #RepoState and its nested definitions are CLOSED (the CUE
+// default for a #Definition with no trailing `...`). `.cn/repo.state.json`
+// is a machine-written ledger, entirely owned by `cn repo install`/`update`/
+// `repair` — never hand-authored — so closedness is the right default here,
+// and it is what makes two P1 invariants structural instead of
+// script-enforced:
+//
+//   - timestamp-free: no timestamp-shaped field is declared anywhere below,
+//     so a fixture adding `timestamp`/`created_at`/`installed_at`/etc. fails
+//     `cue vet` as an unknown-field error under closedness.
+//   - no lock duplication (design doc A1): there is no top-level `packages`
+//     field declared, so a fixture adding one (with `version`/`sha256`)
+//     fails the same way. Package identity is referenced by `name` string
+//     only (managed_dirs[].package), joined against `.cn/deps.lock.json`
+//     (schema cn.lock.v2) at read time by Go code — never copied here.
+//
+// managed_files entries require path/kind/id/sha256 uniformly (not just
+// workflow records) — see gamma-scaffold.md Decision 1 (cnos#656) for why
+// this reads the issue's P1 Acceptance text over the design doc's earlier
+// illustrative JSON, which omitted id/sha256 for manifest/lockfile entries.
+
+package repostate
+
+#RepoState: {
+	schema:  "cn.repo.state.v1"
+	profile: string
+
+	source: #Source
+
+	managed_files: [...#ManagedFile]
+	managed_dirs: [...#ManagedDir]
+
+	external_expectations: {
+		labels: {
+			mode:                 "ensure" | "ignore"
+			source:               string
+			delete_on_uninstall:  bool
+		}
+	}
+}
+
+#Source: {
+	channel: string
+	release: string
+	index:   string
+}
+
+// #ManagedFile types one entry in `managed_files`. Every entry requires
+// path/kind/id/sha256 (P1). Workflow entries additionally require the full
+// render contract (P2) so drift can be classified as matches-ledger /
+// user-edit / renderer-moved without re-deriving render inputs blind.
+#ManagedFile: {
+	path:   string
+	kind:   "manifest" | "lockfile" | "workflow" | "gitignore" | "other"
+	id:     string
+	sha256: string & =~"^[0-9a-f]{64}$"
+
+	if kind == "workflow" {
+		tier:                    "agent" | "engine"
+		renderer:                string
+		renderer_package:        string
+		renderer_version_source: string
+		agent:                   string
+		workflow_pat_secret?:    string
+		bot_name?:               string
+		bot_id?:                 string
+	}
+}
+
+// #ManagedDir types one entry in `managed_dirs` — a materialized vendor
+// directory mapped to the package that owns it. No version/sha256 here
+// (A1): package identity is looked up from `.cn/deps.lock.json` by `package`.
+#ManagedDir: {
+	path:    string
+	package: string
+}

--- a/scripts/ci/validate-repo-state.sh
+++ b/scripts/ci/validate-repo-state.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# scripts/ci/validate-repo-state.sh — validate `.cn/repo.state.json` against
+# schemas/repo_state.cue (cnos#656, P1 CI validation gate).
+#
+# The CUE schema owns shape/type/enum/closedness constraints (including the
+# structural timestamp-free and no-lock-duplication invariants — see
+# schemas/repo_state.cue's header comment). This script owns discovery and
+# the self-test regression suite, mirroring
+# scripts/ci/validate-skill-frontmatter.sh's schema-owns-shape /
+# script-owns-discovery split for schemas/skill.cue.
+#
+# Exit codes:
+#   0  every checked file (or the self-test suite) passed
+#   1  one or more validation failures
+#   2  prerequisite missing (cue) — not a validation failure
+#
+# Usage:
+#   ./scripts/ci/validate-repo-state.sh
+#       Validate ./.cn/repo.state.json if present; no-op (exit 0) if absent
+#       (cnos itself is not a `cn repo install` consumer repo).
+#   ./scripts/ci/validate-repo-state.sh --file <path>
+#       Validate a single repo.state.json path.
+#   ./scripts/ci/validate-repo-state.sh --self-test
+#       Run schemas/fixtures/repo-state/{valid,invalid}/*.json as the
+#       built-in positive/negative regression suite.
+
+set -euo pipefail
+
+if [[ -n "${NO_COLOR:-}" || ! -t 1 ]]; then
+  RED="" GREEN="" RESET=""
+else
+  RED=$'\033[0;31m' GREEN=$'\033[0;32m' RESET=$'\033[0m'
+fi
+SYM_OK="✓" SYM_FAIL="✗"
+
+command -v cue >/dev/null 2>&1 || {
+  echo "${RED}${SYM_FAIL}${RESET} prerequisite missing: cue" >&2
+  exit 2
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SCHEMA="${REPO_ROOT}/schemas/repo_state.cue"
+FIXTURE_VALID="${REPO_ROOT}/schemas/fixtures/repo-state/valid"
+FIXTURE_INVALID="${REPO_ROOT}/schemas/fixtures/repo-state/invalid"
+
+[[ -f "$SCHEMA" ]] || {
+  echo "${RED}${SYM_FAIL}${RESET} schema not found at: $SCHEMA" >&2
+  exit 2
+}
+
+mode="default"
+single_file=""
+while (($#)); do
+  case "$1" in
+    --self-test) mode="self-test"; shift;;
+    --file) mode="file"; single_file="$2"; shift 2;;
+    -h|--help)
+      awk '/^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+      exit 0;;
+    *)
+      echo "${RED}${SYM_FAIL}${RESET} unknown argument: $1" >&2
+      exit 2;;
+  esac
+done
+
+findings=0
+
+# Runs `cue vet` against $1 and prints its outcome. Never touches the global
+# `findings` counter itself — callers decide what counts as a failure (a
+# valid-fixture caller wants "did NOT vet clean" to count; an
+# invalid-fixture caller wants "DID vet clean" to count).
+cue_vet_ok() {
+  local file="$1"
+  cue vet -c -d '#RepoState' "$SCHEMA" "$file"
+}
+
+case "$mode" in
+  file)
+    [[ -f "$single_file" ]] || { echo "${RED}${SYM_FAIL}${RESET} no such file: $single_file" >&2; exit 2; }
+    rel="${single_file#"$REPO_ROOT"/}"
+    if err=$(cue_vet_ok "$single_file" 2>&1); then
+      echo "${GREEN}${SYM_OK}${RESET} $rel"
+    else
+      echo "${RED}${SYM_FAIL}${RESET} $rel"
+      echo "$err" | sed 's/^/    /'
+      findings=$((findings + 1))
+    fi
+    ;;
+  self-test)
+    echo "=== valid fixtures (expect pass) ==="
+    for f in "$FIXTURE_VALID"/*.json; do
+      [[ -e "$f" ]] || continue
+      rel="${f#"$REPO_ROOT"/}"
+      if err=$(cue_vet_ok "$f" 2>&1); then
+        echo "${GREEN}${SYM_OK}${RESET} $rel"
+      else
+        echo "${RED}${SYM_FAIL}${RESET} $rel — expected cue vet to PASS this fixture, but it failed:"
+        echo "$err" | sed 's/^/    /'
+        findings=$((findings + 1))
+      fi
+    done
+    echo
+    echo "=== invalid fixtures (expect reject) ==="
+    for f in "$FIXTURE_INVALID"/*.json; do
+      [[ -e "$f" ]] || continue
+      rel="${f#"$REPO_ROOT"/}"
+      if cue_vet_ok "$f" >/dev/null 2>&1; then
+        echo "${RED}${SYM_FAIL}${RESET} $rel — expected cue vet to REJECT this fixture, but it passed"
+        findings=$((findings + 1))
+      else
+        echo "${GREEN}${SYM_OK}${RESET} $rel (correctly rejected)"
+      fi
+    done
+    ;;
+  default)
+    default_file="${REPO_ROOT}/.cn/repo.state.json"
+    if [[ ! -f "$default_file" ]]; then
+      echo "${GREEN}${SYM_OK}${RESET} no .cn/repo.state.json in this repo — nothing to validate"
+      exit 0
+    fi
+    rel="${default_file#"$REPO_ROOT"/}"
+    if err=$(cue_vet_ok "$default_file" 2>&1); then
+      echo "${GREEN}${SYM_OK}${RESET} $rel"
+    else
+      echo "${RED}${SYM_FAIL}${RESET} $rel"
+      echo "$err" | sed 's/^/    /'
+      findings=$((findings + 1))
+    fi
+    ;;
+esac
+
+if ((findings > 0)); then
+  echo
+  echo "${RED}${SYM_FAIL}${RESET} $findings finding(s)."
+  exit 1
+fi
+
+echo
+echo "${GREEN}${SYM_OK}${RESET} all checks passed."

--- a/src/go/cmd/cn/main.go
+++ b/src/go/cmd/cn/main.go
@@ -49,6 +49,7 @@ func main() {
 	reg.Register(&cli.IssuesFsmCmd{})
 	reg.Register(&cli.IssuesDispatchCmd{})
 	reg.Register(&cli.RepoInstallCmd{})
+	reg.Register(&cli.RepoStatusCmd{})
 	reg.Register(&cli.LabelDoctorCmd{})
 
 	// Discover hub: walk up from cwd to find .cn/.

--- a/src/go/internal/cli/cmd_repo_install_test.go
+++ b/src/go/internal/cli/cmd_repo_install_test.go
@@ -311,7 +311,7 @@ func TestRepoInstall_Idempotent_NoDiffOnSecondRun(t *testing.T) {
 	}
 	runGit(t, repoDir, "diff", "--exit-code")
 
-	runGit(t, repoDir, "add", ".cn/deps.json", ".cn/deps.lock.json", ".gitignore")
+	runGit(t, repoDir, "add", ".cn/deps.json", ".cn/deps.lock.json", ".cn/repo.state.json", ".gitignore")
 	runGit(t, repoDir, "commit", "-q", "-m", "install cds base layer")
 
 	if _, stderr, err := runRepoInstall(t, args); err != nil {

--- a/src/go/internal/cli/cmd_repo_status.go
+++ b/src/go/internal/cli/cmd_repo_status.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/usurobor/cnos/src/go/internal/repostatus"
+)
+
+const repoStatusHelp = `cn repo status - Report this repo's CNOS/CDS install state and drift
+
+USAGE:
+  cn repo status [flags]
+
+DESCRIPTION:
+  Reports source channel/release, per-package desired-vs-locked-vs-vendored
+  versions, the dispatch workflow's presence/tier/drift, canonical label
+  status, orphan vendored packages, locally-edited managed files, and
+  whether a newer release is available (cnos#656, Phase 1 of the cnos#655
+  'cn repo' lifecycle wave).
+
+  This is repo-scoped: "is THIS repo's CNOS install in sync?" — distinct
+  from the existing global 'cn status' (binary/hub health at the current
+  agent hub). Run 'cn status' for hub/binary health; run 'cn repo status'
+  for repo-install drift.
+
+  Read-only: never writes .cn/repo.state.json or any other file, with or
+  without any flag below. When the ledger is absent (pre-cnos#656 installs),
+  reports as much as it can from deps.json/deps.lock.json/vendor/the live
+  workflow file directly, with dispatch drift degraded to "unknown" (no
+  ledger sha to classify against).
+
+FLAGS:
+  --json    Emit the full report as machine-readable JSON (schema
+            cn.repo.status.v1) instead of the human-readable summary.
+  --check   Exit 1 if any drift was detected (packages out of sync, dispatch
+            workflow drifted, canonical labels drifted, orphan vendored
+            packages, or locally-edited managed files); exit 0 otherwise.
+            Without --check, exit code is always 0 regardless of drift —
+            drift is reported, not fatal.
+
+EXAMPLES:
+  cn repo status
+  cn repo status --json
+  cn repo status --check
+
+EXIT CODES:
+  0  Success (report printed; with --check, no drift detected)
+  1  Error (no .cn/deps.json — this repo has no 'cn repo install' state),
+     or with --check, drift was detected
+`
+
+// RepoStatusCmd implements "cn repo status" (cnos#656). NeedsHub is false —
+// this is repo-scoped (resolved via the git repository root), not agent-
+// hub-scoped, mirroring RepoInstallCmd's own A5 rationale.
+type RepoStatusCmd struct{}
+
+func (c *RepoStatusCmd) Spec() CommandSpec {
+	return CommandSpec{
+		Name:     "repo-status",
+		Summary:  "Report this repo's CNOS/CDS install state and drift",
+		Source:   SourceKernel,
+		Tier:     TierKernel,
+		NeedsHub: false,
+	}
+}
+
+func (c *RepoStatusCmd) Help() string {
+	return repoStatusHelp
+}
+
+func (c *RepoStatusCmd) Run(ctx context.Context, inv Invocation) error {
+	jsonOut := false
+	checkMode := false
+	for _, a := range inv.Args {
+		switch a {
+		case "--help", "-h":
+			fmt.Fprint(inv.Stdout, repoStatusHelp)
+			return nil
+		case "--json":
+			jsonOut = true
+		case "--check":
+			checkMode = true
+		default:
+			err := fmt.Errorf("unknown flag: %s", a)
+			fmt.Fprintf(inv.Stderr, "✗ cn repo status: %s\n\n", err)
+			fmt.Fprint(inv.Stderr, repoStatusHelp)
+			return err
+		}
+	}
+
+	// Repo-root resolution: git root, never inv.HubPath — same rationale
+	// as cmd_repo_install.go (A5's repo-scope-vs-hub-scope distinction).
+	root, gerr := gitRepoRoot(ctx)
+	if gerr != nil {
+		fmt.Fprintf(inv.Stderr, "✗ cn repo status must be run inside a Git repository.\n")
+		return fmt.Errorf("repo status: not inside a git repository: %w", gerr)
+	}
+
+	st, err := repostatus.Run(ctx, repostatus.Options{RepoRoot: root})
+	if err != nil {
+		fmt.Fprintf(inv.Stderr, "✗ %s\n", err)
+		return err
+	}
+
+	if jsonOut {
+		data, merr := json.MarshalIndent(st, "", "  ")
+		if merr != nil {
+			return fmt.Errorf("repo status: marshal json: %w", merr)
+		}
+		fmt.Fprintln(inv.Stdout, string(data))
+	} else {
+		renderStatus(inv.Stdout, root, st)
+	}
+
+	if checkMode && st.Drift {
+		return fmt.Errorf("repo status: drift detected")
+	}
+	return nil
+}
+
+func renderStatus(w io.Writer, repoRoot string, st *repostatus.Status) {
+	fmt.Fprintf(w, "→ cn repo status — %s\n", repoRoot)
+
+	if st.Ledger.Present {
+		if st.Source.Release != "" {
+			fmt.Fprintf(w, "✓ source: %s @ %s (%s)\n", st.Source.Channel, st.Source.Release, st.Source.Index)
+		} else {
+			fmt.Fprintf(w, "✓ source: %s (%s)\n", st.Source.Channel, st.Source.Index)
+		}
+	} else {
+		fmt.Fprintf(w, "○ source: unknown (no .cn/repo.state.json ledger)\n")
+	}
+
+	allInSync := true
+	for _, p := range st.Packages {
+		if !p.InSync {
+			allInSync = false
+		}
+	}
+	if allInSync {
+		fmt.Fprintf(w, "✓ deps.json / deps.lock.json / vendor: in sync (%d package(s))\n", len(st.Packages))
+		for _, p := range st.Packages {
+			fmt.Fprintf(w, "    %-12s %s\n", p.Name, p.Desired)
+		}
+	} else {
+		fmt.Fprintf(w, "⚠ deps.json / deps.lock.json / vendor: out of sync\n")
+		for _, p := range st.Packages {
+			if !p.InSync {
+				fmt.Fprintf(w, "    %s: desired=%s locked=%s vendored=%s\n", p.Name, p.Desired, p.Locked, p.Vendored)
+			}
+		}
+	}
+
+	if st.Dispatch.Present {
+		switch st.Dispatch.Drift {
+		case repostatus.DriftMatchesLedger:
+			fmt.Fprintf(w, "✓ dispatch: %s (%s tier) — %s matches ledger\n", st.Dispatch.ID, st.Dispatch.Tier, st.Dispatch.Path)
+		case repostatus.DriftRendererMoved:
+			fmt.Fprintf(w, "⚠ dispatch: %s — %s differs from ledger (renderer_moved: matches a fresh re-render; run `cn repo repair`)\n", st.Dispatch.ID, st.Dispatch.Path)
+		case repostatus.DriftUserEdit:
+			fmt.Fprintf(w, "✗ dispatch: %s — %s differs from ledger (user_edit)\n", st.Dispatch.ID, st.Dispatch.Path)
+		default:
+			fmt.Fprintf(w, "○ dispatch: %s present, drift unknown (no ledger record)\n", st.Dispatch.Path)
+		}
+	} else {
+		fmt.Fprintf(w, "✓ dispatch: none\n")
+	}
+
+	switch st.Labels.Status {
+	case repostatus.LabelsOK:
+		fmt.Fprintf(w, "✓ labels: ok\n")
+	case repostatus.LabelsDrifted:
+		fmt.Fprintf(w, "✗ labels: drifted (missing: %v; drifted: %v)\n", st.Labels.Missing, st.Labels.Drifted)
+	default:
+		fmt.Fprintf(w, "○ labels: unknown (could not resolve repo target or GitHub token)\n")
+	}
+	if len(st.Labels.Unknown) > 0 {
+		fmt.Fprintf(w, "  unknown (non-canonical, informational): %v\n", st.Labels.Unknown)
+	}
+
+	if len(st.OrphanPackages) > 0 {
+		fmt.Fprintf(w, "⚠ orphan vendored packages: %v\n", st.OrphanPackages)
+	} else {
+		fmt.Fprintf(w, "✓ orphan vendored packages: none\n")
+	}
+
+	if len(st.LocalEdits) > 0 {
+		fmt.Fprintf(w, "⚠ locally-edited managed files:\n")
+		for _, e := range st.LocalEdits {
+			fmt.Fprintf(w, "    %s (%s)\n", e.Path, e.Classification)
+		}
+	} else {
+		fmt.Fprintf(w, "✓ locally-edited managed files: none\n")
+	}
+
+	if st.UpdateAvailable.Checked {
+		if st.UpdateAvailable.Available {
+			fmt.Fprintf(w, "  update available: yes — %s (run `cn repo update`)\n", st.UpdateAvailable.Release)
+		} else {
+			fmt.Fprintf(w, "  update available: no (%s is the latest resolved release)\n", st.Source.Release)
+		}
+	} else {
+		fmt.Fprintf(w, "  update available: unknown (network check skipped or failed)\n")
+	}
+
+	fmt.Fprintln(w)
+	if st.Drift {
+		fmt.Fprintf(w, "Drift detected (see ⚠/✗ rows above).\n")
+	} else {
+		fmt.Fprintf(w, "No drift.\n")
+	}
+}

--- a/src/go/internal/cli/cmd_repo_status.go
+++ b/src/go/internal/cli/cmd_repo_status.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/usurobor/cnos/src/go/internal/repostatus"
 )
@@ -173,16 +174,23 @@ func renderStatus(w io.Writer, repoRoot string, st *repostatus.Status) {
 	case repostatus.LabelsOK:
 		fmt.Fprintf(w, "✓ labels: ok\n")
 	case repostatus.LabelsDrifted:
-		fmt.Fprintf(w, "✗ labels: drifted (missing: %v; drifted: %v)\n", st.Labels.Missing, st.Labels.Drifted)
+		var parts []string
+		if len(st.Labels.Missing) > 0 {
+			parts = append(parts, "missing: "+strings.Join(st.Labels.Missing, ", "))
+		}
+		if len(st.Labels.Drifted) > 0 {
+			parts = append(parts, "drifted: "+strings.Join(st.Labels.Drifted, ", "))
+		}
+		fmt.Fprintf(w, "✗ labels: drifted (%s)\n", strings.Join(parts, "; "))
 	default:
 		fmt.Fprintf(w, "○ labels: unknown (could not resolve repo target or GitHub token)\n")
 	}
 	if len(st.Labels.Unknown) > 0 {
-		fmt.Fprintf(w, "  unknown (non-canonical, informational): %v\n", st.Labels.Unknown)
+		fmt.Fprintf(w, "  unknown (non-canonical, informational): %s\n", strings.Join(st.Labels.Unknown, ", "))
 	}
 
 	if len(st.OrphanPackages) > 0 {
-		fmt.Fprintf(w, "⚠ orphan vendored packages: %v\n", st.OrphanPackages)
+		fmt.Fprintf(w, "⚠ orphan vendored packages: %s\n", strings.Join(st.OrphanPackages, ", "))
 	} else {
 		fmt.Fprintf(w, "✓ orphan vendored packages: none\n")
 	}

--- a/src/go/internal/cli/cmd_repo_status.go
+++ b/src/go/internal/cli/cmd_repo_status.go
@@ -166,6 +166,8 @@ func renderStatus(w io.Writer, repoRoot string, st *repostatus.Status) {
 		default:
 			fmt.Fprintf(w, "○ dispatch: %s present, drift unknown (no ledger record)\n", st.Dispatch.Path)
 		}
+	} else if st.Dispatch.Drift == repostatus.DriftRemoved {
+		fmt.Fprintf(w, "⚠ dispatch: %s is recorded in the ledger but no longer exists on disk (removed)\n", st.Dispatch.Path)
 	} else {
 		fmt.Fprintf(w, "✓ dispatch: none\n")
 	}

--- a/src/go/internal/cli/cmd_repo_status.go
+++ b/src/go/internal/cli/cmd_repo_status.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -107,7 +106,7 @@ func (c *RepoStatusCmd) Run(ctx context.Context, inv Invocation) error {
 	}
 
 	if jsonOut {
-		data, merr := json.MarshalIndent(st, "", "  ")
+		data, merr := st.JSON()
 		if merr != nil {
 			return fmt.Errorf("repo status: marshal json: %w", merr)
 		}

--- a/src/go/internal/cli/cmd_repo_status.go
+++ b/src/go/internal/cli/cmd_repo_status.go
@@ -163,6 +163,8 @@ func renderStatus(w io.Writer, repoRoot string, st *repostatus.Status) {
 			fmt.Fprintf(w, "⚠ dispatch: %s — %s differs from ledger (renderer_moved: matches a fresh re-render; run `cn repo repair`)\n", st.Dispatch.ID, st.Dispatch.Path)
 		case repostatus.DriftUserEdit:
 			fmt.Fprintf(w, "✗ dispatch: %s — %s differs from ledger (user_edit)\n", st.Dispatch.ID, st.Dispatch.Path)
+		case repostatus.DriftUnclassified:
+			fmt.Fprintf(w, "✗ dispatch: %s — %s differs from ledger (could not classify further: re-render comparison failed)\n", st.Dispatch.ID, st.Dispatch.Path)
 		default:
 			fmt.Fprintf(w, "○ dispatch: %s present, drift unknown (no ledger record)\n", st.Dispatch.Path)
 		}

--- a/src/go/internal/dispatchrender/dispatchrender.go
+++ b/src/go/internal/dispatchrender/dispatchrender.go
@@ -1,0 +1,110 @@
+// Package dispatchrender invokes the vendored cn-install-wake renderer
+// (cnos#609) to render (or re-render) a cds-dispatch workflow file.
+//
+// Extracted out of internal/repoinstall (cnos#656) so the exact same
+// argument-building logic serves two callers without drifting apart:
+// internal/repoinstall's `cn repo install --dispatch cds` (the original
+// render) and internal/repostatus's `cn repo status` (a fresh re-render
+// into a temp file, compared against the live workflow + the
+// .cn/repo.state.json ledger sha256 to classify drift as matches-ledger /
+// user-edit / renderer-moved — design doc A2). If these two call sites
+// built renderer args independently, a future flag added to one but not
+// the other would silently make A2's drift classification produce false
+// "user_edit" verdicts for every installed repo — this package is the
+// single source of truth for "how do we invoke the renderer" so that
+// class of bug is structurally impossible.
+package dispatchrender
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+)
+
+// Options carries the renderer invocation inputs — the same fields a
+// .cn/repo.state.json workflow managed_files entry records (P2's render
+// contract: schemas/repo_state.cue's #ManagedFile), enough to reproduce
+// the render byte-for-byte given the same vendored renderer version.
+type Options struct {
+	// RepoRoot is the repository root; the renderer is resolved from
+	// RepoRoot's vendored RendererPackage and runs with RepoRoot as its
+	// working directory.
+	RepoRoot string
+	// RendererPackage is the vendored package providing
+	// commands/install-wake/cn-install-wake — "cnos.core" today.
+	RendererPackage   string
+	Tier              string // "agent" | "engine"
+	Agent             string
+	WorkflowPatSecret string
+	BotName           string
+	BotID             string
+	// OutPath is where the renderer writes the workflow file — absolute,
+	// or resolved relative to RepoRoot by the caller.
+	OutPath string
+
+	// Stdout/Stderr receive the renderer subprocess's own output.
+	// Default io.Discard when nil — callers that want the renderer's
+	// interactive install-time output (internal/repoinstall) pass the
+	// real stdout/stderr; callers doing a silent background comparison
+	// (internal/repostatus's fresh-render drift check) leave these nil.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// RendererPath returns the path to the vendored cn-install-wake script
+// Render would invoke for opts.RepoRoot/opts.RendererPackage.
+func RendererPath(repoRoot, rendererPackage string) string {
+	return filepath.Join(pkg.VendorPath(repoRoot, rendererPackage), "commands", "install-wake", "cn-install-wake")
+}
+
+// Render invokes the vendored renderer to write opts.OutPath. Returns an
+// error naming the renderer path if it is not present (the caller's
+// package must be installed first) or if the renderer process itself
+// fails (renderer stderr is included in the returned error).
+func Render(ctx context.Context, opts Options) error {
+	rendererPath := RendererPath(opts.RepoRoot, opts.RendererPackage)
+	if _, err := os.Stat(rendererPath); err != nil {
+		return fmt.Errorf("dispatch renderer not found at %s (the %s package must be installed for --dispatch cds): %w", rendererPath, opts.RendererPackage, err)
+	}
+
+	args := []string{"cds-dispatch", "--out", opts.OutPath, "--agent", opts.Agent}
+	if opts.Tier == "engine" {
+		// Engine tier: the only renderer arg beyond the output path and the
+		// concurrency-group agent name is --tier engine. The identity flags
+		// (workflow-pat-secret / bot-name / bot-id) are deliberately not
+		// forwarded — the engine tier binds nothing to them.
+		args = append(args, "--tier", "engine")
+	} else {
+		if opts.WorkflowPatSecret != "" {
+			args = append(args, "--workflow-pat-secret", opts.WorkflowPatSecret)
+		}
+		if opts.BotName != "" {
+			args = append(args, "--bot-name", opts.BotName)
+		}
+		if opts.BotID != "" {
+			args = append(args, "--bot-id", opts.BotID)
+		}
+	}
+
+	stdout, stderr := opts.Stdout, opts.Stderr
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	cmd := exec.CommandContext(ctx, rendererPath, args...)
+	cmd.Dir = opts.RepoRoot
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("render dispatch workflow: %w", err)
+	}
+	return nil
+}

--- a/src/go/internal/repoinstall/repoinstall.go
+++ b/src/go/internal/repoinstall/repoinstall.go
@@ -41,7 +41,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -49,6 +48,7 @@ import (
 
 	labeldoctor "github.com/usurobor/cnos/packages/cnos.core/commands/label-doctor"
 	"github.com/usurobor/cnos/src/go/internal/binupdate"
+	"github.com/usurobor/cnos/src/go/internal/dispatchrender"
 	"github.com/usurobor/cnos/src/go/internal/hubsetup"
 	"github.com/usurobor/cnos/src/go/internal/pkg"
 	"github.com/usurobor/cnos/src/go/internal/repostate"
@@ -455,40 +455,23 @@ func runDispatchCds(ctx context.Context, opts Options) error {
 		patSecret = "SIGMA_WORKFLOW_PAT"
 	}
 
-	rendererPath := filepath.Join(pkg.VendorPath(opts.RepoRoot, "cnos.core"), "commands", "install-wake", "cn-install-wake")
-	if _, statErr := os.Stat(rendererPath); statErr != nil {
-		err := fmt.Errorf("dispatch renderer not found at %s (the cnos.core package must be installed for --dispatch cds): %w", rendererPath, statErr)
-		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
-		return err
-	}
-
 	outPath := dispatchWorkflowPath(opts.RepoRoot)
-
-	args := []string{"cds-dispatch", "--out", outPath, "--agent", agent}
+	tier := repostate.TierAgent
 	if opts.Engine {
-		// Engine tier: the only renderer arg beyond the output path and the
-		// concurrency-group agent name is --tier engine. The identity flags
-		// (workflow-pat-secret / bot-name / bot-id) are deliberately not
-		// forwarded — the engine tier binds nothing to them.
-		args = append(args, "--tier", "engine")
-	} else {
-		if opts.WorkflowPatSecret != "" {
-			args = append(args, "--workflow-pat-secret", opts.WorkflowPatSecret)
-		}
-		if opts.BotName != "" {
-			args = append(args, "--bot-name", opts.BotName)
-		}
-		if opts.BotID != "" {
-			args = append(args, "--bot-id", opts.BotID)
-		}
+		tier = repostate.TierEngine
 	}
-
-	cmd := exec.CommandContext(ctx, rendererPath, args...)
-	cmd.Dir = opts.RepoRoot
-	cmd.Stdout = opts.Stdout
-	cmd.Stderr = opts.Stderr
-	if err := cmd.Run(); err != nil {
-		err = fmt.Errorf("render dispatch workflow: %w", err)
+	if err := dispatchrender.Render(ctx, dispatchrender.Options{
+		RepoRoot:          opts.RepoRoot,
+		RendererPackage:   "cnos.core",
+		Tier:              tier,
+		Agent:             agent,
+		WorkflowPatSecret: opts.WorkflowPatSecret,
+		BotName:           opts.BotName,
+		BotID:             opts.BotID,
+		OutPath:           outPath,
+		Stdout:            opts.Stdout,
+		Stderr:            opts.Stderr,
+	}); err != nil {
 		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
 		return err
 	}

--- a/src/go/internal/repoinstall/repoinstall.go
+++ b/src/go/internal/repoinstall/repoinstall.go
@@ -322,6 +322,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	var dispatchErr error
+	rendered := false
 	if opts.Dispatch == "cds" {
 		// Base install (above) has already completed and written its
 		// files (AC1/C1) — the dispatch render layers on top of it, not
@@ -332,7 +333,11 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		// error is captured (not returned immediately) so the ledger
 		// write below still runs when the render itself succeeded and
 		// only the label step failed — see the ledger-write comment.
-		dispatchErr = runDispatchCds(ctx, opts)
+		// `rendered` (not "an error occurred") is what decides whether
+		// THIS run actually produced/overwrote the workflow file — see
+		// canWriteLedger below for why that distinction, not mere file
+		// existence, is load-bearing.
+		rendered, dispatchErr = runDispatchCds(ctx, opts)
 		if dispatchErr == nil {
 			fmt.Fprintf(opts.Stdout, "Dispatch: cds (agent: %s)\n", resolveDispatchAgent(opts.Agent))
 		}
@@ -343,22 +348,25 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	// cnos#656 P1: write/update the managed-surface ledger once every
 	// write this run performs has landed on disk. This runs even when
 	// dispatchErr is non-nil, as long as the workflow render itself
-	// produced a file: the ledger describes what IS on disk, and losing
-	// that record because an orthogonal obligation (cnos#493 label
-	// reconciliation) failed would defeat A3's "backfill on next
-	// install" contract for a repo whose base install (and, for
-	// --dispatch cds, workflow render) otherwise succeeded. Skipped only
-	// when --dispatch cds failed before ever writing a workflow file
-	// (the AC2 "no partial render" precondition-failure path, e.g.
-	// missing identity flags) — there is nothing new to describe there,
-	// and hashing a nonexistent file would only produce a confusing
-	// secondary error masking the real one.
-	canWriteLedger := true
-	if opts.Dispatch == "cds" && dispatchErr != nil {
-		if _, statErr := os.Stat(dispatchWorkflowPath(opts.RepoRoot)); statErr != nil {
-			canWriteLedger = false
-		}
-	}
+	// actually ran THIS run (rendered == true): the ledger describes what
+	// IS on disk, and losing that record because an orthogonal
+	// obligation (cnos#493 label reconciliation) failed would defeat A3's
+	// "backfill on next install" contract for a repo whose base install
+	// (and, for --dispatch cds, workflow render) otherwise succeeded.
+	//
+	// Deliberately gated on `rendered`, NOT on "does dispatchWorkflowPath
+	// exist on disk" — the latter is also true when a PRIOR successful
+	// run rendered the file and THIS run's identity gate failed before
+	// ever calling the renderer (e.g. `--dispatch cds --agent acme` with
+	// no --workflow-pat-secret, on a repo an earlier `sigma` install
+	// already rendered). Writing the ledger in that case would describe
+	// an untouched file using THIS run's (different, possibly invalid)
+	// opts.Agent/opts.WorkflowPatSecret/opts.BotName/opts.BotID — silently
+	// corrupting the render-contract metadata for a file nothing this run
+	// touched. Skipping the ledger write when !rendered leaves any
+	// existing ledger exactly as it was, which is correct: nothing on
+	// disk changed, so nothing about the ledger should either.
+	canWriteLedger := opts.Dispatch != "cds" || rendered
 	if canWriteLedger {
 		if err := writeRepoState(opts, manifest, repo, dlBase, releaseTag); err != nil {
 			fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
@@ -458,7 +466,15 @@ func dispatchWorkflowPath(repoRoot string) string {
 //     "origin" remote) or a GitHub token cannot be resolved, or the
 //     GitHub API call itself fails, this surfaces a named, actionable
 //     error once identity resolution + the render themselves succeed.
-func runDispatchCds(ctx context.Context, opts Options) error {
+// runDispatchCds's rendered return value distinguishes "the render itself
+// produced/overwrote the workflow file THIS run" from "runDispatchCds
+// returned an error" — cnos#656's ledger write needs exactly this
+// distinction (see Run's canWriteLedger comment): a stale workflow file
+// left over from a PRIOR successful run must not be mistaken for
+// evidence that THIS run's render happened, or the ledger would be
+// rewritten with this run's (possibly different, possibly invalid)
+// identity/tier fields describing a file nothing here actually touched.
+func runDispatchCds(ctx context.Context, opts Options) (rendered bool, err error) {
 	agent := resolveDispatchAgent(opts.Agent)
 
 	// PAT-secret identity resolution is an AGENT-tier concern only. The
@@ -472,7 +488,7 @@ func runDispatchCds(ctx context.Context, opts Options) error {
 		if agent != "sigma" {
 			err := fmt.Errorf("--workflow-pat-secret is required for --agent %q (no default substrate PAT-secret binding for non-sigma agents); pass --workflow-pat-secret <NAME> naming the GitHub Actions secret that holds this agent's workflow-scoped PAT", agent)
 			fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
-			return err
+			return false, err
 		}
 		// sigma's default substrate PAT binding, mirroring
 		// cn-install-wake's own default (renderer authority; this is
@@ -498,7 +514,7 @@ func runDispatchCds(ctx context.Context, opts Options) error {
 		Stderr:            opts.Stderr,
 	}); err != nil {
 		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
-		return err
+		return false, err
 	}
 
 	fmt.Fprintf(opts.Stdout, "✓ rendered .github/workflows/cnos-cds-dispatch.yml\n")
@@ -513,11 +529,15 @@ func runDispatchCds(ctx context.Context, opts Options) error {
 	fmt.Fprintf(opts.Stdout, "  This changes .github/workflows/ — the installing token needs `workflow` scope.\n")
 	fmt.Fprintf(opts.Stdout, "  Dispatch never pushes to main (PR-only).\n")
 
+	// The render itself succeeded — rendered is true from here on
+	// regardless of what ensureCanonicalDispatchLabels does below; a
+	// label-reconciliation failure is a distinct, orthogonal obligation
+	// (cnos#493), not evidence the render didn't happen.
 	if err := ensureCanonicalDispatchLabels(ctx, opts); err != nil {
 		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
-		return err
+		return true, err
 	}
-	return nil
+	return true, nil
 }
 
 // ensureCanonicalDispatchLabels ensures every canonical label in

--- a/src/go/internal/repoinstall/repoinstall.go
+++ b/src/go/internal/repoinstall/repoinstall.go
@@ -33,6 +33,8 @@ package repoinstall
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,6 +51,7 @@ import (
 	"github.com/usurobor/cnos/src/go/internal/binupdate"
 	"github.com/usurobor/cnos/src/go/internal/hubsetup"
 	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/repostate"
 	"github.com/usurobor/cnos/src/go/internal/restore"
 )
 
@@ -332,6 +335,20 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	} else {
 		fmt.Fprintf(opts.Stdout, "Dispatch: none (base install only — no .github/workflows/ changes)\n")
 	}
+
+	// cnos#656 P1: write/update the managed-surface ledger last, once
+	// every write this run performs (base install + optional dispatch
+	// render) has already landed on disk — the ledger's managed_files
+	// sha256s are content hashes of what Run actually wrote, read back
+	// rather than recomputed from in-memory state, so the ledger can
+	// never drift from the files it describes even if a future change
+	// alters how one of those files is serialized.
+	if err := writeRepoState(opts, manifest, repo, dlBase, releaseTag); err != nil {
+		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+		return nil, err
+	}
+	fmt.Fprintf(opts.Stdout, "✓ wrote .cn/repo.state.json\n")
+
 	fmt.Fprintf(opts.Stdout, "\n✓ cn repo install complete.\n")
 
 	return &Result{ReleaseTag: releaseTag, Manifest: manifest, DryRun: false}, nil
@@ -571,6 +588,127 @@ func applyInstall(ctx context.Context, opts Options, manifest pkg.Manifest, idxP
 	}
 
 	return nil
+}
+
+// writeRepoState builds and writes .cn/repo.state.json (schema
+// cn.repo.state.v1) — the cnos#656 Phase-1 managed-surface ledger. Called
+// once, at the end of Run's non-dry-run path, after every write this run
+// performs (applyInstall's base install + runDispatchCds's optional
+// workflow render) has already landed on disk. Every managed_files sha256
+// is a content hash of the file read back from opts.RepoRoot, never
+// recomputed from in-memory state — so the ledger is always an accurate
+// description of what is actually on disk, and a same-input rerun (same
+// packages, same release, same dispatch flags) produces byte-identical
+// deps.json/deps.lock.json/gitignore/workflow content and therefore a
+// byte-identical ledger (RepoState.Marshal's own Path-sort makes the
+// managed_files/managed_dirs ORDER deterministic on top of that).
+//
+// Running `cn repo install` again on a repo with no prior
+// .cn/repo.state.json backfills one — this is A3's "backfill on next
+// install" for every lifecycle-write command that exists today (`update`/
+// `repair` do not exist yet; see gamma-scaffold.md "Non-goals").
+func writeRepoState(opts Options, manifest pkg.Manifest, repo, dlBase, releaseTag string) error {
+	source := repostate.Source{Channel: "stable", Release: releaseTag}
+	if opts.IndexPath != "" {
+		source.Channel = "index"
+		source.Index = opts.IndexPath
+	} else {
+		source.Index = fmt.Sprintf("%s/%s/releases/download/%s/index.json", dlBase, repo, releaseTag)
+	}
+
+	var managedFiles []repostate.ManagedFile
+
+	depsJSONSHA, err := sha256File(filepath.Join(opts.RepoRoot, ".cn", "deps.json"))
+	if err != nil {
+		return err
+	}
+	managedFiles = append(managedFiles, repostate.ManagedFile{
+		Path: ".cn/deps.json", Kind: repostate.KindManifest, ID: "deps-manifest", SHA256: depsJSONSHA,
+	})
+
+	depsLockSHA, err := sha256File(filepath.Join(opts.RepoRoot, ".cn", "deps.lock.json"))
+	if err != nil {
+		return err
+	}
+	managedFiles = append(managedFiles, repostate.ManagedFile{
+		Path: ".cn/deps.lock.json", Kind: repostate.KindLockfile, ID: "deps-lockfile", SHA256: depsLockSHA,
+	})
+
+	gitignoreSHA, err := sha256File(filepath.Join(opts.RepoRoot, ".gitignore"))
+	if err != nil {
+		return err
+	}
+	managedFiles = append(managedFiles, repostate.ManagedFile{
+		Path: ".gitignore", Kind: repostate.KindGitignore, ID: "gitignore", SHA256: gitignoreSHA,
+	})
+
+	if opts.Dispatch == "cds" {
+		workflowRel := ".github/workflows/cnos-cds-dispatch.yml"
+		workflowSHA, err := sha256File(dispatchWorkflowPath(opts.RepoRoot))
+		if err != nil {
+			return err
+		}
+		tier := repostate.TierAgent
+		if opts.Engine {
+			tier = repostate.TierEngine
+		}
+		agent := resolveDispatchAgent(opts.Agent)
+		patSecret := opts.WorkflowPatSecret
+		if !opts.Engine && patSecret == "" && agent == "sigma" {
+			patSecret = "SIGMA_WORKFLOW_PAT"
+		}
+		wf := repostate.ManagedFile{
+			Path: workflowRel, Kind: repostate.KindWorkflow, ID: "cnos-cds-dispatch", SHA256: workflowSHA,
+			Tier: tier, Renderer: "cnos.core/install-wake", RendererPackage: "cnos.core",
+			RendererVersionSource: "lock", Agent: agent,
+		}
+		if !opts.Engine {
+			wf.WorkflowPatSecret = patSecret
+			wf.BotName = opts.BotName
+			wf.BotID = opts.BotID
+		}
+		managedFiles = append(managedFiles, wf)
+	}
+
+	managedDirs := make([]repostate.ManagedDir, 0, len(manifest.Packages))
+	for _, dep := range manifest.Packages {
+		managedDirs = append(managedDirs, repostate.ManagedDir{
+			Path: path.Join(".cn", "vendor", "packages", dep.Name), Package: dep.Name,
+		})
+	}
+
+	state := repostate.RepoState{
+		Schema:       repostate.Schema,
+		Profile:      manifestProfile,
+		Source:       source,
+		ManagedFiles: managedFiles,
+		ManagedDirs:  managedDirs,
+		ExternalExpectations: repostate.ExternalExpectations{
+			Labels: repostate.LabelExpectations{
+				Mode: repostate.LabelModeEnsure, Source: "cnos.core/labels.json", DeleteOnUninstall: false,
+			},
+		},
+	}
+
+	data, err := state.Marshal()
+	if err != nil {
+		return fmt.Errorf("repo state: %w", err)
+	}
+	statePath := filepath.Join(opts.RepoRoot, ".cn", "repo.state.json")
+	if err := os.WriteFile(statePath, data, 0644); err != nil {
+		return fmt.Errorf("write repo.state.json: %w", err)
+	}
+	return nil
+}
+
+// sha256File returns the lowercase hex SHA-256 of path's content.
+func sha256File(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // writeManifest writes .cn/deps.json deterministically: stable field

--- a/src/go/internal/repoinstall/repoinstall.go
+++ b/src/go/internal/repoinstall/repoinstall.go
@@ -321,33 +321,58 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		return nil, err
 	}
 
+	var dispatchErr error
 	if opts.Dispatch == "cds" {
 		// Base install (above) has already completed and written its
 		// files (AC1/C1) — the dispatch render layers on top of it, not
 		// instead of it. runDispatchCds prints its own identity/PAT-scope
 		// stdout lines and, today, always ends by surfacing the cnos#493
 		// canonical-label gap as a returned error (AC3) — it does not
-		// silently report success while that obligation is unmet.
-		if err := runDispatchCds(ctx, opts); err != nil {
-			return nil, err
+		// silently report success while that obligation is unmet. The
+		// error is captured (not returned immediately) so the ledger
+		// write below still runs when the render itself succeeded and
+		// only the label step failed — see the ledger-write comment.
+		dispatchErr = runDispatchCds(ctx, opts)
+		if dispatchErr == nil {
+			fmt.Fprintf(opts.Stdout, "Dispatch: cds (agent: %s)\n", resolveDispatchAgent(opts.Agent))
 		}
-		fmt.Fprintf(opts.Stdout, "Dispatch: cds (agent: %s)\n", resolveDispatchAgent(opts.Agent))
 	} else {
 		fmt.Fprintf(opts.Stdout, "Dispatch: none (base install only — no .github/workflows/ changes)\n")
 	}
 
-	// cnos#656 P1: write/update the managed-surface ledger last, once
-	// every write this run performs (base install + optional dispatch
-	// render) has already landed on disk — the ledger's managed_files
-	// sha256s are content hashes of what Run actually wrote, read back
-	// rather than recomputed from in-memory state, so the ledger can
-	// never drift from the files it describes even if a future change
-	// alters how one of those files is serialized.
-	if err := writeRepoState(opts, manifest, repo, dlBase, releaseTag); err != nil {
-		fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
-		return nil, err
+	// cnos#656 P1: write/update the managed-surface ledger once every
+	// write this run performs has landed on disk. This runs even when
+	// dispatchErr is non-nil, as long as the workflow render itself
+	// produced a file: the ledger describes what IS on disk, and losing
+	// that record because an orthogonal obligation (cnos#493 label
+	// reconciliation) failed would defeat A3's "backfill on next
+	// install" contract for a repo whose base install (and, for
+	// --dispatch cds, workflow render) otherwise succeeded. Skipped only
+	// when --dispatch cds failed before ever writing a workflow file
+	// (the AC2 "no partial render" precondition-failure path, e.g.
+	// missing identity flags) — there is nothing new to describe there,
+	// and hashing a nonexistent file would only produce a confusing
+	// secondary error masking the real one.
+	canWriteLedger := true
+	if opts.Dispatch == "cds" && dispatchErr != nil {
+		if _, statErr := os.Stat(dispatchWorkflowPath(opts.RepoRoot)); statErr != nil {
+			canWriteLedger = false
+		}
 	}
-	fmt.Fprintf(opts.Stdout, "✓ wrote .cn/repo.state.json\n")
+	if canWriteLedger {
+		if err := writeRepoState(opts, manifest, repo, dlBase, releaseTag); err != nil {
+			fmt.Fprintf(opts.Stderr, "✗ %s\n", err)
+			if dispatchErr == nil {
+				return nil, err
+			}
+		} else {
+			fmt.Fprintf(opts.Stdout, "✓ wrote .cn/repo.state.json\n")
+		}
+	}
+
+	if dispatchErr != nil {
+		return nil, dispatchErr
+	}
 
 	fmt.Fprintf(opts.Stdout, "\n✓ cn repo install complete.\n")
 

--- a/src/go/internal/repoinstall/repoinstall_test.go
+++ b/src/go/internal/repoinstall/repoinstall_test.go
@@ -1113,6 +1113,18 @@ func TestRun_DispatchCds_MissingIdentity_FailsEarlyNoPartialWrite(t *testing.T) 
 			t.Errorf("expected base install artifact %s to still exist: %v", f, statErr)
 		}
 	}
+
+	// cnos#656: a precondition failure BEFORE any render (no workflow
+	// file was ever written) must not produce a ledger either — there is
+	// nothing new on disk for it to describe, and writing one here would
+	// have to either omit the promised workflow record or fabricate one
+	// for a file that doesn't exist. Contrast with
+	// TestRun_WritesRepoState_DispatchWorkflowRenderContract, where the
+	// render DID succeed and the ledger IS written despite a later
+	// (label-doctor) failure.
+	if _, statErr := os.Stat(filepath.Join(repoRoot, ".cn", "repo.state.json")); !os.IsNotExist(statErr) {
+		t.Error("no .cn/repo.state.json may exist after a missing-identity failure (no partial render, nothing new to describe)")
+	}
 }
 
 // AC5 negative case (non-vacuous oracle): the leak grep must actually

--- a/src/go/internal/repoinstall/repostate_write_test.go
+++ b/src/go/internal/repoinstall/repostate_write_test.go
@@ -126,16 +126,11 @@ func TestRun_WritesRepoState_DispatchWorkflowRenderContract(t *testing.T) {
 		t.Fatalf("dispatch workflow was not rendered: %v", statErr)
 	}
 
-	// The ledger write happens after runDispatchCds returns nil — with no
-	// git remote, label-doctor errors, so repo.state.json is never
-	// reached this run. Directly exercise writeRepoState the same way Run
-	// would, to assert the workflow record shape in isolation.
-	manifest := pkg.Manifest{Schema: manifestSchema, Profile: manifestProfile, Packages: []pkg.ManifestDep{{Name: "cnos.core", Version: "9.9.9"}, {Name: "cnos.cds", Version: "9.9.9"}}}
-	opts := Options{RepoRoot: repoRoot, Dispatch: "cds", Engine: true, Stdout: stdout, Stderr: stderr}
-	if err := writeRepoState(opts, manifest, DefaultRepo, defaultDownloadURL, "9.9.9"); err != nil {
-		t.Fatalf("writeRepoState: %v", err)
-	}
-
+	// The render succeeded even though label-doctor (checked above) then
+	// failed — Run still writes the ledger in this case (the fix this
+	// test exists to pin): losing the ledger because an orthogonal
+	// obligation failed would defeat A3's backfill contract for an
+	// otherwise-successful install.
 	data, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "repo.state.json"))
 	if err != nil {
 		t.Fatalf("read repo.state.json: %v", err)

--- a/src/go/internal/repoinstall/repostate_write_test.go
+++ b/src/go/internal/repoinstall/repostate_write_test.go
@@ -1,0 +1,163 @@
+package repoinstall
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/repostate"
+)
+
+// TestRun_WritesRepoState_Deterministic covers cnos#656 P1/P2/A3: install
+// writes .cn/repo.state.json, it validates against schemas/repo_state.cue's
+// closed #RepoState shape (checked structurally here via the Go type — the
+// CUE gate itself is scripts/ci/validate-repo-state.sh's job), no
+// version/sha256 duplication under a "packages" key, and a same-input
+// rerun produces a byte-identical ledger (the idempotence contract).
+func TestRun_WritesRepoState_Deterministic(t *testing.T) {
+	tarData, tarSHA := makeTarGz(t, map[string]string{"cn.package.json": `{"name": "cnos.core", "version": "1.0.0"}`})
+	idx := pkg.PackageIndex{
+		Schema: "cn.package-index.v1",
+		Packages: map[string]map[string]pkg.IndexEntry{
+			"cnos.core": {"1.0.0": {URL: "cnos.core-1.0.0.tar.gz", SHA256: tarSHA}},
+		},
+	}
+	indexBody, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := "acme/widgets"
+	api, dl := newFakeGitHub(t, repo, "1.0.0", indexBody, map[string][]byte{"cnos.core-1.0.0.tar.gz": tarData})
+
+	repoRoot := t.TempDir()
+	runOnce := func() []byte {
+		stdout, stderr := noopStdio()
+		if _, err := Run(context.Background(), Options{
+			RepoRoot:     repoRoot,
+			Release:      "latest",
+			Packages:     []string{"cnos.core"},
+			Repo:         repo,
+			APIBaseURL:   api.URL,
+			DownloadBase: dl.URL,
+			Stdout:       stdout,
+			Stderr:       stderr,
+		}); err != nil {
+			t.Fatalf("Run: %v\nstderr: %s", err, stderr.String())
+		}
+		data, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "repo.state.json"))
+		if err != nil {
+			t.Fatalf("read repo.state.json: %v", err)
+		}
+		return data
+	}
+
+	first := runOnce()
+
+	var state repostate.RepoState
+	if err := json.Unmarshal(first, &state); err != nil {
+		t.Fatalf("parse repo.state.json: %v", err)
+	}
+	if state.Schema != repostate.Schema {
+		t.Errorf("schema = %q, want %q", state.Schema, repostate.Schema)
+	}
+	if state.Source.Release != "1.0.0" {
+		t.Errorf("source.release = %q, want 1.0.0", state.Source.Release)
+	}
+	if f := state.FindManagedFile(".cn/deps.json"); f == nil || f.SHA256 == "" {
+		t.Errorf("managed_files missing a hashed .cn/deps.json entry: %+v", f)
+	}
+	if d := state.FindManagedDir("cnos.core"); d == nil || d.Path != ".cn/vendor/packages/cnos.core" {
+		t.Errorf("managed_dirs missing cnos.core: %+v", d)
+	}
+
+	// No top-level "packages" key (design doc A1 — no lock duplication).
+	var raw map[string]any
+	if err := json.Unmarshal(first, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := raw["packages"]; present {
+		t.Error("repo.state.json carries a top-level \"packages\" key — violates A1 (no lock duplication)")
+	}
+	for k := range raw {
+		if k == "timestamp" || k == "created_at" || k == "installed_at" || k == "updated_at" {
+			t.Errorf("repo.state.json carries a timestamp-shaped field %q — violates P1 (timestamp-free)", k)
+		}
+	}
+
+	second := runOnce()
+	if string(first) != string(second) {
+		t.Errorf("repo.state.json not idempotent across reruns:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+// TestRun_WritesRepoState_DispatchWorkflowRenderContract covers P2: a
+// dispatch-cds install's workflow managed_files entry carries the full
+// render contract (tier/renderer/renderer_package/renderer_version_source/
+// agent), not just path/kind/id/sha256/tier.
+func TestRun_WritesRepoState_DispatchWorkflowRenderContract(t *testing.T) {
+	indexPath := writeDispatchFixtureIndex(t)
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+	_, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core", "cnos.cds"},
+		Dispatch:  "cds",
+		Engine:    true, // engine tier needs no PAT/identity fixture wiring
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	// ensureCanonicalDispatchLabels will fail in this fixture (no git
+	// remote configured) — that's expected and orthogonal to what this
+	// test checks (the workflow file + its would-be ledger record exist
+	// before that later failure). Only fail the test on an error that
+	// isn't the known label-doctor gap.
+	if err == nil || !strings.Contains(err.Error(), "canonical dispatch labels not ensured") {
+		t.Fatalf("Run: unexpected error %v\nstderr: %s", err, stderr.String())
+	}
+
+	workflowPath := dispatchWorkflowPath(repoRoot)
+	if _, statErr := os.Stat(workflowPath); statErr != nil {
+		t.Fatalf("dispatch workflow was not rendered: %v", statErr)
+	}
+
+	// The ledger write happens after runDispatchCds returns nil — with no
+	// git remote, label-doctor errors, so repo.state.json is never
+	// reached this run. Directly exercise writeRepoState the same way Run
+	// would, to assert the workflow record shape in isolation.
+	manifest := pkg.Manifest{Schema: manifestSchema, Profile: manifestProfile, Packages: []pkg.ManifestDep{{Name: "cnos.core", Version: "9.9.9"}, {Name: "cnos.cds", Version: "9.9.9"}}}
+	opts := Options{RepoRoot: repoRoot, Dispatch: "cds", Engine: true, Stdout: stdout, Stderr: stderr}
+	if err := writeRepoState(opts, manifest, DefaultRepo, defaultDownloadURL, "9.9.9"); err != nil {
+		t.Fatalf("writeRepoState: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "repo.state.json"))
+	if err != nil {
+		t.Fatalf("read repo.state.json: %v", err)
+	}
+	var state repostate.RepoState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("parse repo.state.json: %v", err)
+	}
+	wf := state.FindManagedFile(".github/workflows/cnos-cds-dispatch.yml")
+	if wf == nil {
+		t.Fatal("no workflow managed_files entry")
+	}
+	if wf.Kind != repostate.KindWorkflow {
+		t.Errorf("kind = %q, want %q", wf.Kind, repostate.KindWorkflow)
+	}
+	if wf.Tier != repostate.TierEngine {
+		t.Errorf("tier = %q, want %q", wf.Tier, repostate.TierEngine)
+	}
+	if wf.Renderer == "" || wf.RendererPackage == "" || wf.RendererVersionSource == "" || wf.Agent == "" {
+		t.Errorf("workflow render contract incomplete: %+v", wf)
+	}
+	if wf.SHA256 == "" {
+		t.Error("workflow managed_files entry has empty sha256")
+	}
+}

--- a/src/go/internal/repoinstall/repostate_write_test.go
+++ b/src/go/internal/repoinstall/repostate_write_test.go
@@ -156,3 +156,104 @@ func TestRun_WritesRepoState_DispatchWorkflowRenderContract(t *testing.T) {
 		t.Error("workflow managed_files entry has empty sha256")
 	}
 }
+
+// TestRun_DispatchCds_StaleWorkflowFileFromPriorRun_LedgerNotCorrupted pins
+// a bug an adversarial review caught in the first draft of the
+// dispatchErr/canWriteLedger restructure: `canWriteLedger` was derived from
+// os.Stat(dispatchWorkflowPath(...)) — "does a file exist at the fixed
+// output path" — which is ALSO true when a PRIOR successful run rendered
+// the file and THIS run's identity gate fails before ever calling the
+// renderer again. Writing the ledger in that case described an untouched
+// file using THIS run's (different) opts.Agent/opts.WorkflowPatSecret,
+// silently corrupting the render-contract metadata for a file nothing this
+// run touched. The fix threads runDispatchCds's own `rendered` bool through
+// instead of re-deriving it from file presence.
+func TestRun_DispatchCds_StaleWorkflowFileFromPriorRun_LedgerNotCorrupted(t *testing.T) {
+	indexPath := writeDispatchFixtureIndex(t)
+	repoRoot := t.TempDir()
+	stdout, stderr := noopStdio()
+
+	// First run: sigma/engine tier, fully succeeds (engine tier skips the
+	// label-doctor gap entirely — no, it doesn't; engine still calls
+	// ensureCanonicalDispatchLabels. Use a real successful render by
+	// tolerating the expected label-doctor failure, same as
+	// TestRun_WritesRepoState_DispatchWorkflowRenderContract, then assert
+	// the ledger this first run produced.
+	if _, err := Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core", "cnos.cds"},
+		Dispatch:  "cds",
+		Engine:    true,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}); err == nil || !strings.Contains(err.Error(), "canonical dispatch labels not ensured") {
+		t.Fatalf("first Run: unexpected error %v\nstderr: %s", err, stderr.String())
+	}
+
+	firstData, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "repo.state.json"))
+	if err != nil {
+		t.Fatalf("read repo.state.json after first run: %v", err)
+	}
+	var firstState repostate.RepoState
+	if err := json.Unmarshal(firstData, &firstState); err != nil {
+		t.Fatal(err)
+	}
+	firstWF := firstState.FindManagedFile(".github/workflows/cnos-cds-dispatch.yml")
+	if firstWF == nil || firstWF.Agent != "sigma" || firstWF.Tier != repostate.TierEngine {
+		t.Fatalf("first run's ledger workflow entry unexpected: %+v", firstWF)
+	}
+	firstWorkflowBytes, err := os.ReadFile(dispatchWorkflowPath(repoRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run: a DIFFERENT, non-sigma agent with no --workflow-pat-secret
+	// and Engine: false — this fails at the identity gate INSIDE
+	// runDispatchCds, before dispatchrender.Render is ever called again.
+	// The workflow file on disk is the first run's sigma/engine render,
+	// untouched.
+	stdout2, stderr2 := noopStdio()
+	_, err = Run(context.Background(), Options{
+		RepoRoot:  repoRoot,
+		IndexPath: indexPath,
+		Packages:  []string{"cnos.core", "cnos.cds"},
+		Dispatch:  "cds",
+		Agent:     "acme",
+		Stdout:    stdout2,
+		Stderr:    stderr2,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--workflow-pat-secret") {
+		t.Fatalf("second Run: expected the identity gate to fail, got %v\nstderr: %s", err, stderr2.String())
+	}
+
+	// The live workflow file must be byte-identical to the first run's
+	// render — the second run's failed identity gate must not have
+	// touched it.
+	secondWorkflowBytes, err := os.ReadFile(dispatchWorkflowPath(repoRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstWorkflowBytes) != string(secondWorkflowBytes) {
+		t.Error("workflow file changed after a failed-identity-gate rerun — it should be untouched")
+	}
+
+	// The ledger must still describe the FIRST run's render (sigma,
+	// engine) — not be rewritten with the second run's acme identity for
+	// a file the second run never actually produced.
+	secondData, err := os.ReadFile(filepath.Join(repoRoot, ".cn", "repo.state.json"))
+	if err != nil {
+		t.Fatalf("read repo.state.json after second run: %v", err)
+	}
+	var secondState repostate.RepoState
+	if err := json.Unmarshal(secondData, &secondState); err != nil {
+		t.Fatal(err)
+	}
+	secondWF := secondState.FindManagedFile(".github/workflows/cnos-cds-dispatch.yml")
+	if secondWF == nil {
+		t.Fatal("ledger lost its workflow entry entirely after the second run")
+	}
+	if secondWF.Agent != "sigma" || secondWF.Tier != repostate.TierEngine {
+		t.Errorf("ledger workflow entry corrupted by the second (failed, non-rendering) run: got agent=%q tier=%q, want agent=sigma tier=engine (the first run's actual render)", secondWF.Agent, secondWF.Tier)
+	}
+}

--- a/src/go/internal/repostate/repostate.go
+++ b/src/go/internal/repostate/repostate.go
@@ -1,0 +1,162 @@
+// Package repostate defines the pure types for `.cn/repo.state.json`
+// (schema cn.repo.state.v1) — the managed-surface ownership ledger
+// cnos#656 (Phase 1 of the cnos#655 `cn repo` lifecycle wave) introduces.
+//
+// Discipline: no os, no net, no io — file reading/writing lives in
+// internal/repoinstall (write) and internal/repostatus (read), mirroring
+// internal/pkg's own split (pkg.go:9-11). Field names and JSON tags match
+// schemas/repo_state.cue exactly; that CUE file is the enforcement gate
+// (via `cue vet`, scripts/ci/validate-repo-state.sh), not this package —
+// these types exist to read/write the shape CUE already validates.
+package repostate
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Schema is the fixed schema identifier every ledger declares.
+const Schema = "cn.repo.state.v1"
+
+// Managed-file kinds. Mirrors schemas/repo_state.cue's #ManagedFile.kind enum.
+const (
+	KindManifest  = "manifest"
+	KindLockfile  = "lockfile"
+	KindWorkflow  = "workflow"
+	KindGitignore = "gitignore"
+	KindOther     = "other"
+)
+
+// Workflow dispatch tiers. Mirrors the renderer's own --tier values
+// (cn-install-wake:63-72) and schemas/repo_state.cue's #ManagedFile.tier enum.
+const (
+	TierAgent  = "agent"
+	TierEngine = "engine"
+)
+
+// Label-expectation modes. Mirrors schemas/repo_state.cue's
+// #RepoState.external_expectations.labels.mode enum.
+const (
+	LabelModeEnsure = "ensure"
+	LabelModeIgnore = "ignore"
+)
+
+// Source records where the installed release came from.
+type Source struct {
+	Channel string `json:"channel"`
+	Release string `json:"release"`
+	Index   string `json:"index"`
+}
+
+// ManagedFile is one entry in RepoState.ManagedFiles. Path/Kind/ID/SHA256
+// are required for every entry (P1). The render-contract fields
+// (Tier/Renderer/RendererPackage/RendererVersionSource/Agent/
+// WorkflowPatSecret/BotName/BotID) are populated only for Kind ==
+// KindWorkflow (P2) — `omitempty` keeps non-workflow entries free of empty
+// render-contract keys in the serialized JSON, matching the CUE schema's
+// conditional `if kind == "workflow"` block.
+type ManagedFile struct {
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	ID     string `json:"id"`
+	SHA256 string `json:"sha256"`
+
+	Tier                  string `json:"tier,omitempty"`
+	Renderer              string `json:"renderer,omitempty"`
+	RendererPackage       string `json:"renderer_package,omitempty"`
+	RendererVersionSource string `json:"renderer_version_source,omitempty"`
+	Agent                 string `json:"agent,omitempty"`
+	WorkflowPatSecret     string `json:"workflow_pat_secret,omitempty"`
+	BotName               string `json:"bot_name,omitempty"`
+	BotID                 string `json:"bot_id,omitempty"`
+}
+
+// ManagedDir maps a materialized vendor directory to the package that owns
+// it. No version/sha256 here by design (design doc A1): package identity
+// is looked up from .cn/deps.lock.json by Package at read time.
+type ManagedDir struct {
+	Path    string `json:"path"`
+	Package string `json:"package"`
+}
+
+// LabelExpectations types RepoState.ExternalExpectations.Labels.
+type LabelExpectations struct {
+	Mode               string `json:"mode"`
+	Source             string `json:"source"`
+	DeleteOnUninstall  bool   `json:"delete_on_uninstall"`
+}
+
+// ExternalExpectations types RepoState.ExternalExpectations.
+type ExternalExpectations struct {
+	Labels LabelExpectations `json:"labels"`
+}
+
+// RepoState is the parsed/constructed .cn/repo.state.json. Deterministic,
+// timestamp-free (P1/P3) — ManagedFiles/ManagedDirs are sorted by Path
+// before serialization (see Sort) so a same-input rerun produces byte-
+// identical output.
+type RepoState struct {
+	Schema               string               `json:"schema"`
+	Profile              string               `json:"profile"`
+	Source               Source               `json:"source"`
+	ManagedFiles         []ManagedFile        `json:"managed_files"`
+	ManagedDirs          []ManagedDir         `json:"managed_dirs"`
+	ExternalExpectations ExternalExpectations `json:"external_expectations"`
+}
+
+// Sort orders ManagedFiles and ManagedDirs by Path in place, so two
+// RepoState values built from the same inputs (regardless of map/slice
+// build order upstream) marshal to identical bytes.
+func (s *RepoState) Sort() {
+	sort.Slice(s.ManagedFiles, func(i, j int) bool {
+		return s.ManagedFiles[i].Path < s.ManagedFiles[j].Path
+	})
+	sort.Slice(s.ManagedDirs, func(i, j int) bool {
+		return s.ManagedDirs[i].Path < s.ManagedDirs[j].Path
+	})
+}
+
+// Marshal renders s as deterministic, indented JSON with a trailing
+// newline — the same convention internal/repoinstall's writeManifest uses
+// for .cn/deps.json (repoinstall.go:580-590). Calls Sort first so callers
+// never need to remember to do so.
+func (s *RepoState) Marshal() ([]byte, error) {
+	s.Sort()
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal repo state: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// Parse parses a .cn/repo.state.json from raw JSON bytes. Pure — no IO.
+func Parse(data []byte) (*RepoState, error) {
+	var s RepoState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse repo state: %w", err)
+	}
+	return &s, nil
+}
+
+// FindManagedFile returns the ManagedFile entry with the given path, or
+// nil if absent.
+func (s *RepoState) FindManagedFile(path string) *ManagedFile {
+	for i := range s.ManagedFiles {
+		if s.ManagedFiles[i].Path == path {
+			return &s.ManagedFiles[i]
+		}
+	}
+	return nil
+}
+
+// FindManagedDir returns the ManagedDir entry with the given package name,
+// or nil if absent.
+func (s *RepoState) FindManagedDir(pkgName string) *ManagedDir {
+	for i := range s.ManagedDirs {
+		if s.ManagedDirs[i].Package == pkgName {
+			return &s.ManagedDirs[i]
+		}
+	}
+	return nil
+}

--- a/src/go/internal/repostate/repostate_test.go
+++ b/src/go/internal/repostate/repostate_test.go
@@ -1,0 +1,168 @@
+package repostate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func exampleState() *RepoState {
+	return &RepoState{
+		Schema:  Schema,
+		Profile: "cds",
+		Source: Source{
+			Channel: "stable",
+			Release: "3.82.6",
+			Index:   "github:usurobor/cnos/releases/3.82.6/index.json",
+		},
+		ManagedFiles: []ManagedFile{
+			{Path: ".cn/deps.lock.json", Kind: KindLockfile, ID: "deps-lockfile", SHA256: strings.Repeat("b", 64)},
+			{Path: ".cn/deps.json", Kind: KindManifest, ID: "deps-manifest", SHA256: strings.Repeat("a", 64)},
+			{
+				Path: ".github/workflows/cnos-cds-dispatch.yml", Kind: KindWorkflow,
+				ID: "cnos-cds-dispatch", SHA256: strings.Repeat("d", 64),
+				Tier: TierAgent, Renderer: "cnos.core/install-wake",
+				RendererPackage: "cnos.core", RendererVersionSource: "lock",
+				Agent: "sigma", WorkflowPatSecret: "SIGMA_WORKFLOW_PAT",
+				BotName: "sigma@cnos.cn-sigma.cnos", BotID: "41898282",
+			},
+		},
+		ManagedDirs: []ManagedDir{
+			{Path: ".cn/vendor/packages/cnos.cds", Package: "cnos.cds"},
+			{Path: ".cn/vendor/packages/cnos.core", Package: "cnos.core"},
+		},
+		ExternalExpectations: ExternalExpectations{
+			Labels: LabelExpectations{Mode: LabelModeEnsure, Source: "cnos.core/labels.json", DeleteOnUninstall: false},
+		},
+	}
+}
+
+func TestMarshal_SortsManagedFilesAndDirsByPath(t *testing.T) {
+	s := exampleState()
+	data, err := s.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	files := got["managed_files"].([]any)
+	var paths []string
+	for _, f := range files {
+		paths = append(paths, f.(map[string]any)["path"].(string))
+	}
+	want := []string{".cn/deps.json", ".cn/deps.lock.json", ".github/workflows/cnos-cds-dispatch.yml"}
+	for i, w := range want {
+		if paths[i] != w {
+			t.Errorf("managed_files[%d].path = %q, want %q (full order: %v)", i, paths[i], w, paths)
+		}
+	}
+
+	dirs := got["managed_dirs"].([]any)
+	firstDirPath := dirs[0].(map[string]any)["path"].(string)
+	if firstDirPath != ".cn/vendor/packages/cnos.cds" {
+		t.Errorf("managed_dirs[0].path = %q, want sorted-first %q", firstDirPath, ".cn/vendor/packages/cnos.cds")
+	}
+}
+
+func TestMarshal_DeterministicAcrossBuildOrder(t *testing.T) {
+	a := exampleState()
+	b := exampleState()
+	// Reverse b's slices before marshaling — Sort() inside Marshal must
+	// make the output byte-identical regardless of build/insertion order,
+	// which is what makes a same-input `cn repo install` rerun produce no
+	// diff (design doc's idempotence contract).
+	b.ManagedFiles[0], b.ManagedFiles[1] = b.ManagedFiles[1], b.ManagedFiles[0]
+	b.ManagedDirs[0], b.ManagedDirs[1] = b.ManagedDirs[1], b.ManagedDirs[0]
+
+	dataA, err := a.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal a: %v", err)
+	}
+	dataB, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal b: %v", err)
+	}
+	if string(dataA) != string(dataB) {
+		t.Errorf("Marshal not deterministic across build order:\na=%s\nb=%s", dataA, dataB)
+	}
+}
+
+func TestMarshal_TrailingNewline(t *testing.T) {
+	data, err := exampleState().Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("Marshal output does not end with a newline")
+	}
+}
+
+func TestParse_RoundTrip(t *testing.T) {
+	original := exampleState()
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	parsed, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	data2, err := parsed.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal (round-trip): %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Errorf("round-trip not stable:\noriginal=%s\nround-tripped=%s", data, data2)
+	}
+}
+
+func TestParse_MalformedJSON(t *testing.T) {
+	if _, err := Parse([]byte("{not json")); err == nil {
+		t.Error("Parse of malformed JSON: got nil error, want non-nil")
+	}
+}
+
+func TestFindManagedFile(t *testing.T) {
+	s := exampleState()
+	if f := s.FindManagedFile(".cn/deps.json"); f == nil || f.Kind != KindManifest {
+		t.Errorf("FindManagedFile(.cn/deps.json) = %+v, want manifest entry", f)
+	}
+	if f := s.FindManagedFile("nonexistent"); f != nil {
+		t.Errorf("FindManagedFile(nonexistent) = %+v, want nil", f)
+	}
+}
+
+func TestFindManagedDir(t *testing.T) {
+	s := exampleState()
+	if d := s.FindManagedDir("cnos.core"); d == nil || d.Path != ".cn/vendor/packages/cnos.core" {
+		t.Errorf("FindManagedDir(cnos.core) = %+v, want vendor path entry", d)
+	}
+	if d := s.FindManagedDir("nonexistent"); d != nil {
+		t.Errorf("FindManagedDir(nonexistent) = %+v, want nil", d)
+	}
+}
+
+func TestManagedFile_NonWorkflowOmitsRenderContractFields(t *testing.T) {
+	s := exampleState()
+	data, err := s.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	for _, f := range got["managed_files"].([]any) {
+		m := f.(map[string]any)
+		if m["kind"] != KindWorkflow {
+			for _, renderField := range []string{"tier", "renderer", "renderer_package", "renderer_version_source", "agent", "workflow_pat_secret", "bot_name", "bot_id"} {
+				if _, present := m[renderField]; present {
+					t.Errorf("non-workflow managed_files entry %q carries render-contract field %q (should be omitted)", m["path"], renderField)
+				}
+			}
+		}
+	}
+}

--- a/src/go/internal/repostatus/repostatus.go
+++ b/src/go/internal/repostatus/repostatus.go
@@ -1,0 +1,454 @@
+// Package repostatus implements `cn repo status` (cnos#656, Phase 1 of the
+// cnos#655 `cn repo` lifecycle wave): a read-only report of a repo's
+// installed CNOS/CDS state versus its desired/locked/ledger state.
+//
+// Discipline: this package NEVER writes to opts.RepoRoot (design doc P3 —
+// "cn repo status is read-only by default"). It may fetch a release tag
+// over the network for the update-available check, and it may invoke the
+// vendored cn-install-wake renderer into a throwaway temp file to compute
+// a fresh-render comparison sha (A2 drift classification) — neither of
+// those touches opts.RepoRoot itself.
+//
+// This is scoped distinctly from the existing global `cn status`
+// (internal/hubstatus — binary/hub health, operates on the agent hub at
+// inv.HubPath) per the design doc's A5: `cn repo status` answers "is THIS
+// REPO's CNOS install in sync?", resolved via the git repository root,
+// never via inv.HubPath.
+package repostatus
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	labeldoctor "github.com/usurobor/cnos/packages/cnos.core/commands/label-doctor"
+	"github.com/usurobor/cnos/src/go/internal/binupdate"
+	"github.com/usurobor/cnos/src/go/internal/dispatchrender"
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/repostate"
+	"github.com/usurobor/cnos/src/go/internal/restore"
+)
+
+// StatusSchema is the fixed schema identifier `--json` output declares.
+const StatusSchema = "cn.repo.status.v1"
+
+// DefaultRepo mirrors repoinstall.DefaultRepo (kept as an independent
+// literal, not an import, to avoid a status->install dependency for a
+// single stable constant).
+const DefaultRepo = "usurobor/cnos"
+
+// Drift classification values (design doc A2).
+const (
+	DriftMatchesLedger = "matches_ledger"
+	DriftUserEdit       = "user_edit"
+	DriftRendererMoved  = "renderer_moved"
+	DriftUnknown        = "unknown"
+)
+
+// Label status values.
+const (
+	LabelsOK      = "ok"
+	LabelsDrifted = "drifted"
+	LabelsUnknown = "unknown"
+)
+
+type PackageStatus struct {
+	Name     string `json:"name"`
+	Desired  string `json:"desired,omitempty"`
+	Locked   string `json:"locked,omitempty"`
+	Vendored string `json:"vendored,omitempty"`
+	InSync   bool   `json:"in_sync"`
+}
+
+type DispatchStatus struct {
+	Present bool   `json:"present"`
+	Tier    string `json:"tier,omitempty"`
+	ID      string `json:"id,omitempty"`
+	Path    string `json:"path,omitempty"`
+	// Drift is "" when Present is false; otherwise one of
+	// matches_ledger / user_edit / renderer_moved / unknown.
+	Drift string `json:"drift,omitempty"`
+}
+
+type LabelStatus struct {
+	// Status is "ok" (no missing/drifted canonical labels), "drifted"
+	// (at least one missing or color/description-drifted canonical
+	// label), or "unknown" (repo target or GitHub token could not be
+	// resolved — informational, never treated as drift by IsDrift).
+	Status  string   `json:"status"`
+	Missing []string `json:"missing,omitempty"`
+	// Drifted names canonical labels present with a wrong color/
+	// description. Exceeds the design doc's illustrative
+	// {status,missing,unknown} shape (mock_parity row A4 — safe:
+	// additional, non-conflicting information).
+	Drifted []string `json:"drifted,omitempty"`
+	// Unknown names labels present on the repo but not in the canonical
+	// manifest — informational only, never contributes to Status or to
+	// the top-level Drift verdict.
+	Unknown []string `json:"unknown,omitempty"`
+}
+
+type LocalEdit struct {
+	Path string `json:"path"`
+	// Classification is "user_edit" (content differs from the ledger
+	// sha256) or "removed" (the managed file no longer exists on disk).
+	Classification string `json:"classification"`
+}
+
+type UpdateAvailable struct {
+	// Checked reports whether the network resolution actually ran;
+	// false means "could not determine" (offline, no token, etc.) —
+	// distinct from Available=false, which means "checked, and current".
+	Checked   bool   `json:"checked"`
+	Available bool   `json:"available"`
+	Release   string `json:"release,omitempty"`
+}
+
+type LedgerInfo struct {
+	Present       bool `json:"present"`
+	Reconstructed bool `json:"reconstructed"`
+}
+
+// Status is the full `cn repo status` report — the `--json` shape.
+type Status struct {
+	Schema          string           `json:"schema"`
+	Source          repostate.Source `json:"source"`
+	Packages        []PackageStatus  `json:"packages"`
+	Dispatch        DispatchStatus   `json:"dispatch"`
+	Labels          LabelStatus      `json:"labels"`
+	OrphanPackages  []string         `json:"orphan_packages"`
+	LocalEdits      []LocalEdit      `json:"local_edits"`
+	UpdateAvailable UpdateAvailable  `json:"update_available"`
+	Ledger          LedgerInfo       `json:"ledger"`
+	Drift           bool             `json:"drift"`
+}
+
+// Options carries Run's configuration. Every field beyond RepoRoot is
+// optional and defaults to production behavior (live GitHub API calls for
+// labels/update-available) — tests override HTTPClient/APIBaseURL/
+// DownloadBase/Repo/Token/SkipNetwork the same way repoinstall's test
+// seams work.
+type Options struct {
+	RepoRoot string
+
+	// Repo/Token override label-doctor's and the update-available
+	// check's target repo/token resolution. Empty means "resolve from
+	// RepoRoot's git origin remote" (labels) / DefaultRepo (update
+	// check).
+	Repo  string
+	Token string
+
+	HTTPClient   *http.Client
+	APIBaseURL   string
+	DownloadBase string
+
+	// SkipNetwork disables the update-available check entirely (tests
+	// that don't want any live/mock HTTP call for that informational
+	// field). Label lookups are unaffected — they already degrade to
+	// LabelsUnknown on any resolution failure.
+	SkipNetwork bool
+}
+
+// Run produces a Status report for opts.RepoRoot. Never writes to
+// opts.RepoRoot (P3).
+func Run(ctx context.Context, opts Options) (*Status, error) {
+	if opts.RepoRoot == "" {
+		return nil, fmt.Errorf("repo status: RepoRoot is required")
+	}
+
+	manifestPath := filepath.Join(opts.RepoRoot, ".cn", "deps.json")
+	manifest, err := restore.ReadManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("repo status: %s not found or unreadable — this repo has no `cn repo install` state (%w)", manifestPath, err)
+	}
+
+	lockPath := filepath.Join(opts.RepoRoot, ".cn", "deps.lock.json")
+	lockfile, lockErr := restore.ReadLockfile(lockPath)
+	locked := map[string]string{}
+	if lockErr == nil {
+		for _, dep := range lockfile.Packages {
+			locked[dep.Name] = dep.Version
+		}
+	}
+
+	statePath := filepath.Join(opts.RepoRoot, ".cn", "repo.state.json")
+	ledger, ledgerErr := readLedger(statePath)
+	ledgerInfo := LedgerInfo{Present: ledgerErr == nil, Reconstructed: ledgerErr != nil}
+
+	packages, orphans := packageStatuses(opts.RepoRoot, manifest, locked, lockErr == nil)
+
+	dispatch := dispatchStatus(ctx, opts.RepoRoot, ledger)
+	labels := labelStatus(ctx, opts)
+	localEdits := localEditStatus(opts.RepoRoot, ledger)
+	update := updateAvailableStatus(ctx, opts, ledger)
+
+	drift := false
+	for _, p := range packages {
+		if !p.InSync {
+			drift = true
+		}
+	}
+	if dispatch.Drift == DriftUserEdit || dispatch.Drift == DriftRendererMoved {
+		drift = true
+	}
+	if labels.Status == LabelsDrifted {
+		drift = true
+	}
+	if len(orphans) > 0 || len(localEdits) > 0 {
+		drift = true
+	}
+
+	source := repostate.Source{}
+	if ledger != nil {
+		source = ledger.Source
+	}
+
+	return &Status{
+		Schema:          StatusSchema,
+		Source:          source,
+		Packages:        packages,
+		Dispatch:        dispatch,
+		Labels:          labels,
+		OrphanPackages:  orphans,
+		LocalEdits:      localEdits,
+		UpdateAvailable: update,
+		Ledger:          ledgerInfo,
+		Drift:           drift,
+	}, nil
+}
+
+func readLedger(path string) (*repostate.RepoState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return repostate.Parse(data)
+}
+
+// packageStatuses reports desired/locked/vendored per manifest package,
+// plus orphan vendored directories (materialized but absent from the
+// lockfile — design doc's orphan-package invariant). Orphan detection
+// only runs when lockPresent — with no lockfile at all there is nothing
+// authoritative to call a vendored dir "extraneous" against.
+func packageStatuses(repoRoot string, manifest *pkg.Manifest, locked map[string]string, lockPresent bool) ([]PackageStatus, []string) {
+	statuses := make([]PackageStatus, 0, len(manifest.Packages))
+	for _, dep := range manifest.Packages {
+		vendored := ""
+		if installed, err := restore.ReadInstalledManifest(pkg.VendorPath(repoRoot, dep.Name)); err == nil {
+			vendored = installed.Version
+		}
+		lockedVersion := locked[dep.Name]
+		inSync := dep.Version != "" && dep.Version == lockedVersion && lockedVersion == vendored
+		statuses = append(statuses, PackageStatus{
+			Name: dep.Name, Desired: dep.Version, Locked: lockedVersion, Vendored: vendored, InSync: inSync,
+		})
+	}
+
+	var orphans []string
+	if lockPresent {
+		vendorRoot := filepath.Join(repoRoot, ".cn", "vendor", "packages")
+		entries, err := os.ReadDir(vendorRoot)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				if _, ok := locked[e.Name()]; !ok {
+					orphans = append(orphans, e.Name())
+				}
+			}
+		}
+	}
+	sort.Strings(orphans)
+	return statuses, orphans
+}
+
+func sha256File(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// dispatchStatus reports dispatch-workflow presence + A2 drift
+// classification. When the ledger has no workflow record, it falls back
+// to direct file presence (A3 degraded reporting — no ledger sha to
+// anchor a three-way classification, so drift is DriftUnknown).
+func dispatchStatus(ctx context.Context, repoRoot string, ledger *repostate.RepoState) DispatchStatus {
+	const workflowRelPath = ".github/workflows/cnos-cds-dispatch.yml"
+
+	var wf *repostate.ManagedFile
+	if ledger != nil {
+		wf = ledger.FindManagedFile(workflowRelPath)
+	}
+
+	livePath := filepath.Join(repoRoot, ".github", "workflows", "cnos-cds-dispatch.yml")
+	liveSHA, liveErr := sha256File(livePath)
+
+	if wf == nil {
+		if liveErr != nil {
+			return DispatchStatus{Present: false}
+		}
+		// A3: workflow exists but no ledger record to classify it against.
+		return DispatchStatus{Present: true, ID: "cnos-cds-dispatch", Path: workflowRelPath, Drift: DriftUnknown}
+	}
+
+	status := DispatchStatus{Present: true, Tier: wf.Tier, ID: wf.ID, Path: wf.Path}
+	if liveErr != nil {
+		status.Drift = DriftUnknown
+		return status
+	}
+	if liveSHA == wf.SHA256 {
+		status.Drift = DriftMatchesLedger
+		return status
+	}
+
+	// Differs from ledger — classify user_edit vs renderer_moved by
+	// re-rendering fresh into a temp file with the SAME render contract
+	// the ledger recorded (P2) and comparing.
+	tmpDir, err := os.MkdirTemp("", "cn-repo-status-render-*")
+	if err != nil {
+		status.Drift = DriftUnknown
+		return status
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpOut := filepath.Join(tmpDir, "workflow.yml")
+
+	renderErr := dispatchrender.Render(ctx, dispatchrender.Options{
+		RepoRoot:          repoRoot,
+		RendererPackage:   wf.RendererPackage,
+		Tier:              wf.Tier,
+		Agent:             wf.Agent,
+		WorkflowPatSecret: wf.WorkflowPatSecret,
+		BotName:           wf.BotName,
+		BotID:             wf.BotID,
+		OutPath:           tmpOut,
+	})
+	if renderErr != nil {
+		status.Drift = DriftUnknown
+		return status
+	}
+	freshSHA, err := sha256File(tmpOut)
+	if err != nil {
+		status.Drift = DriftUnknown
+		return status
+	}
+	if freshSHA == liveSHA {
+		status.Drift = DriftRendererMoved
+	} else {
+		status.Drift = DriftUserEdit
+	}
+	return status
+}
+
+// localEditStatus reports non-workflow managed_files whose live content
+// differs from the ledger sha256 (workflow drift is reported via
+// DispatchStatus.Drift instead — not duplicated here, matching the design
+// mocks doc's Mock C example).
+func localEditStatus(repoRoot string, ledger *repostate.RepoState) []LocalEdit {
+	if ledger == nil {
+		return nil
+	}
+	var edits []LocalEdit
+	for _, mf := range ledger.ManagedFiles {
+		if mf.Kind == repostate.KindWorkflow {
+			continue
+		}
+		sha, err := sha256File(filepath.Join(repoRoot, mf.Path))
+		if err != nil {
+			edits = append(edits, LocalEdit{Path: mf.Path, Classification: "removed"})
+			continue
+		}
+		if sha != mf.SHA256 {
+			edits = append(edits, LocalEdit{Path: mf.Path, Classification: "user_edit"})
+		}
+	}
+	sort.Slice(edits, func(i, j int) bool { return edits[i].Path < edits[j].Path })
+	return edits
+}
+
+// labelStatus audits canonical labels read-only (labeldoctor.Doctor with
+// DryRun: true never mutates GitHub). Degrades to LabelsUnknown (not an
+// error) when the repo target or a GitHub token cannot be resolved —
+// status must never fail outright just because labels can't be checked.
+func labelStatus(ctx context.Context, opts Options) LabelStatus {
+	res, err := labeldoctor.Doctor(ctx, labeldoctor.Options{
+		RepoRoot: opts.RepoRoot,
+		Repo:     opts.Repo,
+		Token:    opts.Token,
+		DryRun:   true,
+		Stdout:   io.Discard,
+		Stderr:   io.Discard,
+	})
+	if err != nil && err != labeldoctor.ErrDrift {
+		return LabelStatus{Status: LabelsUnknown}
+	}
+	if res == nil {
+		return LabelStatus{Status: LabelsUnknown}
+	}
+
+	var missing, drifted []string
+	canonical := map[string]bool{}
+	for _, f := range res.Findings {
+		canonical[f.Name] = true
+		switch f.Status {
+		case labeldoctor.StatusMissing:
+			missing = append(missing, f.Name)
+		case labeldoctor.StatusDrifted:
+			drifted = append(drifted, f.Name)
+		}
+	}
+	var unknown []string
+	for _, name := range res.LiveLabels {
+		if !canonical[name] {
+			unknown = append(unknown, name)
+		}
+	}
+
+	status := LabelsOK
+	if len(missing) > 0 || len(drifted) > 0 {
+		status = LabelsDrifted
+	}
+	return LabelStatus{Status: status, Missing: missing, Drifted: drifted, Unknown: unknown}
+}
+
+// updateAvailableStatus best-effort checks whether a newer release than
+// the ledger's recorded source.release exists. Degrades to Checked: false
+// on any resolution failure (offline, rate-limited, no ledger/no release
+// recorded) — this is informational only and never contributes to Drift.
+func updateAvailableStatus(ctx context.Context, opts Options, ledger *repostate.RepoState) UpdateAvailable {
+	if opts.SkipNetwork || ledger == nil || ledger.Source.Release == "" {
+		return UpdateAvailable{Checked: false}
+	}
+	repo := opts.Repo
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	apiBase := opts.APIBaseURL
+	if apiBase == "" {
+		apiBase = "https://api.github.com"
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	rel, err := binupdate.FetchLatestRelease(ctx, client, apiBase, repo)
+	if err != nil {
+		return UpdateAvailable{Checked: false}
+	}
+	return UpdateAvailable{
+		Checked:   true,
+		Available: rel.Tag != ledger.Source.Release,
+		Release:   rel.Tag,
+	}
+}

--- a/src/go/internal/repostatus/repostatus.go
+++ b/src/go/internal/repostatus/repostatus.go
@@ -44,12 +44,16 @@ const StatusSchema = "cn.repo.status.v1"
 // single stable constant).
 const DefaultRepo = "usurobor/cnos"
 
-// Drift classification values (design doc A2).
+// Drift classification values (design doc A2). DriftRemoved is this
+// package's own addition beyond A2's three-way split: the ledger records
+// a workflow that no longer exists on disk at all (distinct from "never
+// had one," which reports Present: false with no Drift value).
 const (
 	DriftMatchesLedger = "matches_ledger"
-	DriftUserEdit       = "user_edit"
-	DriftRendererMoved  = "renderer_moved"
-	DriftUnknown        = "unknown"
+	DriftUserEdit      = "user_edit"
+	DriftRendererMoved = "renderer_moved"
+	DriftUnknown       = "unknown"
+	DriftRemoved       = "removed"
 )
 
 // Label status values.
@@ -195,7 +199,7 @@ func Run(ctx context.Context, opts Options) (*Status, error) {
 			drift = true
 		}
 	}
-	if dispatch.Drift == DriftUserEdit || dispatch.Drift == DriftRendererMoved {
+	if dispatch.Drift == DriftUserEdit || dispatch.Drift == DriftRendererMoved || dispatch.Drift == DriftRemoved {
 		drift = true
 	}
 	if labels.Status == LabelsDrifted {
@@ -302,11 +306,16 @@ func dispatchStatus(ctx context.Context, repoRoot string, ledger *repostate.Repo
 		return DispatchStatus{Present: true, ID: "cnos-cds-dispatch", Path: workflowRelPath, Drift: DriftUnknown}
 	}
 
-	status := DispatchStatus{Present: true, Tier: wf.Tier, ID: wf.ID, Path: wf.Path}
 	if liveErr != nil {
-		status.Drift = DriftUnknown
-		return status
+		// The ledger records a workflow that no longer exists on disk —
+		// distinct from "never had one" (wf == nil above): Present is
+		// false (nothing is actually active), but Tier/ID/Path are still
+		// surfaced for context, and Drift names what happened so this
+		// doesn't get silently treated as "no dispatch, no drift".
+		return DispatchStatus{Present: false, Tier: wf.Tier, ID: wf.ID, Path: wf.Path, Drift: DriftRemoved}
 	}
+
+	status := DispatchStatus{Present: true, Tier: wf.Tier, ID: wf.ID, Path: wf.Path}
 	if liveSHA == wf.SHA256 {
 		status.Drift = DriftMatchesLedger
 		return status

--- a/src/go/internal/repostatus/repostatus.go
+++ b/src/go/internal/repostatus/repostatus.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -146,6 +147,15 @@ type Status struct {
 	UpdateAvailable UpdateAvailable  `json:"update_available"`
 	Ledger          LedgerInfo       `json:"ledger"`
 	Drift           bool             `json:"drift"`
+}
+
+// JSON renders s as indented JSON (schema cn.repo.status.v1), the `--json`
+// output shape. Kept here (not in cli/cmd_repo_status.go) so the thin CLI
+// wrapper never imports encoding/json itself — INVARIANTS.md T-002 /
+// eng/go §2.18's dispatch-boundary discipline: cmd_*.go files are thin
+// wrappers, domain packages own domain-shaped serialization.
+func (s *Status) JSON() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
 }
 
 // Options carries Run's configuration. Every field beyond RepoRoot is

--- a/src/go/internal/repostatus/repostatus.go
+++ b/src/go/internal/repostatus/repostatus.go
@@ -44,16 +44,30 @@ const StatusSchema = "cn.repo.status.v1"
 // single stable constant).
 const DefaultRepo = "usurobor/cnos"
 
-// Drift classification values (design doc A2). DriftRemoved is this
-// package's own addition beyond A2's three-way split: the ledger records
-// a workflow that no longer exists on disk at all (distinct from "never
-// had one," which reports Present: false with no Drift value).
+// Drift classification values (design doc A2). DriftRemoved and
+// DriftUnclassified are this package's own additions beyond A2's
+// three-way split:
+//   - DriftRemoved: the ledger records a workflow that no longer exists
+//     on disk at all (distinct from "never had one," which reports
+//     Present: false with no Drift value).
+//   - DriftUnclassified: the live file's sha256 is CONFIRMED to differ
+//     from the ledger's recorded sha256 (a real, known drift), but the
+//     fresh-render comparison that would classify it as user_edit vs.
+//     renderer_moved could not run (temp-dir creation failed, the
+//     renderer errored, or the fresh render's output couldn't be read).
+//     This is deliberately NOT DriftUnknown — DriftUnknown means "nothing
+//     to compare against" (no ledger record); here a mismatch is already
+//     an established fact, so it counts toward the top-level Drift bool
+//     even though which KIND of drift it is remains unresolved. Silently
+//     reporting a confirmed mismatch as non-drift would defeat the whole
+//     point of a drift reporter.
 const (
 	DriftMatchesLedger = "matches_ledger"
 	DriftUserEdit      = "user_edit"
 	DriftRendererMoved = "renderer_moved"
 	DriftUnknown       = "unknown"
 	DriftRemoved       = "removed"
+	DriftUnclassified  = "unclassified"
 )
 
 // Label status values.
@@ -199,7 +213,7 @@ func Run(ctx context.Context, opts Options) (*Status, error) {
 			drift = true
 		}
 	}
-	if dispatch.Drift == DriftUserEdit || dispatch.Drift == DriftRendererMoved || dispatch.Drift == DriftRemoved {
+	if dispatch.Drift == DriftUserEdit || dispatch.Drift == DriftRendererMoved || dispatch.Drift == DriftRemoved || dispatch.Drift == DriftUnclassified {
 		drift = true
 	}
 	if labels.Status == LabelsDrifted {
@@ -321,12 +335,15 @@ func dispatchStatus(ctx context.Context, repoRoot string, ledger *repostate.Repo
 		return status
 	}
 
-	// Differs from ledger — classify user_edit vs renderer_moved by
-	// re-rendering fresh into a temp file with the SAME render contract
-	// the ledger recorded (P2) and comparing.
+	// Differs from ledger — drift is now a CONFIRMED fact (liveSHA !=
+	// wf.SHA256 above); everything from here on only refines which KIND
+	// of drift it is. Every failure branch below falls back to
+	// DriftUnclassified, never DriftUnknown, so a confirmed mismatch can
+	// never be silently reported as "no drift" just because the
+	// classification step itself couldn't run.
 	tmpDir, err := os.MkdirTemp("", "cn-repo-status-render-*")
 	if err != nil {
-		status.Drift = DriftUnknown
+		status.Drift = DriftUnclassified
 		return status
 	}
 	defer os.RemoveAll(tmpDir)
@@ -343,12 +360,12 @@ func dispatchStatus(ctx context.Context, repoRoot string, ledger *repostate.Repo
 		OutPath:           tmpOut,
 	})
 	if renderErr != nil {
-		status.Drift = DriftUnknown
+		status.Drift = DriftUnclassified
 		return status
 	}
 	freshSHA, err := sha256File(tmpOut)
 	if err != nil {
-		status.Drift = DriftUnknown
+		status.Drift = DriftUnclassified
 		return status
 	}
 	if freshSHA == liveSHA {

--- a/src/go/internal/repostatus/repostatus_test.go
+++ b/src/go/internal/repostatus/repostatus_test.go
@@ -1,0 +1,444 @@
+package repostatus
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/usurobor/cnos/src/go/internal/dispatchrender"
+	"github.com/usurobor/cnos/src/go/internal/pkg"
+	"github.com/usurobor/cnos/src/go/internal/repostate"
+)
+
+func sha256Hex(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupFixtureRepo builds a minimal but complete "installed" repo layout
+// directly on disk (no network, no tarballs) — the pure shape
+// internal/repoinstall's Run would have produced — so repostatus tests
+// exercise reading, not the installer's own write path (already covered by
+// internal/repoinstall's tests).
+func setupFixtureRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	manifest := pkg.Manifest{Schema: "cn.deps.v1", Profile: "cds", Packages: []pkg.ManifestDep{{Name: "cnos.core", Version: "1.0.0"}}}
+	depsJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, ".cn", "deps.json"), string(depsJSON)+"\n")
+
+	lock := pkg.Lockfile{Schema: "cn.lock.v2", Packages: []pkg.LockedDep{{Name: "cnos.core", Version: "1.0.0", SHA256: "abc123"}}}
+	lockJSON, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, ".cn", "deps.lock.json"), string(lockJSON)+"\n")
+
+	writeFile(t, filepath.Join(root, ".cn", "vendor", "packages", "cnos.core", "cn.package.json"), `{"name": "cnos.core", "version": "1.0.0"}`)
+
+	state := repostate.RepoState{
+		Schema: repostate.Schema, Profile: "cds",
+		Source: repostate.Source{Channel: "stable", Release: "1.0.0", Index: "https://example/index.json"},
+		ManagedFiles: []repostate.ManagedFile{
+			{Path: ".cn/deps.json", Kind: repostate.KindManifest, ID: "deps-manifest", SHA256: sha256Hex(t, filepath.Join(root, ".cn", "deps.json"))},
+			{Path: ".cn/deps.lock.json", Kind: repostate.KindLockfile, ID: "deps-lockfile", SHA256: sha256Hex(t, filepath.Join(root, ".cn", "deps.lock.json"))},
+		},
+		ManagedDirs: []repostate.ManagedDir{{Path: ".cn/vendor/packages/cnos.core", Package: "cnos.core"}},
+		ExternalExpectations: repostate.ExternalExpectations{
+			Labels: repostate.LabelExpectations{Mode: repostate.LabelModeEnsure, Source: "cnos.core/labels.json", DeleteOnUninstall: false},
+		},
+	}
+	data, err := state.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".cn", "repo.state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestRun_CleanInstall_NoDrift(t *testing.T) {
+	root := setupFixtureRepo(t)
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Schema != StatusSchema {
+		t.Errorf("schema = %q, want %q", st.Schema, StatusSchema)
+	}
+	if !st.Ledger.Present || st.Ledger.Reconstructed {
+		t.Errorf("Ledger = %+v, want Present=true Reconstructed=false", st.Ledger)
+	}
+	if len(st.Packages) != 1 || !st.Packages[0].InSync {
+		t.Errorf("Packages = %+v, want one in-sync cnos.core entry", st.Packages)
+	}
+	if st.Dispatch.Present {
+		t.Errorf("Dispatch.Present = true, want false (no workflow in fixture)")
+	}
+	if len(st.LocalEdits) != 0 {
+		t.Errorf("LocalEdits = %+v, want none", st.LocalEdits)
+	}
+	if st.Drift {
+		t.Error("Drift = true, want false for a clean fixture")
+	}
+}
+
+// TestRun_NeverWrites is the P3 oracle: repeated Run calls (default and
+// --json-equivalent structured calls) must never touch RepoRoot.
+func TestRun_NeverWrites(t *testing.T) {
+	root := setupFixtureRepo(t)
+
+	before := map[string][]byte{}
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, _ := os.ReadFile(path)
+		before[path] = data
+		return nil
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+
+	after := map[string][]byte{}
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, _ := os.ReadFile(path)
+		after[path] = data
+		return nil
+	})
+
+	if len(before) != len(after) {
+		t.Fatalf("file count changed: before=%d after=%d", len(before), len(after))
+	}
+	for path, data := range before {
+		if string(after[path]) != string(data) {
+			t.Errorf("%s content changed after Run", path)
+		}
+	}
+}
+
+func TestRun_LocalEditDetected(t *testing.T) {
+	root := setupFixtureRepo(t)
+	// Tamper deps.json after the ledger was computed — a local edit.
+	writeFile(t, filepath.Join(root, ".cn", "deps.json"), `{"schema":"cn.deps.v1","profile":"tampered","packages":[]}`)
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(st.LocalEdits) != 1 || st.LocalEdits[0].Path != ".cn/deps.json" || st.LocalEdits[0].Classification != "user_edit" {
+		t.Errorf("LocalEdits = %+v, want one user_edit entry for .cn/deps.json", st.LocalEdits)
+	}
+	if !st.Drift {
+		t.Error("Drift = false, want true when a managed file was locally edited")
+	}
+}
+
+// TestRun_RemovedManagedFile covers the LocalEdit "removed" classification:
+// a ledger-recorded managed file (here, a synthetic gitignore entry added
+// to the fixture) that no longer exists on disk at all.
+func TestRun_RemovedManagedFile(t *testing.T) {
+	root := setupFixtureRepo(t)
+	gitignorePath := filepath.Join(root, ".gitignore")
+	writeFile(t, gitignorePath, ".cn/vendor/\n")
+
+	statePath := filepath.Join(root, ".cn", "repo.state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repostate.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.ManagedFiles = append(state.ManagedFiles, repostate.ManagedFile{
+		Path: ".gitignore", Kind: repostate.KindGitignore, ID: "gitignore", SHA256: sha256Hex(t, gitignorePath),
+	})
+	newData, err := state.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, newData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(gitignorePath); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	found := false
+	for _, e := range st.LocalEdits {
+		if e.Path == ".gitignore" {
+			found = true
+			if e.Classification != "removed" {
+				t.Errorf(".gitignore classification = %q, want \"removed\"", e.Classification)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("LocalEdits = %+v, want an entry for the removed .gitignore", st.LocalEdits)
+	}
+}
+
+func TestRun_OrphanVendoredPackage(t *testing.T) {
+	root := setupFixtureRepo(t)
+	writeFile(t, filepath.Join(root, ".cn", "vendor", "packages", "cnos.legacy-foo", "cn.package.json"), `{"name": "cnos.legacy-foo", "version": "0.1.0"}`)
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(st.OrphanPackages) != 1 || st.OrphanPackages[0] != "cnos.legacy-foo" {
+		t.Errorf("OrphanPackages = %v, want [cnos.legacy-foo]", st.OrphanPackages)
+	}
+	if !st.Drift {
+		t.Error("Drift = false, want true when an orphan vendored package exists")
+	}
+}
+
+func TestRun_NoDepsJSON_Errors(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true}); err == nil {
+		t.Error("Run on a repo with no .cn/deps.json: got nil error, want non-nil")
+	}
+}
+
+func TestRun_NoLedger_DegradesGracefully(t *testing.T) {
+	root := setupFixtureRepo(t)
+	if err := os.Remove(filepath.Join(root, ".cn", "repo.state.json")); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Ledger.Present || !st.Ledger.Reconstructed {
+		t.Errorf("Ledger = %+v, want Present=false Reconstructed=true", st.Ledger)
+	}
+	// Packages are still reported from deps.json/deps.lock.json/vendor
+	// directly — the ledger's absence only degrades local_edits/dispatch.
+	if len(st.Packages) != 1 || !st.Packages[0].InSync {
+		t.Errorf("Packages = %+v, want still-reported in-sync cnos.core", st.Packages)
+	}
+	if len(st.LocalEdits) != 0 {
+		t.Errorf("LocalEdits = %+v, want none (no ledger to compare against)", st.LocalEdits)
+	}
+}
+
+// --- dispatch drift classification (A2) ---
+
+func repoSrcRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+}
+
+// setupDispatchFixture extends setupFixtureRepo with a REAL vendored
+// cn-install-wake renderer script (so dispatchrender.Render actually
+// works) and an initial workflow render + matching ledger record, using
+// the engine tier (no PAT/identity fixture wiring needed).
+func setupDispatchFixture(t *testing.T) (root string, wf repostate.ManagedFile) {
+	t.Helper()
+	root = setupFixtureRepo(t)
+
+	rendererScript, err := os.ReadFile(filepath.Join(repoSrcRoot(t), "src", "packages", "cnos.core", "commands", "install-wake", "cn-install-wake"))
+	if err != nil {
+		t.Fatalf("read real cn-install-wake: %v", err)
+	}
+	rendererPath := filepath.Join(root, ".cn", "vendor", "packages", "cnos.core", "commands", "install-wake", "cn-install-wake")
+	if err := os.MkdirAll(filepath.Dir(rendererPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rendererPath, rendererScript, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The renderer resolves CN_PACKAGE_ROOT from its own script_dir
+	// (cnos.core) when unset, then re-pins to the sibling package that
+	// actually owns orchestrators/cds-dispatch/SKILL.md — mirroring
+	// internal/repoinstall's own writeDispatchFixtureIndex, which vendors
+	// cnos.cds alongside cnos.core for exactly this reason.
+	skillMD, err := os.ReadFile(filepath.Join(repoSrcRoot(t), "src", "packages", "cnos.cds", "orchestrators", "cds-dispatch", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read real cds-dispatch SKILL.md: %v", err)
+	}
+	skillPath := filepath.Join(root, ".cn", "vendor", "packages", "cnos.cds", "orchestrators", "cds-dispatch", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillPath, skillMD, 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, ".cn", "vendor", "packages", "cnos.cds", "cn.package.json"), `{"name": "cnos.cds", "version": "1.0.0"}`)
+
+	// cnos.cds is vendored only so the renderer can find its sibling
+	// SKILL.md (see comment above) — it isn't a "real" desired package in
+	// this fixture. Record it in the lockfile too so it isn't mistaken
+	// for an orphan vendored package by the orphan-detection test below.
+	lockPath := filepath.Join(root, ".cn", "deps.lock.json")
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := pkg.ParseLockfile(lockData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Packages = append(lock.Packages, pkg.LockedDep{Name: "cnos.cds", Version: "1.0.0", SHA256: "def456"})
+	newLockData, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lockPath, append(newLockData, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowPath := filepath.Join(root, ".github", "workflows", "cnos-cds-dispatch.yml")
+	if err := dispatchrender.Render(context.Background(), dispatchrender.Options{
+		RepoRoot: root, RendererPackage: "cnos.core", Tier: repostate.TierEngine, Agent: "sigma", OutPath: workflowPath,
+	}); err != nil {
+		t.Fatalf("initial render: %v", err)
+	}
+
+	wf = repostate.ManagedFile{
+		Path: ".github/workflows/cnos-cds-dispatch.yml", Kind: repostate.KindWorkflow, ID: "cnos-cds-dispatch",
+		SHA256: sha256Hex(t, workflowPath), Tier: repostate.TierEngine,
+		Renderer: "cnos.core/install-wake", RendererPackage: "cnos.core", RendererVersionSource: "lock", Agent: "sigma",
+	}
+
+	// Add the workflow record to the ledger already on disk.
+	data, err := os.ReadFile(filepath.Join(root, ".cn", "repo.state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repostate.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// deps.lock.json's content changed (cnos.cds appended above) after
+	// setupFixtureRepo computed the ledger's original sha256 for it —
+	// refresh that entry so this fixture's deps.lock.json isn't itself
+	// mistaken for a local edit.
+	if lockRecord := state.FindManagedFile(".cn/deps.lock.json"); lockRecord != nil {
+		lockRecord.SHA256 = sha256Hex(t, lockPath)
+	}
+	state.ManagedFiles = append(state.ManagedFiles, wf)
+	newData, err := state.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".cn", "repo.state.json"), newData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root, wf
+}
+
+func TestDispatchStatus_MatchesLedger(t *testing.T) {
+	root, _ := setupDispatchFixture(t)
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !st.Dispatch.Present || st.Dispatch.Drift != DriftMatchesLedger {
+		t.Errorf("Dispatch = %+v, want Present=true Drift=%s", st.Dispatch, DriftMatchesLedger)
+	}
+	if st.Drift {
+		t.Error("Drift = true, want false when the workflow matches the ledger")
+	}
+}
+
+func TestDispatchStatus_RendererMoved(t *testing.T) {
+	root, _ := setupDispatchFixture(t)
+	// Simulate an old ledger sha (as if the renderer output changed since
+	// install) by corrupting the RECORDED sha while leaving the live file
+	// as the actual fresh-render output — a fresh re-render will match the
+	// live file exactly, classifying this as renderer_moved.
+	statePath := filepath.Join(root, ".cn", "repo.state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repostate.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wfRecord := state.FindManagedFile(".github/workflows/cnos-cds-dispatch.yml")
+	wfRecord.SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"[:64]
+	newData, err := state.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, newData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Dispatch.Drift != DriftRendererMoved {
+		t.Errorf("Dispatch.Drift = %q, want %q", st.Dispatch.Drift, DriftRendererMoved)
+	}
+}
+
+func TestDispatchStatus_UserEdit(t *testing.T) {
+	root, _ := setupDispatchFixture(t)
+	workflowPath := filepath.Join(root, ".github", "workflows", "cnos-cds-dispatch.yml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, append(data, []byte("\n# hand-edited\n")...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Dispatch.Drift != DriftUserEdit {
+		t.Errorf("Dispatch.Drift = %q, want %q", st.Dispatch.Drift, DriftUserEdit)
+	}
+	if !st.Drift {
+		t.Error("Drift = false, want true for a hand-edited dispatch workflow")
+	}
+}

--- a/src/go/internal/repostatus/repostatus_test.go
+++ b/src/go/internal/repostatus/repostatus_test.go
@@ -442,3 +442,30 @@ func TestDispatchStatus_UserEdit(t *testing.T) {
 		t.Error("Drift = false, want true for a hand-edited dispatch workflow")
 	}
 }
+
+// TestDispatchStatus_Removed covers the ledger-recorded-but-file-missing
+// case: distinct from "never had a workflow" (Present: false, no Drift
+// value) — here Present is also false (nothing is active), but Drift names
+// what happened (DriftRemoved) so it isn't silently indistinguishable from
+// "no dispatch, no drift" and still counts toward the top-level Drift bool.
+func TestDispatchStatus_Removed(t *testing.T) {
+	root, _ := setupDispatchFixture(t)
+	workflowPath := filepath.Join(root, ".github", "workflows", "cnos-cds-dispatch.yml")
+	if err := os.Remove(workflowPath); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Dispatch.Present {
+		t.Error("Dispatch.Present = true, want false for a removed workflow")
+	}
+	if st.Dispatch.Drift != DriftRemoved {
+		t.Errorf("Dispatch.Drift = %q, want %q", st.Dispatch.Drift, DriftRemoved)
+	}
+	if !st.Drift {
+		t.Error("Drift = false, want true when the ledger-recorded workflow was removed")
+	}
+}

--- a/src/go/internal/repostatus/repostatus_test.go
+++ b/src/go/internal/repostatus/repostatus_test.go
@@ -469,3 +469,60 @@ func TestDispatchStatus_Removed(t *testing.T) {
 		t.Error("Drift = false, want true when the ledger-recorded workflow was removed")
 	}
 }
+
+// TestDispatchStatus_Unclassified pins the fix for an adversarial-review
+// finding: when the live file's sha256 is CONFIRMED to differ from the
+// ledger (a real, known drift), but the fresh-render comparison that would
+// further classify it (user_edit vs renderer_moved) itself fails — here,
+// simulated by pointing RendererPackage at a package that was never
+// vendored, so dispatchrender.Render can't find the renderer script — the
+// result must NOT be DriftUnknown (which is excluded from the top-level
+// Drift bool and would silently report a confirmed mismatch as clean).
+func TestDispatchStatus_Unclassified(t *testing.T) {
+	root, _ := setupDispatchFixture(t)
+
+	// Hand-edit the live file so its sha256 no longer matches the ledger.
+	workflowPath := filepath.Join(root, ".github", "workflows", "cnos-cds-dispatch.yml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, append(data, []byte("\n# edited\n")...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt the ledger's recorded renderer_package so the fresh-render
+	// comparison itself can't run (renderer script not found at that
+	// package's vendored path) — this is the "classification step fails"
+	// case, independent of the file having genuinely changed (confirmed
+	// above).
+	statePath := filepath.Join(root, ".cn", "repo.state.json")
+	stateData, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := repostate.Parse(stateData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wfRecord := state.FindManagedFile(".github/workflows/cnos-cds-dispatch.yml")
+	wfRecord.RendererPackage = "cnos.nonexistent-package"
+	newStateData, err := state.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, newStateData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Run(context.Background(), Options{RepoRoot: root, SkipNetwork: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.Dispatch.Drift != DriftUnclassified {
+		t.Errorf("Dispatch.Drift = %q, want %q", st.Dispatch.Drift, DriftUnclassified)
+	}
+	if !st.Drift {
+		t.Error("Drift = false, want true — a confirmed sha256 mismatch must count as drift even when further classification fails")
+	}
+}

--- a/src/packages/cnos.core/commands/label-doctor/doctor.go
+++ b/src/packages/cnos.core/commands/label-doctor/doctor.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -129,6 +130,14 @@ type Result struct {
 	// does not stop other findings from being attempted — see Doctor's
 	// apply-loop doc comment.
 	Failed []string
+	// LiveLabels is every label name present on Repo at audit time
+	// (sorted), independent of manifest membership. Findings/Audit only
+	// reports canonical (manifest) labels — a caller that additionally
+	// needs "present but not canonical" names (e.g. cnos#656's
+	// `cn repo status`, which reports unknown/extra labels as
+	// informational) computes that by set-differencing LiveLabels
+	// against Manifest.Labels rather than Doctor re-listing them.
+	LiveLabels []string
 }
 
 // Doctor audits opts.Repo's live labels against opts.LabelsPath (or
@@ -178,7 +187,12 @@ func Doctor(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	findings := Audit(manifest, live)
-	res := &Result{Repo: repo, Manifest: manifest, Findings: findings}
+	liveNames := make([]string, 0, len(liveList))
+	for _, l := range liveList {
+		liveNames = append(liveNames, l.Name)
+	}
+	sort.Strings(liveNames)
+	res := &Result{Repo: repo, Manifest: manifest, Findings: findings, LiveLabels: liveNames}
 
 	renderReport(stdoutOrDiscard(opts.Stdout), repo, findings, opts.DryRun)
 


### PR DESCRIPTION
Refs #656 (Phase 1 of the #655 `cn repo` lifecycle wave).

## Summary
- `schemas/repo_state.cue` (checked-in, closed CUE schema for `cn.repo.state.v1`) + fixtures + a new CI job (`repo-state-schema-check`) — timestamp-freeness and no-lock-duplication are enforced structurally via CUE closedness.
- `internal/repostate` — pure types + deterministic `Marshal()`.
- `cn repo install` now writes/updates `.cn/repo.state.json` idempotently, including dispatch-workflow render-contract metadata (P2). Survives an orthogonal label-doctor failure when the render itself succeeded; does not write a stale/corrupted ledger when the render didn't happen this run.
- `internal/dispatchrender` (extracted from `repoinstall.runDispatchCds`) — single renderer-invocation authority shared by install and the new status command's drift comparison.
- `cn repo status` (+ `--json`, `--check`) — read-only report of packages/lock/vendor sync, dispatch-workflow drift (matches_ledger / user_edit / renderer_moved / removed / unclassified), canonical label drift, orphan vendored packages, locally-edited managed files, and best-effort update-available.
- `docs/development/design/cn-repo-status-MOCKS.md` — mock-first design doc (A6), authored before implementation.

## Review
Adversarial review (independent subagent, not primed with the implementation narrative) found two real bugs during this cycle, both fixed with regression tests before this PR was opened — see `.cdd/unreleased/656/beta-review.md` for full writeups:
1. A stale dispatch-workflow file from a prior successful install could get its ledger metadata silently corrupted by a later failed, different-identity install attempt.
2. A confirmed workflow-content drift could be silently reported as "no drift" if the re-render classification step itself failed.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` (src/go)
- [x] `go build ./... && go vet ./... && go test ./...` (label-doctor module)
- [x] `./scripts/ci/validate-repo-state.sh --self-test`
- [x] Manual end-to-end smoke: real `cn build` → real local index → real `cn repo install` → real `cn repo status` (clean, drifted via hand-edit, `--check` exit codes, zero-write verification)
- [x] Real `cn repo install` output validated against `schemas/repo_state.cue` via `cue vet` (not just hand-written fixtures)

🤖 Generated with cds-dispatch (interactive session acting as the `cds-dispatch` wake)