### PR TITLE
cell-runner: walking-skeleton spike — runnable CC→PC→WC agentic loop (proof-of-life)

### DIFF
--- a/go.work
+++ b/go.work
@@ -7,4 +7,5 @@ use (
 	./src/packages/cnos.issues/commands/issues-fsm
 	./src/packages/cnos.issues/commands/issues-dispatch
 	./src/packages/cnos.core/commands/label-doctor
+	./src/packages/cnos.cell-runner
 )

--- a/src/packages/cnos.cell-runner/DESIGN.md
+++ b/src/packages/cnos.cell-runner/DESIGN.md
@@ -1,0 +1,142 @@
+# cnos cell-runner — walking-skeleton spike (proof-of-life)
+
+**Status: EXPLORATORY SPIKE, not canonical runtime.** This is a proof-of-life for the
+three-cell agentic loop (CC → PC → WC). It is built *against* the R12 cell-runtime doctrine
+design (PR #672) to learn from running, not to pre-empt the authored doctrine (#672 WCs) or the
+implementation wave (#627 S2–S8). When the doctrine is authorized, this spike is reconciled to it
+(or discarded). It invents no policy; where it must choose, it picks the minimal mechanical option
+and says so here.
+
+## What it proves
+
+One turn of the loop, mechanically, git-native, no human in the machinery:
+
+```
+CC.measure(target)  → CM object + judgment{request_planning}   (incoherence detected)
+  → PC.plan(judgment,CM) → wave{ one WC contract }             (relation graph)
+    → WC.execute(contract) → α produce → β review → γ close → V validate → δ decide → receipt
+      → CC.measure(target) → judgment{coherent}                (incoherence cleared)
+  → loop terminates: incoherence 1 → 0, receipt chain closed.
+```
+
+The three cells are distinguished ONLY by output telos (the R12 doctrine's classification rule):
+**WC → artifact, PC → relation_graph, CC → judgment.** They run the *same* kernel.
+
+## Non-negotiables (operator directives)
+
+- **Go for code, CUE for schemas. NO Python.** `go.work` module + `cue.mod`.
+- Reuse cnos idioms: a **declarative FSM transition table + a package-agnostic Go evaluator**
+  (mirroring `src/packages/cnos.issues/commands/issues-fsm/`), and receipts shaped after
+  `schemas/cdd/receipt.cue`. Do not hardcode a state name in a switch/if-chain.
+- Fail closed. `cue vet` every emitted object. `gofmt`/`go vet` clean.
+
+## Architecture
+
+### Kernel FSM (declarative)
+`kernel/transitions.json` — the CCNF cell kernel as a transition table over states
+`{init, produced, reviewed, closed, validated, decided, held}` with guards evaluated by a generic
+evaluator (`kernel/engine.go`). Transitions:
+
+| from | guard | to | step |
+|---|---|---|---|
+| init | contract_present | produced | α produce |
+| produced | artifact_present | reviewed | β review |
+| reviewed | review_approved | closed | γ close (compute receipt) |
+| reviewed | review_rejected | held | δ hold (stop) |
+| closed | receipt_bound | validated | V validate |
+| validated | v_pass | decided | δ accept |
+| validated | v_fail | held | δ hold (stop) |
+
+The evaluator is generic: it reads the table + a `FactSnapshot` (booleans produced by the actors
+and the workspace) and picks the first matching transition, exactly like the CDS issues-fsm engine.
+
+### Actor seam (the "assisted" boundary)
+```go
+type Actor interface {
+    // Alpha produces the artifact; Beta reviews; Gamma closes (computes receipt fields);
+    // V validates mechanically; Delta decides; Measure is the CC's CM+judgment producer.
+}
+```
+v0 ships **deterministic stub actors** (`actor/stub/`) so the loop runs end-to-end with zero
+external calls — proving the *machinery*. Agent-backed actors (real α/β/CC judgment) implement the
+same interface next (v1); nothing in the kernel/loop changes.
+
+### Cells = kernel + telos
+A "cell" is the kernel run under a telos:
+- **WC**: `requested_output.kind = artifact`; V checks the artifact against acceptance predicates.
+- **PC**: `requested_output.kind = relation_graph`; α emits a wave (one WC contract) from the CM.
+- **CC**: `requested_output.kind = judgment`; the Measure actor produces a CM object, δ emits a
+  judgment (`coherent | request_planning | request_working`).
+
+### CM object (the shared cnos↔tsc seam)
+`schema/cm.cue` — `#CM{ target, alpha_score, defects[], provenance, measured_at_ref }`. This is the
+**runner/provider-produced measurement object** (NOT the CC's judgment; the CC *consumes* it). It is
+the exact seam a tsc-provided TSC measurement plugs into (WC-2 of #672). v0's CM provider is a
+mechanical checker over the toy target; a tsc/agent provider drops in behind the same schema.
+
+### Receipts
+`schema/receipt.cue` — a minimal runner receipt (id, cell, telos, transitions[], evidence_refs,
+verdict, boundary_decision, produced_at_ref) shaped after `schemas/cdd/receipt.cue`. γ computes it
+from the transition evidence; it is not free-text authored. Every cell writes one to
+`<workspace>/receipts/<cell>.receipt.yaml`; the loop chains them (ε = the receipt stream).
+
+## Toy task (real, mechanical, decreasing-incoherence)
+`testdata/toy/` — a target markdown file missing a required `## Coherence` section.
+- CC.measure: section absent → defect `missing-required-section` → judgment `request_planning`.
+- PC.plan: emits a WC contract "add the `## Coherence` section to the target".
+- WC.execute: α appends the section; β approves (section text matches the required shape);
+  γ closes; V mechanically asserts the section is present and well-formed; δ accept.
+- CC.re-measure: defect cleared → `coherent` → loop ends.
+
+## v0 acceptance (the spike is "alive")
+`go run ./cmd/cell-runner --workspace <tmp> --task testdata/toy` exits 0 and:
+1. prints a loop transcript showing incoherence `1 → 0` across the CC→PC→WC→CC turn;
+2. writes CUE-valid CM, wave, and per-cell receipts under `<workspace>/`;
+3. `cue vet` of every emitted object against `schema/*.cue` passes;
+4. a `--fail-injection` flag (e.g. β rejects, or V fails) drives the kernel to `held` with a stop
+   receipt and non-zero exit — proving the FSM branches and fails closed;
+5. `gofmt -l` empty, `go vet ./...` clean, `go test ./...` green.
+
+## Explicitly deferred (NOT in v0)
+Agent-backed actors; multi-WC waves / parallel branches; the wave FSM (WC-3b) beyond one node;
+real CM scoring beyond defect-count; operator-authorization gate wiring; self-hosting on a real
+cnos change; tsc adoption. Each is a named next increment, not a silent gap.
+
+## Build notes
+
+Points where the spec was underspecified and the build took the minimal mechanical option:
+
+- **Guard/step timing in the kernel.** The transition table lists a `step` per edge. The
+  implemented semantics: the guard of the edge *out of* a state is satisfied by the step run *into*
+  it (the prior step), and taking an edge runs its `step`, which produces the fact the next edge's
+  guard reads. `contract_present` is the α-input fact, set true before the run (the contract is
+  present at handover). This makes the evaluator a pure first-match projection with no lookahead,
+  matching the issues-fsm engine.
+- **`step` vs guard registries.** Two fixed generic vocabularies, mirroring issues-fsm's single
+  `guardFuncs` map: `guardFuncs` (fact predicates) in `kernel/table.go` and `stepFuncs` (actor
+  dispatch) in `kernel/actor.go`. Neither switches on a state name; `Drive` dispatches steps through
+  the registry. Adding a state/edge is a `transitions.json` edit.
+- **Terminal states are declared** in the table (`"terminal": ["decided","held"]`) rather than
+  inferred as "states with no outgoing edge", so `Drive`'s stop condition stays table-driven and a
+  genuinely stuck non-terminal state is still an explicit fail-closed error.
+- **"Measure" actor method.** DESIGN lists Measure alongside α/β/γ/V/δ. To keep the kernel uniform
+  (all cells run the identical six steps), Measure is realized as the **CC actor's α step** (it
+  produces the CM); the CC's **δ** emits the judgment. No extra interface method — the `kernel.Actor`
+  seam is exactly α/β/γ/V/δ (with δ split into `DeltaAccept`/`DeltaHold` for the two boundary
+  actions), so PC/WC don't carry a no-op Measure.
+- **Emitted objects are JSON, not YAML.** DESIGN sketches `*.receipt.yaml`. To honor the stdlib-only
+  constraint (no third-party YAML dependency) objects are written as `*.json` (JSON is a strict YAML
+  subset and `cue vet` reads it directly). Files: `cm/<turn>.cm.json`, `wave/pc.wave.json`,
+  `receipts/<turn>.receipt.json`, `judgment/<turn>.judgment.json`.
+- **CC runs twice**, so receipts are disambiguated by turn (`cc-1`, `pc`, `wc`, `cc-2`) rather than
+  the bare `<cell>` name DESIGN sketches — otherwise the re-measure receipt would clobber the first.
+- **`alpha_score`** is scored mechanically as `1.0 - min(1, defect_count)` (so 0.0 with the one
+  defect, 1.0 when clear); incoherence is the defect count. A richer provider refines the score
+  behind the same `#CM` schema.
+- **Fault injection targets the WC turn** (the natural α/β/V gate for an artifact). `beta-reject`
+  drives `reviewed → held`; `v-fail` drives `validated → held`. Both write a `not_transmissible`
+  stop receipt and exit non-zero.
+- **Receipt schema is a minimal spike shape**, not `cnos.cdd.receipt.v1`: it reuses that schema's
+  structural verdict × action → transmissibility derivation (the fail-closed gate) but types only the
+  fields the skeleton needs (`id, cell, telos, transitions, evidence_refs, validation,
+  boundary_decision, transmissibility, verdict, produced_at_ref`).

--- a/src/packages/cnos.cell-runner/README.md
+++ b/src/packages/cnos.cell-runner/README.md
@@ -1,0 +1,77 @@
+# cnos cell-runner (walking-skeleton spike)
+
+**Exploratory spike — proof-of-life, NOT canonical doctrine or runtime.** This
+is a runnable skeleton of the three-cell agentic loop (CC → PC → WC → CC). It
+exists to learn from *running* the loop, ahead of the authored R12 cell-runtime
+doctrine (#672) and its implementation wave (#627 S2–S8). When that doctrine is
+authorized, this spike is reconciled to it or discarded. It invents no policy;
+where the design was underspecified it takes the minimal mechanical option and
+records the choice in `DESIGN.md` §Build notes.
+
+## What it proves
+
+One turn of the loop, mechanically, with no human in the machinery: measured
+incoherence goes **1 → 0** across a `CC.measure → PC.plan → WC.execute →
+CC.re-measure` turn, and a chain of `cue vet`-green receipts is produced. The
+three cells are distinguished ONLY by output telos (CC → judgment, PC →
+relation_graph, WC → artifact); they run the **same** kernel FSM.
+
+- **Kernel FSM** is a declarative transition table (`kernel/transitions.json`)
+  evaluated by a generic engine (`kernel/engine.go`, `kernel/drive.go`) that
+  never hardcodes a state name in a switch/if-chain — the
+  `cnos.issues/issues-fsm` idiom.
+- **Actors** (`actor/stub/`) are the "assisted" seam. v0 ships deterministic
+  stubs so the loop runs with zero external calls. Agent-backed actors
+  implement the same `kernel.Actor` interface next (v1) with no kernel change.
+- **Receipts** (`schema/receipt.cue`) are **computed** at γ from transition
+  evidence, never authored. The verdict × action → transmissibility table is
+  enforced structurally in CUE (fail closed).
+
+## Run it
+
+```sh
+export PATH="$PATH:$(go env GOPATH)/bin"   # so `cue` is on PATH
+cd src/packages/cnos.cell-runner
+
+# happy path: exits 0, prints the 1 → 0 transcript, writes objects under $WS
+go run ./cmd/cell-runner --workspace "$(mktemp -d)" --task testdata/toy
+
+# fail-injection: drives the kernel to `held`, writes a stop receipt, exits non-zero
+go run ./cmd/cell-runner --workspace "$(mktemp -d)" --task testdata/toy --fail-injection=beta-reject
+go run ./cmd/cell-runner --workspace "$(mktemp -d)" --task testdata/toy --fail-injection=v-fail
+```
+
+Emitted under `<workspace>/`: `cm/*.cm.json`, `wave/pc.wave.json`,
+`receipts/*.receipt.json`, `judgment/*.judgment.json`, and the working copy of
+the target under `target/`.
+
+## Validate & test
+
+```sh
+cue vet ./schema/ <workspace>/cm/cc-1.cm.json         -d '#CM'
+cue vet ./schema/ <workspace>/wave/pc.wave.json       -d '#Wave'
+cue vet ./schema/ <workspace>/receipts/wc.receipt.json -d '#Receipt'
+
+gofmt -l .        # prints nothing
+go vet ./...      # clean
+go test ./...     # green (the cue-vet integration test self-skips if cue is absent)
+```
+
+## Layout
+
+```
+cmd/cell-runner/   CLI entry (flags, exit codes)
+kernel/            transition table (JSON) + generic evaluator + Drive loop + Actor seam
+actor/stub/        deterministic CC/PC/WC actors (the v0 "assisted" boundary)
+cell/              kernel-under-telos + the CC→PC→WC→CC loop driver
+model/             Go structs for the emitted objects (JSON field names match schema/)
+schema/            CUE definitions (cm, wave, contract, judgment, receipt)
+testdata/toy/      the toy target (markdown missing `## Coherence`)
+```
+
+## Explicitly deferred (not in v0)
+
+Agent-backed actors; multi-WC / parallel waves; the wave FSM beyond one node;
+real CM scoring beyond defect-count; the operator-authorization gate;
+self-hosting on a real cnos change; tsc adoption. Each is a named next
+increment (see `DESIGN.md`), not a silent gap.

--- a/src/packages/cnos.cell-runner/actor/stub/cc.go
+++ b/src/packages/cnos.cell-runner/actor/stub/cc.go
@@ -1,0 +1,103 @@
+package stub
+
+import (
+	"fmt"
+	"os"
+
+	"cnos.dev/cnos/cell-runner/kernel"
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// ccActor is the Coherence Cell: telos = judgment. Its α IS the Measure step
+// (it produces the CM object); its δ emits the judgment the loop routes on.
+type ccActor struct{ baseActor }
+
+// NewCC returns a deterministic CC actor.
+func NewCC() kernel.Actor { return ccActor{} }
+
+// Alpha is the CC's Measure step: it mechanically measures the target and
+// produces the CM object. A missing `## Coherence` section is one defect.
+func (ccActor) Alpha(rc *kernel.RunContext) error {
+	content, err := os.ReadFile(rc.Target)
+	if err != nil {
+		return fmt.Errorf("read target for measurement: %w", err)
+	}
+	defects := []model.Defect{}
+	if !hasCoherenceSection(string(content)) {
+		defects = append(defects, model.Defect{
+			ID:     "missing-required-section",
+			Kind:   "missing-required-section",
+			Detail: fmt.Sprintf("required %q section is absent from the target", CoherenceHeading),
+		})
+	}
+	score := 1.0
+	if len(defects) > 0 {
+		score = 0.0
+	}
+	rc.CM = &model.CM{
+		Target:     rc.Target,
+		AlphaScore: score,
+		Defects:    defects,
+		Provenance: model.Provenance{
+			MeasuredBy: "cc.stub.measure",
+			Method:     "mechanical-required-section-check",
+			CMVersion:  "v0",
+		},
+		MeasuredAtRef: rc.Ref + "/cm",
+	}
+	rc.Facts.ArtifactPresent = true
+	rc.AddEvidence("cm", rc.CM.MeasuredAtRef)
+	rc.Log("  α measure: CM produced — defects=%d alpha_score=%.2f (incoherence=%d)",
+		len(defects), score, rc.CM.Incoherence())
+	return nil
+}
+
+// Beta approves the measurement.
+func (ccActor) Beta(rc *kernel.RunContext) error {
+	rc.Facts.ReviewApproved = true
+	rc.AddEvidence("beta_review", "approved")
+	rc.Log("  β review: approve (measurement is well-formed)")
+	return nil
+}
+
+// Validate asserts the CM is structurally well-formed.
+func (ccActor) Validate(rc *kernel.RunContext) error {
+	var failed []string
+	if rc.CM == nil || rc.CM.Target == "" {
+		failed = append(failed, "cm_has_target")
+	}
+	if rc.CM != nil && rc.CM.Provenance.MeasuredBy == "" {
+		failed = append(failed, "cm_has_provenance")
+	}
+	if len(failed) > 0 {
+		setValidation(rc, false, failed)
+		rc.Log("  V validate: FAIL (%v)", failed)
+		return nil
+	}
+	setValidation(rc, true, nil)
+	rc.AddEvidence("v_validate", "CM well-formed")
+	rc.Log("  V validate: PASS (CM well-formed)")
+	return nil
+}
+
+// DeltaAccept finalizes the receipt (via the shared accept path) AND emits the
+// CC's judgment computed from the CM: no defects → coherent, else
+// request_planning.
+func (ccActor) DeltaAccept(rc *kernel.RunContext) error {
+	if err := acceptReceipt(rc); err != nil {
+		return err
+	}
+	verdict := "coherent"
+	if rc.CM != nil && rc.CM.Incoherence() > 0 {
+		verdict = "request_planning"
+	}
+	rc.Judgment = &model.Judgment{
+		Verdict:      verdict,
+		CMRef:        rc.CM.MeasuredAtRef,
+		Target:       rc.CM.Target,
+		DecidedAtRef: rc.Ref + "/judgment",
+	}
+	rc.AddEvidence("judgment", rc.Judgment.DecidedAtRef)
+	rc.Log("  δ judgment: %s", verdict)
+	return nil
+}

--- a/src/packages/cnos.cell-runner/actor/stub/common.go
+++ b/src/packages/cnos.cell-runner/actor/stub/common.go
@@ -1,0 +1,153 @@
+// Package stub provides deterministic, external-call-free actors so the loop
+// runs end-to-end and proves the MACHINERY (not the intelligence). Each cell's
+// telos is expressed only by which actor is bound; all three drive the same
+// kernel. Agent-backed actors implement kernel.Actor next (v1) with no kernel
+// change. Spike code; see ../../DESIGN.md.
+package stub
+
+import (
+	"regexp"
+	"strings"
+
+	"cnos.dev/cnos/cell-runner/kernel"
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// CoherenceHeading is the required section the toy target must carry.
+const CoherenceHeading = "## Coherence"
+
+// coherenceBody is the section body α appends (the WC's artifact edit).
+const coherenceBody = "This artifact declares its coherence: every required section is present\n" +
+	"and mutually consistent with the target's stated telos.\n"
+
+var coherenceRe = regexp.MustCompile(`(?m)^##\s+Coherence\s*$`)
+
+// hasCoherenceSection reports whether content contains a `## Coherence` heading.
+func hasCoherenceSection(content string) bool { return coherenceRe.MatchString(content) }
+
+// coherenceSectionWellFormed reports whether the `## Coherence` heading is
+// present AND followed by a non-empty body (before the next `## ` heading or
+// EOF). This is the mechanical acceptance predicate V asserts for a WC.
+func coherenceSectionWellFormed(content string) bool {
+	loc := coherenceRe.FindStringIndex(content)
+	if loc == nil {
+		return false
+	}
+	rest := content[loc[1]:]
+	for _, line := range strings.Split(rest, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if strings.HasPrefix(t, "## ") {
+			break // reached the next section with no body in between
+		}
+		return true // a non-blank body line
+	}
+	return false
+}
+
+// baseActor supplies the telos-agnostic steps every cell shares: γ close, δ
+// accept, and δ hold. The three concrete actors embed it and override only the
+// telos-specific steps (Alpha, Beta, Validate; CC also overrides DeltaAccept
+// to emit its judgment).
+type baseActor struct{}
+
+// Gamma closes the cell: it computes the receipt skeleton from the transition
+// evidence gathered so far and binds it. The verdict is filled by V; the
+// boundary decision by δ. The receipt is COMPUTED here, never authored.
+func (baseActor) Gamma(rc *kernel.RunContext) error {
+	ensureReceipt(rc)
+	rc.Facts.ReceiptBound = true
+	rc.AddEvidence("gamma_close", rc.Ref+"/gamma")
+	rc.Log("  γ close: receipt bound from %d transition(s) of evidence", len(rc.Transitions))
+	return nil
+}
+
+// DeltaAccept records the accept boundary decision and finalizes the receipt.
+func (baseActor) DeltaAccept(rc *kernel.RunContext) error { return acceptReceipt(rc) }
+
+// DeltaHold finalizes a STOP receipt with a reject boundary decision (fail
+// closed). It is reached on β-reject (from `reviewed`) or V-fail (from
+// `validated`); it distinguishes the two by the edge that led here.
+func (baseActor) DeltaHold(rc *kernel.RunContext) error { return holdReceipt(rc) }
+
+// ensureReceipt lazily creates the receipt (the β-reject path skips γ, so δ
+// must be able to compute the receipt itself).
+func ensureReceipt(rc *kernel.RunContext) {
+	if rc.Receipt == nil {
+		rc.Receipt = &model.Receipt{
+			ID:            rc.Cell,
+			Cell:          rc.Cell,
+			Telos:         rc.Telos,
+			ProducedAtRef: rc.Ref,
+		}
+	}
+}
+
+// setValidation records V's verdict into the receipt and sets the VPass/VFail
+// fact the kernel table reads next.
+func setValidation(rc *kernel.RunContext, pass bool, failed []string) {
+	ensureReceipt(rc)
+	if pass {
+		rc.Facts.VPass = true
+		rc.Receipt.Validation = model.ValidationVerdict{Verdict: "PASS", FailedPredicates: []string{}, Warnings: []string{}}
+	} else {
+		rc.Facts.VFail = true
+		rc.Receipt.Validation = model.ValidationVerdict{Verdict: "FAIL", FailedPredicates: nonNil(failed), Warnings: []string{}}
+	}
+}
+
+// acceptReceipt finalizes the pass-path receipt.
+func acceptReceipt(rc *kernel.RunContext) error {
+	ensureReceipt(rc)
+	rc.Receipt.Transitions = snapshotTransitions(rc)
+	rc.Receipt.EvidenceRefs = snapshotEvidence(rc)
+	rc.Receipt.BoundaryDecision = model.BoundaryDecision{Actor: "delta", Action: "accept"}
+	rc.Receipt.Verdict = "accept"
+	rc.Receipt.Transmissibility = model.DeriveTransmissibility(rc.Receipt.Validation.Verdict, "accept")
+	rc.Log("  δ accept: boundary=accept transmissibility=%s", rc.Receipt.Transmissibility)
+	return nil
+}
+
+// holdReceipt finalizes the fail-path (STOP) receipt.
+func holdReceipt(rc *kernel.RunContext) error {
+	ensureReceipt(rc)
+	// If V never ran (β-reject skips γ/V), the failing predicate is the review
+	// itself; record it so the receipt is a complete evidence surface.
+	if rc.Receipt.Validation.Verdict == "" {
+		rc.Receipt.Validation = model.ValidationVerdict{
+			Verdict:          "FAIL",
+			FailedPredicates: []string{"beta_review_approved"},
+			Warnings:         []string{},
+		}
+	}
+	rc.Receipt.Transitions = snapshotTransitions(rc)
+	rc.Receipt.EvidenceRefs = snapshotEvidence(rc)
+	rc.Receipt.BoundaryDecision = model.BoundaryDecision{Actor: "delta", Action: "reject"}
+	rc.Receipt.Verdict = "hold"
+	rc.Receipt.Transmissibility = model.DeriveTransmissibility(rc.Receipt.Validation.Verdict, "reject")
+	rc.Log("  δ HOLD: boundary=reject transmissibility=%s (fail closed)", rc.Receipt.Transmissibility)
+	return nil
+}
+
+func snapshotTransitions(rc *kernel.RunContext) []model.TransitionRecord {
+	out := make([]model.TransitionRecord, len(rc.Transitions))
+	copy(out, rc.Transitions)
+	return out
+}
+
+func snapshotEvidence(rc *kernel.RunContext) map[string]string {
+	out := make(map[string]string, len(rc.Evidence))
+	for k, v := range rc.Evidence {
+		out[k] = v
+	}
+	return out
+}
+
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/src/packages/cnos.cell-runner/actor/stub/pc.go
+++ b/src/packages/cnos.cell-runner/actor/stub/pc.go
@@ -1,0 +1,66 @@
+package stub
+
+import (
+	"fmt"
+
+	"cnos.dev/cnos/cell-runner/kernel"
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// pcActor is the Planning Cell: telos = relation_graph. Its α emits a wave
+// (one WC contract) from the measurement; its V asserts the wave is well-formed.
+type pcActor struct{ baseActor }
+
+// NewPC returns a deterministic PC actor.
+func NewPC() kernel.Actor { return pcActor{} }
+
+// Alpha emits a wave carrying exactly one WC contract derived from the CM: a
+// contract to add the missing `## Coherence` section to the target.
+func (pcActor) Alpha(rc *kernel.RunContext) error {
+	if rc.CM == nil {
+		return fmt.Errorf("PC planning requires a CM but none was provided")
+	}
+	wc := model.Contract{
+		ID:          "wc-1",
+		Telos:       "artifact",
+		Target:      rc.CM.Target,
+		Instruction: fmt.Sprintf("add the %q section to the target to clear the measured defect", CoherenceHeading),
+		Acceptance:  []string{"coherence_section_present", "coherence_section_wellformed"},
+	}
+	rc.Wave = &model.Wave{
+		ID:        "wave-1",
+		FromCMRef: rc.CM.MeasuredAtRef,
+		Contracts: []model.Contract{wc},
+	}
+	rc.Facts.ArtifactPresent = true
+	rc.AddEvidence("artifact", rc.Ref+"/wave")
+	rc.Log("  α produce: planned wave of %d WC contract(s) from the CM", len(rc.Wave.Contracts))
+	return nil
+}
+
+// Beta approves the planned wave.
+func (pcActor) Beta(rc *kernel.RunContext) error {
+	rc.Facts.ReviewApproved = true
+	rc.AddEvidence("beta_review", "approved")
+	rc.Log("  β review: approve (wave targets the measured defect)")
+	return nil
+}
+
+// Validate asserts the wave is well-formed: exactly one contract, telos artifact.
+func (pcActor) Validate(rc *kernel.RunContext) error {
+	var failed []string
+	if rc.Wave == nil || len(rc.Wave.Contracts) != 1 {
+		failed = append(failed, "wave_has_exactly_one_contract")
+	} else if rc.Wave.Contracts[0].Telos != "artifact" {
+		failed = append(failed, "wave_contract_telos_is_artifact")
+	}
+	if len(failed) > 0 {
+		setValidation(rc, false, failed)
+		rc.Log("  V validate: FAIL (%v)", failed)
+		return nil
+	}
+	setValidation(rc, true, nil)
+	rc.AddEvidence("v_validate", "wave well-formed")
+	rc.Log("  V validate: PASS (wave well-formed: one WC contract, telos=artifact)")
+	return nil
+}

--- a/src/packages/cnos.cell-runner/actor/stub/wc.go
+++ b/src/packages/cnos.cell-runner/actor/stub/wc.go
@@ -1,0 +1,81 @@
+package stub
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"cnos.dev/cnos/cell-runner/kernel"
+)
+
+// wcActor is the Working Cell: telos = artifact. Its α edits the target file;
+// its V asserts the contract's mechanical acceptance predicates against the
+// edited file.
+type wcActor struct{ baseActor }
+
+// NewWC returns a deterministic WC actor.
+func NewWC() kernel.Actor { return wcActor{} }
+
+// Alpha appends the required `## Coherence` section to the target file.
+func (wcActor) Alpha(rc *kernel.RunContext) error {
+	content, err := os.ReadFile(rc.Target)
+	if err != nil {
+		return fmt.Errorf("read target: %w", err)
+	}
+	body := string(content)
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	body += "\n" + CoherenceHeading + "\n\n" + coherenceBody
+	if err := os.WriteFile(rc.Target, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write target: %w", err)
+	}
+	rc.Facts.ArtifactPresent = true
+	rc.AddEvidence("artifact", rc.Target)
+	rc.Log("  α produce: appended %q section to target", CoherenceHeading)
+	return nil
+}
+
+// Beta approves unless the beta-reject fault is injected.
+func (wcActor) Beta(rc *kernel.RunContext) error {
+	if rc.FailInjection == "beta-reject" {
+		rc.Facts.ReviewRejected = true
+		rc.AddEvidence("beta_review", "rejected")
+		rc.Log("  β review: REJECT (fault injected: beta-reject)")
+		return nil
+	}
+	rc.Facts.ReviewApproved = true
+	rc.AddEvidence("beta_review", "approved")
+	rc.Log("  β review: approve (artifact matches the required shape)")
+	return nil
+}
+
+// Validate mechanically asserts the acceptance predicates: the `## Coherence`
+// section is present and well-formed. The v-fail fault forces a rejection.
+func (wcActor) Validate(rc *kernel.RunContext) error {
+	content, err := os.ReadFile(rc.Target)
+	if err != nil {
+		return fmt.Errorf("read target for validation: %w", err)
+	}
+	if rc.FailInjection == "v-fail" {
+		setValidation(rc, false, []string{"coherence_section_present (fault injected: v-fail)"})
+		rc.Log("  V validate: FAIL (fault injected: v-fail)")
+		return nil
+	}
+	var failed []string
+	if !hasCoherenceSection(string(content)) {
+		failed = append(failed, "coherence_section_present")
+	}
+	if !coherenceSectionWellFormed(string(content)) {
+		failed = append(failed, "coherence_section_wellformed")
+	}
+	if len(failed) > 0 {
+		setValidation(rc, false, failed)
+		rc.Log("  V validate: FAIL (%s)", strings.Join(failed, ", "))
+		return nil
+	}
+	setValidation(rc, true, nil)
+	rc.AddEvidence("v_validate", "acceptance predicates satisfied")
+	rc.Log("  V validate: PASS (section present and well-formed)")
+	return nil
+}

--- a/src/packages/cnos.cell-runner/cell/cell.go
+++ b/src/packages/cnos.cell-runner/cell/cell.go
@@ -1,0 +1,61 @@
+// Package cell runs the kernel under a telos (the CC/PC/WC cells) and drives
+// the CC→PC→WC→CC loop. A "cell" here is nothing more than the kernel FSM
+// driven with a telos-specific Actor bound; the loop chains four such cell
+// runs and shows the measured incoherence going 1 → 0. Spike code; see
+// ../DESIGN.md.
+package cell
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"cnos.dev/cnos/cell-runner/kernel"
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// runCell drives one cell (one kernel run to a terminal state), then writes the
+// computed receipt to <workspace>/receipts/<receiptName>.receipt.json. It
+// returns the RunContext (carrying CM/wave/judgment outputs) and the terminal
+// state ("decided" on accept, "held" on fail-closed).
+func runCell(t *kernel.Table, a kernel.Actor, rc *kernel.RunContext, receiptName string) (string, error) {
+	rc.Facts.ContractPresent = true // the contract is the α-input, present at handover
+	rc.Log("[%s.%s] telos=%s contract=%s", rc.Cell, verb(rc.Cell), rc.Telos, rc.Contract.ID)
+
+	final, err := kernel.Drive(t, a, rc, "init")
+	if err != nil {
+		return final, err
+	}
+
+	if rc.Receipt != nil {
+		path := filepath.Join(rc.Workspace, "receipts", receiptName+".receipt.json")
+		if werr := model.WriteJSON(path, rc.Receipt); werr != nil {
+			return final, fmt.Errorf("write receipt: %w", werr)
+		}
+		rc.Log("  → receipt: receipts/%s.receipt.json (verdict=%s, transmissibility=%s)",
+			receiptName, rc.Receipt.Verdict, rc.Receipt.Transmissibility)
+	}
+	return final, nil
+}
+
+// verb labels a cell's action for the transcript.
+func verb(cell string) string {
+	switch cell {
+	case "CC":
+		return "measure"
+	case "PC":
+		return "plan"
+	case "WC":
+		return "execute"
+	default:
+		return "run"
+	}
+}
+
+// newLog wraps an io.Writer into a nil-safe transcript sink.
+func newLog(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
+}

--- a/src/packages/cnos.cell-runner/cell/loop.go
+++ b/src/packages/cnos.cell-runner/cell/loop.go
@@ -1,0 +1,204 @@
+package cell
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"cnos.dev/cnos/cell-runner/actor/stub"
+	"cnos.dev/cnos/cell-runner/kernel"
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// Options configures one loop run.
+type Options struct {
+	// Workspace is the writable run root (CM/wave/receipts are written here).
+	Workspace string
+	// TaskDir is the source task directory (holds the target markdown). Its
+	// target is copied into the workspace so the source is never mutated.
+	TaskDir string
+	// FailInjection injects a fault into the WC turn: "" (none), "beta-reject",
+	// or "v-fail".
+	FailInjection string
+	// Log receives the loop transcript (nil → discarded).
+	Log io.Writer
+}
+
+// Result summarizes a loop run.
+type Result struct {
+	InitialIncoherence int
+	FinalIncoherence   int
+	FinalJudgment      string
+	Held               bool
+	HeldCell           string
+	TargetPath         string
+}
+
+// RunLoop executes one CC→PC→WC→CC turn of the agentic loop. It returns a
+// non-nil error when the loop fails closed (a cell reached `held`) or does not
+// converge — the caller maps that to a non-zero exit.
+func RunLoop(opts Options) (Result, error) {
+	log := newLog(opts.Log)
+	var res Result
+
+	target, err := prepareWorkspace(opts.Workspace, opts.TaskDir)
+	if err != nil {
+		return res, err
+	}
+	res.TargetPath = target
+
+	t, err := kernel.DefaultTable()
+	if err != nil {
+		return res, fmt.Errorf("load kernel table: %w", err)
+	}
+
+	fmt.Fprintf(log, "=== cnos cell-runner — CC→PC→WC→CC walking skeleton ===\n")
+	fmt.Fprintf(log, "workspace: %s\ntarget:    %s\n", opts.Workspace, target)
+	if opts.FailInjection != "" {
+		fmt.Fprintf(log, "fault:     %s (injected into the WC turn)\n", opts.FailInjection)
+	}
+	fmt.Fprintln(log)
+
+	// --- Turn 1: CC.measure -------------------------------------------------
+	fmt.Fprintln(log, "── turn 1: CC.measure ──────────────────────────────────")
+	cc1 := kernel.NewRunContext("CC", "judgment", "ref:turn-1/CC", opts.Workspace, target,
+		model.Contract{ID: "cc-measure", Telos: "judgment", Target: target,
+			Instruction: "measure the target's coherence", Acceptance: []string{"cm_has_target", "cm_has_provenance"}},
+		"", log)
+	if _, err := runCell(t, stub.NewCC(), cc1, "cc-1"); err != nil {
+		return res, err
+	}
+	if err := writeCCOutputs(cc1, "cc-1"); err != nil {
+		return res, err
+	}
+	res.InitialIncoherence = cc1.CM.Incoherence()
+	fmt.Fprintf(log, "  incoherence: %d   judgment: %s\n\n", res.InitialIncoherence, cc1.Judgment.Verdict)
+
+	if cc1.Judgment.Verdict == "coherent" {
+		res.FinalIncoherence = res.InitialIncoherence
+		res.FinalJudgment = "coherent"
+		fmt.Fprintln(log, "target already coherent; nothing to do.")
+		return res, nil
+	}
+
+	// --- Turn 2: PC.plan ----------------------------------------------------
+	fmt.Fprintln(log, "── turn 2: PC.plan ─────────────────────────────────────")
+	pc := kernel.NewRunContext("PC", "relation_graph", "ref:turn-2/PC", opts.Workspace, target,
+		model.Contract{ID: "pc-plan", Telos: "relation_graph", Target: target,
+			Instruction: "plan a wave that clears the measured defect", Acceptance: []string{"wave_has_exactly_one_contract"}},
+		"", log)
+	pc.CM = cc1.CM // the PC plans from the CM the CC produced
+	if _, err := runCell(t, stub.NewPC(), pc, "pc"); err != nil {
+		return res, err
+	}
+	if err := model.WriteJSON(filepath.Join(opts.Workspace, "wave", "pc.wave.json"), pc.Wave); err != nil {
+		return res, fmt.Errorf("write wave: %w", err)
+	}
+	pc.Log("  → wave: wave/pc.wave.json (%d contract)\n", len(pc.Wave.Contracts))
+
+	// --- Turn 3: WC.execute -------------------------------------------------
+	fmt.Fprintln(log, "── turn 3: WC.execute ──────────────────────────────────")
+	wcContract := pc.Wave.Contracts[0]
+	wc := kernel.NewRunContext("WC", "artifact", "ref:turn-3/WC", opts.Workspace, target,
+		wcContract, opts.FailInjection, log)
+	wcFinal, err := runCell(t, stub.NewWC(), wc, "wc")
+	if err != nil {
+		return res, err
+	}
+	if wcFinal == "held" {
+		res.Held = true
+		res.HeldCell = "WC"
+		fmt.Fprintf(log, "\nLOOP HELD at WC (fail closed): stop receipt written to receipts/wc.receipt.json\n")
+		return res, fmt.Errorf("loop failed closed: WC reached 'held' (%s)", describeHold(opts.FailInjection))
+	}
+	fmt.Fprintln(log)
+
+	// --- Turn 4: CC.re-measure ---------------------------------------------
+	fmt.Fprintln(log, "── turn 4: CC.re-measure ───────────────────────────────")
+	cc2 := kernel.NewRunContext("CC", "judgment", "ref:turn-4/CC", opts.Workspace, target,
+		model.Contract{ID: "cc-remeasure", Telos: "judgment", Target: target,
+			Instruction: "re-measure the target after the WC edit", Acceptance: []string{"cm_has_target", "cm_has_provenance"}},
+		"", log)
+	if _, err := runCell(t, stub.NewCC(), cc2, "cc-2"); err != nil {
+		return res, err
+	}
+	if err := writeCCOutputs(cc2, "cc-2"); err != nil {
+		return res, err
+	}
+	res.FinalIncoherence = cc2.CM.Incoherence()
+	res.FinalJudgment = cc2.Judgment.Verdict
+	fmt.Fprintf(log, "  incoherence: %d   judgment: %s\n\n", res.FinalIncoherence, cc2.Judgment.Verdict)
+
+	fmt.Fprintf(log, "=== LOOP COMPLETE: incoherence %d → %d, judgment=%s, receipt chain closed ===\n",
+		res.InitialIncoherence, res.FinalIncoherence, res.FinalJudgment)
+
+	if res.FinalJudgment != "coherent" || res.FinalIncoherence != 0 {
+		return res, fmt.Errorf("loop did not converge: final judgment=%s incoherence=%d", res.FinalJudgment, res.FinalIncoherence)
+	}
+	return res, nil
+}
+
+// writeCCOutputs writes a CC turn's CM and judgment objects.
+func writeCCOutputs(rc *kernel.RunContext, name string) error {
+	if err := model.WriteJSON(filepath.Join(rc.Workspace, "cm", name+".cm.json"), rc.CM); err != nil {
+		return fmt.Errorf("write CM: %w", err)
+	}
+	if err := model.WriteJSON(filepath.Join(rc.Workspace, "judgment", name+".judgment.json"), rc.Judgment); err != nil {
+		return fmt.Errorf("write judgment: %w", err)
+	}
+	rc.Log("  → cm: cm/%s.cm.json   judgment: judgment/%s.judgment.json", name, name)
+	return nil
+}
+
+func describeHold(faultInjection string) string {
+	switch faultInjection {
+	case "beta-reject":
+		return "β rejected the artifact; reviewed → held"
+	case "v-fail":
+		return "V rejected the artifact; validated → held"
+	default:
+		return "a gate rejected the artifact"
+	}
+}
+
+// prepareWorkspace creates the workspace layout and copies the task's target
+// markdown into <workspace>/target/, returning the copy's path. The source
+// task directory is never mutated (so tests and re-runs are repeatable).
+func prepareWorkspace(workspace, taskDir string) (string, error) {
+	if workspace == "" {
+		return "", fmt.Errorf("--workspace is required")
+	}
+	srcTarget, err := findTarget(taskDir)
+	if err != nil {
+		return "", err
+	}
+	dstDir := filepath.Join(workspace, "target")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return "", err
+	}
+	dst := filepath.Join(dstDir, filepath.Base(srcTarget))
+	data, err := os.ReadFile(srcTarget)
+	if err != nil {
+		return "", fmt.Errorf("read task target: %w", err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return "", fmt.Errorf("copy task target: %w", err)
+	}
+	return dst, nil
+}
+
+// findTarget returns the single markdown target inside taskDir.
+func findTarget(taskDir string) (string, error) {
+	if taskDir == "" {
+		return "", fmt.Errorf("--task is required")
+	}
+	matches, err := filepath.Glob(filepath.Join(taskDir, "*.md"))
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("task %q must contain exactly one .md target, found %d", taskDir, len(matches))
+	}
+	return matches[0], nil
+}

--- a/src/packages/cnos.cell-runner/cell/loop_test.go
+++ b/src/packages/cnos.cell-runner/cell/loop_test.go
@@ -1,0 +1,167 @@
+package cell
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+const toyTask = "../testdata/toy"
+
+// TestHappyLoop runs the full CC→PC→WC→CC loop and asserts incoherence 1 → 0,
+// a coherent final judgment, and that every expected object was written.
+func TestHappyLoop(t *testing.T) {
+	ws := t.TempDir()
+	var log bytes.Buffer
+	res, err := RunLoop(Options{Workspace: ws, TaskDir: toyTask, Log: &log})
+	if err != nil {
+		t.Fatalf("RunLoop: %v\n%s", err, log.String())
+	}
+	if res.InitialIncoherence != 1 || res.FinalIncoherence != 0 {
+		t.Fatalf("incoherence %d -> %d, want 1 -> 0", res.InitialIncoherence, res.FinalIncoherence)
+	}
+	if res.FinalJudgment != "coherent" {
+		t.Fatalf("final judgment=%q want coherent", res.FinalJudgment)
+	}
+	transcript := log.String()
+	for _, want := range []string{"incoherence: 1", "incoherence: 0", "LOOP COMPLETE"} {
+		if !strings.Contains(transcript, want) {
+			t.Fatalf("transcript missing %q", want)
+		}
+	}
+	for _, f := range []string{
+		"cm/cc-1.cm.json", "cm/cc-2.cm.json",
+		"wave/pc.wave.json",
+		"receipts/cc-1.receipt.json", "receipts/pc.receipt.json",
+		"receipts/wc.receipt.json", "receipts/cc-2.receipt.json",
+	} {
+		if _, err := os.Stat(filepath.Join(ws, f)); err != nil {
+			t.Fatalf("expected emitted file %s: %v", f, err)
+		}
+	}
+
+	// The first CM records the defect; the second clears it.
+	cm1 := readCM(t, filepath.Join(ws, "cm/cc-1.cm.json"))
+	cm2 := readCM(t, filepath.Join(ws, "cm/cc-2.cm.json"))
+	if len(cm1.Defects) != 1 || cm1.Defects[0].Kind != "missing-required-section" {
+		t.Fatalf("cm1 defects=%v want one missing-required-section", cm1.Defects)
+	}
+	if len(cm2.Defects) != 0 {
+		t.Fatalf("cm2 defects=%v want none", cm2.Defects)
+	}
+
+	// The WC receipt must be an accepted, transmissible artifact.
+	rc := readReceipt(t, filepath.Join(ws, "receipts/wc.receipt.json"))
+	if rc.Verdict != "accept" || rc.Transmissibility != "accepted" {
+		t.Fatalf("wc receipt verdict=%q transmissibility=%q want accept/accepted", rc.Verdict, rc.Transmissibility)
+	}
+}
+
+// TestFailInjection covers both fail-closed branches: β-reject and V-fail both
+// drive WC to `held`, error out, and write a not_transmissible stop receipt.
+func TestFailInjection(t *testing.T) {
+	cases := []struct {
+		fault     string
+		wantFinal string // From-state of the held edge
+	}{
+		{"beta-reject", "reviewed"},
+		{"v-fail", "validated"},
+	}
+	for _, c := range cases {
+		t.Run(c.fault, func(t *testing.T) {
+			ws := t.TempDir()
+			var log bytes.Buffer
+			res, err := RunLoop(Options{Workspace: ws, TaskDir: toyTask, FailInjection: c.fault, Log: &log})
+			if err == nil {
+				t.Fatalf("expected fail-closed error, got nil\n%s", log.String())
+			}
+			if !res.Held || res.HeldCell != "WC" {
+				t.Fatalf("res.Held=%v cell=%q want held WC", res.Held, res.HeldCell)
+			}
+			rc := readReceipt(t, filepath.Join(ws, "receipts/wc.receipt.json"))
+			if rc.Verdict != "hold" {
+				t.Fatalf("verdict=%q want hold", rc.Verdict)
+			}
+			if rc.Transmissibility != "not_transmissible" {
+				t.Fatalf("transmissibility=%q want not_transmissible", rc.Transmissibility)
+			}
+			if rc.BoundaryDecision.Action != "reject" {
+				t.Fatalf("action=%q want reject", rc.BoundaryDecision.Action)
+			}
+			last := rc.Transitions[len(rc.Transitions)-1]
+			if last.To != "held" || last.From != c.wantFinal {
+				t.Fatalf("held edge %s->%s want %s->held", last.From, last.To, c.wantFinal)
+			}
+			// A held run must NOT reach turn 4.
+			if _, err := os.Stat(filepath.Join(ws, "cm/cc-2.cm.json")); err == nil {
+				t.Fatal("re-measure should not run after a held WC")
+			}
+		})
+	}
+}
+
+// TestEmittedObjectsCueVet validates every emitted object against schema/*.cue
+// with the real `cue` binary. Skipped if cue is not on PATH.
+func TestEmittedObjectsCueVet(t *testing.T) {
+	cueBin, err := exec.LookPath("cue")
+	if err != nil {
+		t.Skip("cue not on PATH; skipping schema-vet integration test")
+	}
+	ws := t.TempDir()
+	if _, err := RunLoop(Options{Workspace: ws, TaskDir: toyTask}); err != nil {
+		t.Fatalf("RunLoop: %v", err)
+	}
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	objs := []struct{ file, def string }{
+		{"cm/cc-1.cm.json", "#CM"},
+		{"cm/cc-2.cm.json", "#CM"},
+		{"wave/pc.wave.json", "#Wave"},
+		{"receipts/cc-1.receipt.json", "#Receipt"},
+		{"receipts/pc.receipt.json", "#Receipt"},
+		{"receipts/wc.receipt.json", "#Receipt"},
+		{"receipts/cc-2.receipt.json", "#Receipt"},
+		{"judgment/cc-1.judgment.json", "#Judgment"},
+		{"judgment/cc-2.judgment.json", "#Judgment"},
+	}
+	for _, o := range objs {
+		cmd := exec.Command(cueBin, "vet", "./schema/", filepath.Join(ws, o.file), "-d", o.def)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cue vet %s -d %s failed: %v\n%s", o.file, o.def, err, out)
+		}
+	}
+}
+
+func readCM(t *testing.T, path string) model.CM {
+	t.Helper()
+	var cm model.CM
+	readJSON(t, path, &cm)
+	return cm
+}
+
+func readReceipt(t *testing.T, path string) model.Receipt {
+	t.Helper()
+	var r model.Receipt
+	readJSON(t, path, &r)
+	return r
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}

--- a/src/packages/cnos.cell-runner/cmd/cell-runner/main.go
+++ b/src/packages/cnos.cell-runner/cmd/cell-runner/main.go
@@ -1,0 +1,45 @@
+// Command cell-runner is the walking-skeleton driver for the three-cell
+// agentic loop (CC→PC→WC→CC). It runs one turn of the loop over a toy task,
+// prints a transcript showing the measured incoherence going 1 → 0, and writes
+// CUE-valid CM / wave / receipt objects under the workspace.
+//
+// Exit codes: 0 on a converged loop; non-zero when the loop fails closed (a
+// cell reached the kernel's `held` state) or does not converge. This is spike
+// code (an exploratory proof-of-life), not canonical runtime — see
+// ../../DESIGN.md and ../../README.md.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"cnos.dev/cnos/cell-runner/cell"
+)
+
+func main() {
+	workspace := flag.String("workspace", "", "writable run root for CM/wave/receipt outputs (required)")
+	task := flag.String("task", "", "task directory holding the target markdown (required, e.g. testdata/toy)")
+	failInjection := flag.String("fail-injection", "", "inject a WC fault: 'beta-reject' or 'v-fail' (drives the kernel to 'held')")
+	flag.Parse()
+
+	switch *failInjection {
+	case "", "beta-reject", "v-fail":
+	default:
+		fmt.Fprintf(os.Stderr, "cell-runner: unknown --fail-injection %q (want 'beta-reject' or 'v-fail')\n", *failInjection)
+		os.Exit(2)
+	}
+
+	res, err := cell.RunLoop(cell.Options{
+		Workspace:     *workspace,
+		TaskDir:       *task,
+		FailInjection: *failInjection,
+		Log:           os.Stdout,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\ncell-runner: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nOK: incoherence %d → %d (%s)\n", res.InitialIncoherence, res.FinalIncoherence, res.FinalJudgment)
+}

--- a/src/packages/cnos.cell-runner/go.mod
+++ b/src/packages/cnos.cell-runner/go.mod
@@ -1,0 +1,3 @@
+module cnos.dev/cnos/cell-runner
+
+go 1.24

--- a/src/packages/cnos.cell-runner/kernel/actor.go
+++ b/src/packages/cnos.cell-runner/kernel/actor.go
@@ -1,0 +1,46 @@
+package kernel
+
+// Actor is the "assisted" seam: the boundary between the mechanical kernel and
+// whatever performs each step. v0 ships deterministic stub actors
+// (../actor/stub); agent-backed actors (real α/β/CC judgment) implement this
+// SAME interface next (v1) with nothing in the kernel or Drive loop changing.
+//
+// The kernel is uniform across all three cells: every cell runs the same six
+// steps. A cell's telos is expressed purely by WHICH Actor is bound:
+//   - WC: Alpha edits the target file; Validate asserts acceptance predicates.
+//   - PC: Alpha emits a wave (one WC contract); the artifact is the relation graph.
+//   - CC: Alpha IS the Measure step (produces the CM); DeltaAccept emits the
+//     judgment. ("Measure" in DESIGN.md is realized as the CC actor's α — the
+//     kernel stays uniform; see ../DESIGN.md §Build notes.)
+type Actor interface {
+	// Alpha produces the cell's artifact and sets ArtifactPresent.
+	Alpha(rc *RunContext) error
+	// Beta reviews the artifact and sets ReviewApproved or ReviewRejected.
+	Beta(rc *RunContext) error
+	// Gamma closes: computes the receipt from transition evidence and sets
+	// ReceiptBound.
+	Gamma(rc *RunContext) error
+	// Validate mechanically checks the artifact against the contract's
+	// acceptance predicates and sets VPass or VFail (recording the verdict
+	// into the receipt).
+	Validate(rc *RunContext) error
+	// DeltaAccept is δ on the pass path: records the accept boundary decision
+	// and finalizes the receipt (and, for a CC, emits the judgment).
+	DeltaAccept(rc *RunContext) error
+	// DeltaHold is δ on the fail path: computes/finalizes a STOP receipt with a
+	// reject boundary decision (fail closed).
+	DeltaHold(rc *RunContext) error
+}
+
+// stepFuncs is the actor-step registry: it maps the step ids named in the
+// transition table to Actor method calls. Like guardFuncs, it is a fixed
+// generic vocabulary — Drive dispatches through it and never switches on a
+// state name.
+var stepFuncs = map[string]func(Actor, *RunContext) error{
+	"alpha_produce": func(a Actor, rc *RunContext) error { return a.Alpha(rc) },
+	"beta_review":   func(a Actor, rc *RunContext) error { return a.Beta(rc) },
+	"gamma_close":   func(a Actor, rc *RunContext) error { return a.Gamma(rc) },
+	"v_validate":    func(a Actor, rc *RunContext) error { return a.Validate(rc) },
+	"delta_accept":  func(a Actor, rc *RunContext) error { return a.DeltaAccept(rc) },
+	"delta_hold":    func(a Actor, rc *RunContext) error { return a.DeltaHold(rc) },
+}

--- a/src/packages/cnos.cell-runner/kernel/drive.go
+++ b/src/packages/cnos.cell-runner/kernel/drive.go
@@ -1,0 +1,54 @@
+package kernel
+
+import (
+	"fmt"
+
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// Drive runs the kernel FSM to a terminal state. Starting at `initial`, it
+// repeatedly: (1) evaluates the table for the current state, (2) records the
+// matched transition, (3) runs the transition's step actor (which mutates the
+// facts that gate the NEXT transition), and (4) advances to the target state —
+// until a terminal state is reached.
+//
+// Drive is fully generic: it contains no cell-specific and no state-specific
+// logic. Every state name, guard, and step comes from the table + the step
+// registry. It returns the terminal state reached, plus an error if a step
+// fails or the machine gets stuck (no guard satisfied at a non-terminal
+// state — the fail-closed signal).
+func Drive(t *Table, a Actor, rc *RunContext, initial string) (string, error) {
+	state := initial
+	rc.Facts.State = state
+	for {
+		if t.IsTerminal(state) {
+			return state, nil
+		}
+		d, err := Evaluate(t, state, *rc.Facts)
+		if err != nil {
+			return state, err
+		}
+		if !d.Matched {
+			return state, fmt.Errorf("kernel stuck at state %q: no transition guard satisfied", state)
+		}
+
+		rc.Transitions = append(rc.Transitions, model.TransitionRecord{
+			From:  d.From,
+			To:    d.To,
+			Step:  d.Step,
+			Guard: d.Guard,
+		})
+		rc.Log("  kernel: %-9s --%-16s--> %-9s  [%s]", d.From, d.Guard, d.To, d.Step)
+
+		step, ok := stepFuncs[d.Step]
+		if !ok {
+			return state, fmt.Errorf("transition table references unknown step %q", d.Step)
+		}
+		if err := step(a, rc); err != nil {
+			return state, fmt.Errorf("step %q failed: %w", d.Step, err)
+		}
+
+		state = d.To
+		rc.Facts.State = state
+	}
+}

--- a/src/packages/cnos.cell-runner/kernel/engine.go
+++ b/src/packages/cnos.cell-runner/kernel/engine.go
@@ -1,0 +1,105 @@
+package kernel
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FactSnapshot is the evaluator's entire input: an explicit, inference-free
+// observation of one cell's evidence. Each boolean is produced by an actor
+// step (or, for ContractPresent, by the cell handing over the contract). The
+// evaluator reads these; it never re-derives a fact by guessing.
+type FactSnapshot struct {
+	// State is the current kernel state.
+	State string
+
+	ContractPresent bool
+	ArtifactPresent bool
+	ReviewApproved  bool
+	ReviewRejected  bool
+	ReceiptBound    bool
+	VPass           bool
+	VFail           bool
+}
+
+// Decision is the evaluator's structured output for one (state, facts) pair:
+// the matched transition, or Matched=false when no rule fires (either a
+// terminal state, or a genuinely stuck state). It is a pure projection of a
+// Table + FactSnapshot — read-only and idempotent.
+type Decision struct {
+	From    string
+	To      string
+	Step    string
+	Guard   string
+	Reason  string
+	Matched bool
+}
+
+// Evaluate is the generic evaluator: it looks up state's entry in t and
+// returns the Decision from the first matching rule. It performs no
+// cell-specific reasoning — every state name, guard, step, and target comes
+// from t. This is the "never hardcode a state name in a switch" invariant.
+func Evaluate(t *Table, state string, f FactSnapshot) (Decision, error) {
+	for _, tr := range t.Transitions {
+		if tr.State != state {
+			continue
+		}
+		for _, r := range tr.Rules {
+			ok, err := ruleMatches(r, f)
+			if err != nil {
+				return Decision{}, err
+			}
+			if !ok {
+				continue
+			}
+			return Decision{
+				From:    state,
+				To:      r.To,
+				Step:    r.Step,
+				Guard:   guardLabel(r),
+				Reason:  r.Reason,
+				Matched: true,
+			}, nil
+		}
+		// State entry exists but no rule matched: not an error here — the
+		// caller (Drive) decides whether that is terminal or stuck.
+		return Decision{From: state, Matched: false}, nil
+	}
+	// No entry for this state at all (e.g. a terminal state).
+	return Decision{From: state, Matched: false}, nil
+}
+
+// guardLabel renders a rule's guard set for the transcript/receipt.
+func guardLabel(r Rule) string {
+	parts := append([]string{}, r.AllTrue...)
+	for _, g := range r.AnyTrue {
+		parts = append(parts, "any:"+g)
+	}
+	for _, g := range r.AllFalse {
+		parts = append(parts, "!"+g)
+	}
+	if len(parts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(parts, "&")
+}
+
+// GuardsKnown reports whether every guard referenced anywhere in the table is
+// implemented by the engine's guard registry — a table-authoring lint used by
+// tests to keep transitions.json and the guard vocabulary in sync.
+func (t *Table) GuardsKnown() error {
+	var unknown []string
+	for _, tr := range t.Transitions {
+		for _, r := range tr.Rules {
+			for _, g := range append(append(append([]string{}, r.AllTrue...), r.AnyTrue...), r.AllFalse...) {
+				if _, ok := guardFuncs[g]; !ok {
+					unknown = append(unknown, g)
+				}
+			}
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("table references unknown guards: %s", strings.Join(unknown, ", "))
+	}
+	return nil
+}

--- a/src/packages/cnos.cell-runner/kernel/engine_test.go
+++ b/src/packages/cnos.cell-runner/kernel/engine_test.go
@@ -1,0 +1,151 @@
+package kernel
+
+import (
+	"io"
+	"testing"
+
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// TestEvaluateFirstMatchWins checks the generic evaluator picks the correct
+// transition per state from the default (embedded) table, purely from facts.
+func TestEvaluateFirstMatchWins(t *testing.T) {
+	tab, err := DefaultTable()
+	if err != nil {
+		t.Fatalf("DefaultTable: %v", err)
+	}
+	cases := []struct {
+		name     string
+		state    string
+		facts    FactSnapshot
+		wantTo   string
+		wantStep string
+		matched  bool
+	}{
+		{"init->produced", "init", FactSnapshot{ContractPresent: true}, "produced", "alpha_produce", true},
+		{"produced->reviewed", "produced", FactSnapshot{ArtifactPresent: true}, "reviewed", "beta_review", true},
+		{"reviewed->closed", "reviewed", FactSnapshot{ReviewApproved: true}, "closed", "gamma_close", true},
+		{"reviewed->held", "reviewed", FactSnapshot{ReviewRejected: true}, "held", "delta_hold", true},
+		{"closed->validated", "closed", FactSnapshot{ReceiptBound: true}, "validated", "v_validate", true},
+		{"validated->decided", "validated", FactSnapshot{VPass: true}, "decided", "delta_accept", true},
+		{"validated->held", "validated", FactSnapshot{VFail: true}, "held", "delta_hold", true},
+		{"no facts, no match", "init", FactSnapshot{}, "", "", false},
+		{"terminal decided", "decided", FactSnapshot{}, "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d, err := Evaluate(tab, c.state, c.facts)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if d.Matched != c.matched {
+				t.Fatalf("matched=%v want %v", d.Matched, c.matched)
+			}
+			if d.To != c.wantTo || d.Step != c.wantStep {
+				t.Fatalf("got (to=%q step=%q) want (to=%q step=%q)", d.To, d.Step, c.wantTo, c.wantStep)
+			}
+		})
+	}
+}
+
+// TestUnknownGuardErrors ensures a table referencing an unknown guard is a
+// clean error, not a silent pass.
+func TestUnknownGuardErrors(t *testing.T) {
+	tab := &Table{
+		States:   []string{"init"},
+		Terminal: []string{},
+		Transitions: []StateTransition{{
+			State:   "init",
+			Trigger: "advance",
+			Rules:   []Rule{{AllTrue: []string{"no_such_guard"}, To: "x", Step: "y"}},
+		}},
+	}
+	if _, err := Evaluate(tab, "init", FactSnapshot{}); err == nil {
+		t.Fatal("expected error for unknown guard, got nil")
+	}
+	if err := tab.GuardsKnown(); err == nil {
+		t.Fatal("GuardsKnown should reject an unknown guard")
+	}
+}
+
+// TestDefaultTableGuardsKnown checks the shipped table only uses implemented guards.
+func TestDefaultTableGuardsKnown(t *testing.T) {
+	tab, err := DefaultTable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tab.GuardsKnown(); err != nil {
+		t.Fatalf("default table has unknown guards: %v", err)
+	}
+}
+
+// scriptedActor is a minimal fact-only actor used to exercise Drive without
+// any file IO: each step sets the fact its transition produces. reject/vFail
+// select the held branches.
+type scriptedActor struct {
+	reject bool
+	vFail  bool
+}
+
+func (a scriptedActor) Alpha(rc *RunContext) error { rc.Facts.ArtifactPresent = true; return nil }
+func (a scriptedActor) Beta(rc *RunContext) error {
+	if a.reject {
+		rc.Facts.ReviewRejected = true
+	} else {
+		rc.Facts.ReviewApproved = true
+	}
+	return nil
+}
+func (a scriptedActor) Gamma(rc *RunContext) error { rc.Facts.ReceiptBound = true; return nil }
+func (a scriptedActor) Validate(rc *RunContext) error {
+	if a.vFail {
+		rc.Facts.VFail = true
+	} else {
+		rc.Facts.VPass = true
+	}
+	return nil
+}
+func (a scriptedActor) DeltaAccept(rc *RunContext) error {
+	rc.Receipt = &model.Receipt{Verdict: "accept"}
+	return nil
+}
+func (a scriptedActor) DeltaHold(rc *RunContext) error {
+	rc.Receipt = &model.Receipt{Verdict: "hold"}
+	return nil
+}
+
+func drive(t *testing.T, a scriptedActor) string {
+	t.Helper()
+	tab, err := DefaultTable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := NewRunContext("WC", "artifact", "ref:test", t.TempDir(), "", model.Contract{}, "", io.Discard)
+	rc.Facts.ContractPresent = true
+	final, err := Drive(tab, a, rc, "init")
+	if err != nil {
+		t.Fatalf("Drive: %v", err)
+	}
+	return final
+}
+
+// TestDriveReachesDecided drives the happy path to the decided terminal.
+func TestDriveReachesDecided(t *testing.T) {
+	if got := drive(t, scriptedActor{}); got != "decided" {
+		t.Fatalf("final=%q want decided", got)
+	}
+}
+
+// TestDriveBetaRejectHolds drives the β-reject branch to held.
+func TestDriveBetaRejectHolds(t *testing.T) {
+	if got := drive(t, scriptedActor{reject: true}); got != "held" {
+		t.Fatalf("final=%q want held", got)
+	}
+}
+
+// TestDriveVFailHolds drives the V-fail branch to held.
+func TestDriveVFailHolds(t *testing.T) {
+	if got := drive(t, scriptedActor{vFail: true}); got != "held" {
+		t.Fatalf("final=%q want held", got)
+	}
+}

--- a/src/packages/cnos.cell-runner/kernel/runcontext.go
+++ b/src/packages/cnos.cell-runner/kernel/runcontext.go
@@ -1,0 +1,72 @@
+package kernel
+
+import (
+	"fmt"
+	"io"
+
+	"cnos.dev/cnos/cell-runner/model"
+)
+
+// RunContext is the mutable state of one kernel run (one cell turn). Actor
+// steps read and mutate it: they set facts, append evidence refs, and build
+// the CM / wave / judgment / receipt outputs. The kernel Drive loop owns the
+// state machine; the RunContext owns the accumulated evidence.
+type RunContext struct {
+	// Cell is the telos-role label: "CC", "PC", or "WC".
+	Cell string
+	// Telos is the output kind: "judgment", "relation_graph", or "artifact".
+	Telos string
+	// Ref is a synthetic, git-native-style reference string for this turn
+	// (e.g. "ref:turn-1/CC"); used as measured_at_ref / produced_at_ref. The
+	// spike does not touch git, so refs are stable synthetic identifiers.
+	Ref string
+
+	// Workspace is the run's writable root.
+	Workspace string
+	// Target is the path (inside the workspace) of the file the cell acts on.
+	Target string
+	// Contract is the α-input for this run.
+	Contract model.Contract
+	// FailInjection selects a fault to inject ("", "beta-reject", "v-fail").
+	FailInjection string
+
+	// Facts is the evaluator's observation, mutated by actor steps.
+	Facts *FactSnapshot
+	// Evidence accumulates typed evidence refs for the receipt.
+	Evidence map[string]string
+	// Transitions records every kernel edge traversed (receipt evidence).
+	Transitions []model.TransitionRecord
+
+	// Outputs (set by the relevant actor step for this cell's telos).
+	CM       *model.CM
+	Wave     *model.Wave
+	Judgment *model.Judgment
+	Receipt  *model.Receipt
+
+	logw io.Writer
+}
+
+// NewRunContext builds a RunContext with an initialized fact snapshot and
+// evidence map, logging the transcript to logw.
+func NewRunContext(cell, telos, ref, workspace, target string, contract model.Contract, failInjection string, logw io.Writer) *RunContext {
+	return &RunContext{
+		Cell:          cell,
+		Telos:         telos,
+		Ref:           ref,
+		Workspace:     workspace,
+		Target:        target,
+		Contract:      contract,
+		FailInjection: failInjection,
+		Facts:         &FactSnapshot{},
+		Evidence:      map[string]string{},
+		logw:          logw,
+	}
+}
+
+// Log writes a transcript line.
+func (rc *RunContext) Log(format string, args ...any) {
+	fmt.Fprintf(rc.logw, format+"\n", args...)
+}
+
+// AddEvidence records a typed evidence ref for the receipt.
+func (rc *RunContext) AddEvidence(key, ref string) { rc.Evidence[key] = ref }

--- a/src/packages/cnos.cell-runner/kernel/table.go
+++ b/src/packages/cnos.cell-runner/kernel/table.go
@@ -1,0 +1,155 @@
+// Package kernel is the package-agnostic cell FSM: a declarative transition
+// table (transitions.json) plus a generic evaluator that never hardcodes a
+// state name in a switch/if-chain. It mirrors the cnos.issues/issues-fsm
+// idiom: guards are a fixed generic predicate vocabulary; which guard applies
+// to which state, and what step/target it drives, is entirely table-driven.
+//
+// The kernel is telos-agnostic. A "cell" is this kernel run under a telos —
+// CC, PC, and WC all drive THIS table; they differ only by which Actor is
+// bound (see actor.go, drive.go). Spike code; see ../DESIGN.md.
+package kernel
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// transitionsJSON is the kernel transition table, embedded so the binary is
+// self-contained regardless of the working directory (criterion 2 runs
+// `go run ./cmd/cell-runner` from the module root).
+//
+//go:embed transitions.json
+var transitionsJSON []byte
+
+// Rule is one entry in a state's rule list. A rule matches a FactSnapshot when
+// every AllTrue guard is true, every AllFalse guard is false, and (if AnyTrue
+// is non-empty) at least one AnyTrue guard is true. Rules are evaluated in
+// file order; the first match wins. Rule is pure data decoded from the table.
+type Rule struct {
+	AllTrue  []string `json:"all_true,omitempty"`
+	AnyTrue  []string `json:"any_true,omitempty"`
+	AllFalse []string `json:"all_false,omitempty"`
+
+	// To is the target state this rule transitions into.
+	To string `json:"to"`
+	// Step is the actor-step id run while taking this transition (resolved
+	// against the step registry in drive.go). The step produces the evidence
+	// (facts) the NEXT state's guard reads.
+	Step string `json:"step"`
+	// Reason is the human-readable rationale printed for this transition.
+	Reason string `json:"reason"`
+}
+
+// StateTransition holds every rule for one state, evaluated when Trigger
+// fires (the kernel has exactly one trigger: "advance").
+type StateTransition struct {
+	State   string `json:"state"`
+	Trigger string `json:"trigger"`
+	Rules   []Rule `json:"rules"`
+}
+
+// Table is the full declarative transition table — the single source of truth
+// for the kernel FSM. It is loaded from JSON, never constructed as Go literals.
+type Table struct {
+	Doc         []string          `json:"_doc,omitempty"`
+	States      []string          `json:"states"`
+	Terminal    []string          `json:"terminal"`
+	Guards      map[string]string `json:"guards,omitempty"`
+	Transitions []StateTransition `json:"transitions"`
+}
+
+// DefaultTable parses the embedded transition table.
+func DefaultTable() (*Table, error) { return parseTable(transitionsJSON) }
+
+// LoadTable reads and parses a transition table from path (used by tests that
+// want to exercise an alternate table).
+func LoadTable(path string) (*Table, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read transition table: %w", err)
+	}
+	return parseTable(data)
+}
+
+func parseTable(data []byte) (*Table, error) {
+	var t Table
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("parse transition table JSON: %w", err)
+	}
+	return &t, nil
+}
+
+// IsTerminal reports whether state is a terminal state (no outgoing edges).
+func (t *Table) IsTerminal(state string) bool {
+	for _, s := range t.Terminal {
+		if s == state {
+			return true
+		}
+	}
+	return false
+}
+
+// guardFuncs is the fixed, generic predicate vocabulary the evaluator
+// understands — the ONLY place FactSnapshot fields are read as booleans. It is
+// never switched on a state name; it only names reusable evidence predicates
+// over the fact model, exactly like issues-fsm's guard registry.
+var guardFuncs = map[string]func(FactSnapshot) bool{
+	"contract_present": func(f FactSnapshot) bool { return f.ContractPresent },
+	"artifact_present": func(f FactSnapshot) bool { return f.ArtifactPresent },
+	"review_approved":  func(f FactSnapshot) bool { return f.ReviewApproved },
+	"review_rejected":  func(f FactSnapshot) bool { return f.ReviewRejected },
+	"receipt_bound":    func(f FactSnapshot) bool { return f.ReceiptBound },
+	"v_pass":           func(f FactSnapshot) bool { return f.VPass },
+	"v_fail":           func(f FactSnapshot) bool { return f.VFail },
+}
+
+// evalGuard evaluates a single named guard. It errors if the table references
+// a guard the engine does not recognize — a table-authoring error.
+func evalGuard(name string, f FactSnapshot) (bool, error) {
+	fn, ok := guardFuncs[name]
+	if !ok {
+		return false, fmt.Errorf("transition table references unknown guard %q", name)
+	}
+	return fn(f), nil
+}
+
+// ruleMatches reports whether r's conditions all hold against f.
+func ruleMatches(r Rule, f FactSnapshot) (bool, error) {
+	for _, g := range r.AllTrue {
+		v, err := evalGuard(g, f)
+		if err != nil {
+			return false, err
+		}
+		if !v {
+			return false, nil
+		}
+	}
+	for _, g := range r.AllFalse {
+		v, err := evalGuard(g, f)
+		if err != nil {
+			return false, err
+		}
+		if v {
+			return false, nil
+		}
+	}
+	if len(r.AnyTrue) > 0 {
+		any := false
+		for _, g := range r.AnyTrue {
+			v, err := evalGuard(g, f)
+			if err != nil {
+				return false, err
+			}
+			if v {
+				any = true
+				break
+			}
+		}
+		if !any {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/src/packages/cnos.cell-runner/kernel/transitions.json
+++ b/src/packages/cnos.cell-runner/kernel/transitions.json
@@ -1,0 +1,65 @@
+{
+  "_doc": [
+    "The CCNF cell kernel as a declarative transition table (spike; see",
+    "../DESIGN.md §Kernel FSM). This is the single source of truth for the",
+    "kernel FSM: the generic evaluator in engine.go reads the current state,",
+    "looks up its entry in `transitions` below, and returns the first rule",
+    "whose guards hold against the observed FactSnapshot (first match wins) —",
+    "it never hardcodes a state name in a switch/if-chain, exactly like the",
+    "cnos.issues/issues-fsm engine. Adding a kernel state or edge is an edit",
+    "to THIS FILE, not to Go source. Guard names reference the fixed generic",
+    "predicate vocabulary in engine.go's guard registry; step names reference",
+    "the actor-step registry in drive.go. All three cells (CC/PC/WC) run this",
+    "same table — they differ only by telos (which actor is bound)."
+  ],
+  "states": ["init", "produced", "reviewed", "closed", "validated", "decided", "held"],
+  "terminal": ["decided", "held"],
+  "guards": {
+    "contract_present": "a contract was handed to this cell (α input present)",
+    "artifact_present": "α produced its artifact (WC file edit / PC wave / CC measurement)",
+    "review_approved": "β reviewed the artifact and approved",
+    "review_rejected": "β reviewed the artifact and rejected",
+    "receipt_bound": "γ computed and bound the receipt from transition evidence",
+    "v_pass": "V mechanically validated the artifact against the contract's acceptance predicates",
+    "v_fail": "V mechanically rejected the artifact"
+  },
+  "transitions": [
+    {
+      "state": "init",
+      "trigger": "advance",
+      "rules": [
+        {"all_true": ["contract_present"], "to": "produced", "step": "alpha_produce", "reason": "contract present → α produces the artifact"}
+      ]
+    },
+    {
+      "state": "produced",
+      "trigger": "advance",
+      "rules": [
+        {"all_true": ["artifact_present"], "to": "reviewed", "step": "beta_review", "reason": "artifact present → β reviews it"}
+      ]
+    },
+    {
+      "state": "reviewed",
+      "trigger": "advance",
+      "rules": [
+        {"all_true": ["review_approved"], "to": "closed", "step": "gamma_close", "reason": "β approved → γ closes (computes receipt)"},
+        {"all_true": ["review_rejected"], "to": "held", "step": "delta_hold", "reason": "β rejected → δ holds (stop, fail closed)"}
+      ]
+    },
+    {
+      "state": "closed",
+      "trigger": "advance",
+      "rules": [
+        {"all_true": ["receipt_bound"], "to": "validated", "step": "v_validate", "reason": "receipt bound → V validates mechanically"}
+      ]
+    },
+    {
+      "state": "validated",
+      "trigger": "advance",
+      "rules": [
+        {"all_true": ["v_pass"], "to": "decided", "step": "delta_accept", "reason": "V passed → δ accepts"},
+        {"all_true": ["v_fail"], "to": "held", "step": "delta_hold", "reason": "V failed → δ holds (stop, fail closed)"}
+      ]
+    }
+  ]
+}

--- a/src/packages/cnos.cell-runner/model/model.go
+++ b/src/packages/cnos.cell-runner/model/model.go
@@ -1,0 +1,139 @@
+// Package model holds the domain objects the runner emits: the contract, the
+// coherence-measurement object (CM), the wave, the judgment, and the receipt.
+// Every struct's JSON field names match the CUE definitions in
+// ../schema/*.cue, so each emitted object round-trips through `cue vet`.
+//
+// This is spike code (see ../DESIGN.md) — a walking skeleton for the CC→PC→WC
+// loop, not canonical R12 runtime.
+package model
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Contract is the pinned unit of work handed to one kernel run (#Contract).
+type Contract struct {
+	ID          string   `json:"id"`
+	Telos       string   `json:"telos"`
+	Target      string   `json:"target"`
+	Instruction string   `json:"instruction"`
+	Acceptance  []string `json:"acceptance"`
+}
+
+// Defect is one measured incoherence (#Defect).
+type Defect struct {
+	ID     string `json:"id"`
+	Kind   string `json:"kind"`
+	Detail string `json:"detail"`
+}
+
+// Provenance records who/how produced a CM.
+type Provenance struct {
+	MeasuredBy string `json:"measured_by"`
+	Method     string `json:"method"`
+	CMVersion  string `json:"cm_version"`
+}
+
+// CM is the coherence-measurement object (#CM) — the cnos↔tsc seam.
+type CM struct {
+	Target        string     `json:"target"`
+	AlphaScore    float64    `json:"alpha_score"`
+	Defects       []Defect   `json:"defects"`
+	Provenance    Provenance `json:"provenance"`
+	MeasuredAtRef string     `json:"measured_at_ref"`
+}
+
+// Incoherence is the defect count — the loop's decreasing quantity.
+func (c CM) Incoherence() int { return len(c.Defects) }
+
+// Wave is the PC's relation-graph output (#Wave).
+type Wave struct {
+	ID        string     `json:"id"`
+	FromCMRef string     `json:"from_cm_ref"`
+	Contracts []Contract `json:"contracts"`
+}
+
+// Judgment is the CC's δ-output over a CM (#Judgment).
+type Judgment struct {
+	Verdict      string `json:"verdict"`
+	CMRef        string `json:"cm_ref"`
+	Target       string `json:"target"`
+	DecidedAtRef string `json:"decided_at_ref"`
+}
+
+// TransitionRecord is one kernel edge actually traversed (#TransitionRecord).
+type TransitionRecord struct {
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Step  string `json:"step"`
+	Guard string `json:"guard"`
+}
+
+// ValidationVerdict is V's mechanical output (#ValidationVerdict).
+type ValidationVerdict struct {
+	Verdict          string   `json:"verdict"`
+	FailedPredicates []string `json:"failed_predicates"`
+	Warnings         []string `json:"warnings"`
+}
+
+// BoundaryDecision is δ's action at the cell boundary (#BoundaryDecision).
+type BoundaryDecision struct {
+	Actor  string `json:"actor"`
+	Action string `json:"action"`
+}
+
+// Receipt is the parent-facing trust surface of a closed/held cell (#Receipt).
+type Receipt struct {
+	ID               string             `json:"id"`
+	Cell             string             `json:"cell"`
+	Telos            string             `json:"telos"`
+	Transitions      []TransitionRecord `json:"transitions"`
+	EvidenceRefs     map[string]string  `json:"evidence_refs"`
+	Validation       ValidationVerdict  `json:"validation"`
+	BoundaryDecision BoundaryDecision   `json:"boundary_decision"`
+	Transmissibility string             `json:"transmissibility"`
+	Verdict          string             `json:"verdict"`
+	ProducedAtRef    string             `json:"produced_at_ref"`
+}
+
+// DeriveTransmissibility computes the trust property from the
+// (validation verdict × boundary action) pair, mirroring the structural table
+// in ../schema/receipt.cue. Returns "" for an inconsistent pair so the caller
+// fails closed (and `cue vet` would reject the emitted receipt anyway).
+func DeriveTransmissibility(verdict, action string) string {
+	switch verdict {
+	case "PASS":
+		switch action {
+		case "accept", "release":
+			return "accepted"
+		case "reject", "repair_dispatch":
+			return "not_transmissible"
+		}
+	case "FAIL":
+		switch action {
+		case "reject", "repair_dispatch":
+			return "not_transmissible"
+		case "override":
+			return "degraded"
+		}
+	}
+	return ""
+}
+
+// WriteJSON marshals v as indented JSON (a valid CUE/YAML input) to path,
+// creating parent directories as needed. JSON is used rather than YAML to stay
+// stdlib-only (no third-party YAML dependency); JSON is a strict subset of
+// YAML and `cue vet` reads it directly. See ../DESIGN.md §Build notes.
+func WriteJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/src/packages/cnos.cell-runner/schema/cm.cue
+++ b/src/packages/cnos.cell-runner/schema/cm.cue
@@ -1,0 +1,30 @@
+// schema/cm.cue — the Coherence Measurement object (the cnos↔tsc seam).
+//
+// #CM is the runner/provider-produced MEASUREMENT of a target (NOT the CC's
+// judgment; the CC consumes a #CM and emits a #Judgment). v0's provider is a
+// mechanical checker over the toy target; a tsc/agent measurement provider
+// drops in behind this same schema (WC-2 of #672). Exploratory spike.
+package schema
+
+// #Defect is one measured incoherence against the target.
+#Defect: {
+	id:     string
+	kind:   string
+	detail: string
+}
+
+// #CM is the measurement object. alpha_score is a coherence score in [0,1]
+// (1.0 = fully coherent); incoherence is the defect count. v0 scores
+// mechanically as 1 - min(1, len(defects)); a richer provider refines the
+// score behind this schema without changing the seam.
+#CM: {
+	target:      string
+	alpha_score: number & >=0 & <=1
+	defects: [...#Defect]
+	provenance: {
+		measured_by: string
+		method:      string
+		cm_version:  string
+	}
+	measured_at_ref: string
+}

--- a/src/packages/cnos.cell-runner/schema/contract.cue
+++ b/src/packages/cnos.cell-runner/schema/contract.cue
@@ -1,0 +1,23 @@
+// schema/contract.cue — the WC/PC work contract handed to a kernel run.
+//
+// A contract is the α-input of a cell: it pins the telos (output kind), the
+// target the cell acts on, the instruction, and the mechanical acceptance
+// predicates V asserts at validation. This is an exploratory-spike schema
+// (see ../DESIGN.md), not canonical R12 doctrine.
+package schema
+
+// #Telos classifies a cell purely by its output kind — the R12 rule that
+// distinguishes CC / PC / WC without any other structural difference.
+#Telos: "artifact" | "relation_graph" | "judgment"
+
+// #Contract is the pinned unit of work for one kernel run.
+#Contract: {
+	id:          string
+	telos:       #Telos
+	target:      string
+	instruction: string
+	// acceptance predicates V asserts mechanically at validation (V pass iff
+	// every predicate holds). Free-text ids here; the actor maps each to a
+	// mechanical check.
+	acceptance: [...string]
+}

--- a/src/packages/cnos.cell-runner/schema/judgment.cue
+++ b/src/packages/cnos.cell-runner/schema/judgment.cue
@@ -1,0 +1,14 @@
+// schema/judgment.cue — the CC's δ-output: a judgment over a measurement.
+//
+// The CC consumes a #CM and emits exactly one #Judgment. The verdict drives
+// the loop: request_planning routes to a PC; request_working routes straight
+// to a WC; coherent terminates the loop. Exploratory spike.
+package schema
+
+// #Judgment is the CC's parent-facing verdict computed from a #CM.
+#Judgment: {
+	verdict:        "coherent" | "request_planning" | "request_working"
+	cm_ref:         string
+	target:         string
+	decided_at_ref: string
+}

--- a/src/packages/cnos.cell-runner/schema/receipt.cue
+++ b/src/packages/cnos.cell-runner/schema/receipt.cue
@@ -1,0 +1,74 @@
+// schema/receipt.cue — the runner receipt, shaped after schemas/cdd/receipt.cue.
+//
+// A receipt is COMPUTED at γ close-out from the cell's transition evidence
+// (and finalized by δ) — it is never free-text authored. Every cell writes
+// exactly one. The verdict × action → transmissibility table is enforced
+// STRUCTURALLY below (mirroring schemas/cdd/receipt.cue): an author-asserted
+// transmissibility inconsistent with the (validation.verdict × action) pair
+// unifies to _|_ and fails `cue vet`. This is the "fail closed" surface.
+//
+// This is a minimal spike receipt (see ../DESIGN.md), not the canonical
+// cnos.cdd.receipt.v1 — it types only the fields the walking skeleton needs.
+package schema
+
+// #ValidationVerdict is V's mechanical output, recorded into the receipt. δ
+// never rewrites it (mirrors schemas/cdd/boundary_decision.cue §Q4).
+#ValidationVerdict: {
+	verdict: "PASS" | "FAIL"
+	failed_predicates: [...string]
+	warnings: [...string]
+}
+
+// #BoundaryDecision is δ's parent-facing action at the cell boundary.
+#BoundaryDecision: {
+	actor:  string
+	action: "accept" | "release" | "reject" | "repair_dispatch" | "override"
+}
+
+// #Transmissibility is the derived trust property — what crosses the boundary.
+#Transmissibility: "accepted" | "not_transmissible" | "degraded"
+
+// #TransitionRecord is one edge the kernel actually traversed. The receipt's
+// transitions[] is the evidence the verdict is computed from.
+#TransitionRecord: {
+	from:  string
+	to:    string
+	step:  string
+	guard: string
+}
+
+// #Receipt is the parent-facing trust surface of a closed (or held) cell.
+#Receipt: {
+	id:    string
+	cell:  "CC" | "PC" | "WC"
+	telos: #Telos
+	transitions: [...#TransitionRecord]
+	evidence_refs: [string]: string
+	validation:        #ValidationVerdict
+	boundary_decision: #BoundaryDecision
+	transmissibility:  #Transmissibility
+	// verdict is the one-word terminal outcome of the cell: accept (reached
+	// `decided`) or hold (reached `held`, fail-closed).
+	verdict:          "accept" | "hold"
+	produced_at_ref:  string
+
+	// Structural transmissibility derivation (the fail-closed gate). The four
+	// rows the spike can produce are pinned; any other (verdict × action)
+	// pair leaves transmissibility unifying to _|_ and fails vet.
+	if validation.verdict == "PASS" {
+		if boundary_decision.action == "accept" || boundary_decision.action == "release" {
+			transmissibility: "accepted"
+		}
+		if boundary_decision.action == "reject" || boundary_decision.action == "repair_dispatch" {
+			transmissibility: "not_transmissible"
+		}
+	}
+	if validation.verdict == "FAIL" {
+		if boundary_decision.action == "reject" || boundary_decision.action == "repair_dispatch" {
+			transmissibility: "not_transmissible"
+		}
+		if boundary_decision.action == "override" {
+			transmissibility: "degraded"
+		}
+	}
+}

--- a/src/packages/cnos.cell-runner/schema/wave.cue
+++ b/src/packages/cnos.cell-runner/schema/wave.cue
@@ -1,0 +1,14 @@
+// schema/wave.cue — the PC's relation-graph output: a wave of WC contracts.
+//
+// v0's wave carries exactly one WC contract (multi-WC waves / parallel
+// branches are explicitly deferred — see ../DESIGN.md §Explicitly deferred).
+// #Contract resolves from contract.cue in this same package (no import).
+package schema
+
+// #Wave is the α-output of a PC run: a set of downstream WC contracts derived
+// from a measurement, plus the ref of the #CM it was planned from.
+#Wave: {
+	id:          string
+	from_cm_ref: string
+	contracts: [...#Contract]
+}

--- a/src/packages/cnos.cell-runner/testdata/toy/spec.md
+++ b/src/packages/cnos.cell-runner/testdata/toy/spec.md
@@ -1,0 +1,16 @@
+# Toy Target Spec
+
+This is the toy target the walking-skeleton loop acts on. It deliberately
+lacks the required `## Coherence` section, so the Coherence Cell measures one
+defect (`missing-required-section`) on the first pass.
+
+## Overview
+
+Some prose describing the toy artifact. The mechanical measurement only checks
+for the presence and well-formedness of the required coherence section; this
+section exists so the target is more than a single heading.
+
+## Notes
+
+The Working Cell will append the missing `## Coherence` section, after which a
+re-measurement finds zero defects and the loop terminates coherent.


### PR DESCRIPTION
## CDD Trace

| Step | Artifact | Skills loaded | Decision |
|------|----------|---------------|----------|
| 0 Observe | the three-cell loop (CC→PC→WC) exists only as a hand-cranked bootstrap; no code turns it | — | proceed |
| 1 Select | milestone: "cnos moves to three cells running" | — | walking-skeleton first |
| 4 Gap | see below | — | |
| 5 Mode | see below | — | |
| 6 Artifacts | `src/packages/cnos.cell-runner/**` | — | built |
| 8 Review | PR #this | — | Pending (external β) |
| 9 Gate | — | — | Pending |
| 10 Release | — | — | Pending |

## Gap (step 4)

**What:** the three-cell agentic loop (CC→PC→WC) exists today only as a *hand-cranked* bootstrap (κ + external β + subagents). There is no runnable machinery that turns the loop.

**Why it matters:** the milestone — cnos running its own development through the three cells, and tsc adopting the same structure — needs *code that runs the loop*, not only a specification of it (the doctrine plan is PR #672; the implementation wave is #627). Designing forever without running hides the real integration seams.

**What fails if skipped:** we keep perfecting a plan and never discover, by running, where CM ⇄ CC ⇄ PC ⇄ WC actually breaks.

## Mode + Active Skills (step 5)

- **Mode:** MCA
- **Work shape:** runtime (exploratory spike)
- **Level:** L6
- **Active skills:** reuse-house-idiom (declarative FSM table + generic evaluator, per `cnos.issues/issues-fsm`); fail-closed; honest-provenance (spike ≠ canonical doctrine)
- **Dominant risk:** a spike quietly presenting itself as authored doctrine, or a validator that only *looks* mechanical — both explicitly guarded here.

## Changes

### Added

A runnable Go+CUE proof-of-life for the three-cell loop under `src/packages/cnos.cell-runner/` (new `go.work` module `cnos.dev/cnos/cell-runner`; the only edit outside the package is adding it to the root `go.work`).

One loop turn, mechanically, git-native, no human in the machinery:

```
CC.measure → CM object + judgment{request_planning}   (incoherence detected)
  → PC.plan → wave{ one WC contract }                 (relation graph)
    → WC.execute → α produce · β review · γ close · V validate · δ decide · receipt
      → CC.re-measure → judgment{coherent}            (incoherence cleared)
loop terminates: incoherence 1 → 0, receipt chain closed.
```

- The three cells are distinguished ONLY by output telos (**WC→artifact, PC→relation_graph, CC→judgment**) and run the **same** kernel.
- Kernel is a **declarative transition table** (`kernel/transitions.json`) driven by a generic evaluator — mirroring the `cnos.issues/issues-fsm` idiom; never switches on a state name.
- Judgment seams sit behind an `Actor` interface; **v0 ships deterministic stub actors** — agent-backed actors (the real α/β/CC judgment) drop into the same interface next.
- The **CM object** (`schema/cm.cue`) is the runner/provider-produced measurement — the exact seam a **tsc-provided TSC measurement** plugs into (WC-2 of #672); it is NOT the CC's judgment (the CC *consumes* it).
- Receipts are **computed at γ** from transition evidence (not free-text), shaped after `schemas/cdd/receipt.cue`, and cue-vet green.

Built against the R12 cell-runtime doctrine design (PR #672).

### Not in scope

Agent-backed actors; multi-WC / parallel waves; the full wave FSM (WC-3b) beyond one node; real CM scoring beyond defect-count; operator-authorization gate wiring; self-hosting on a real cnos change; tsc adoption. Each is a **named next increment** in `DESIGN.md`, not a silent gap. **This spike is not canonical runtime** — it is reconciled to the authored doctrine (#672 WCs / #627 S2–S8) when that lands, or discarded.

## Acceptance Criteria

- [x] `go run ./cmd/cell-runner --workspace <tmp> --task testdata/toy` → exit 0, transcript shows incoherence **1 → 0** across CC→PC→WC→CC
- [x] every emitted CM / wave / receipt / judgment cue-vets against `schema/*.cue`
- [x] fault injection (`--fail-injection=v-fail|beta-reject`) drives the kernel to a fail-closed `held` state with a stop receipt and **non-zero exit**
- [x] `go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt -l` empty
- [x] no Python (`find … -name '*.py'` empty)
- [ ] CI green
- [ ] external β review

## Known Debt

v0 actors are deterministic stubs — the loop's *judgment* is not yet real (that is v1: agent-backed actors behind the same `Actor` interface). The runner receipt schema is a minimal spike shape reusing the cdd transmissibility gate, not the full `cnos.cdd.receipt.v1`. Emitted objects are JSON (stdlib-only; JSON is a YAML/CUE subset). All recorded in `DESIGN.md §Build notes`.

## Pre-Review Gate (alpha/SKILL.md §2.6)

- [x] Rebased on current `main` (branched from `main` tip)
- [x] PR body carries CDD Trace through step 7
- [x] Every AC mapped to evidence (run transcript + cue-vet output)
- [ ] Peer enumeration — n/a (single new isolated package)
- [x] Schema / shape audit — all emitted objects cue-vet against `schema/*.cue`
- [x] Harness audit — new module added to `go.work`; no existing surface changed
- [x] Known debt explicit
- [ ] CI green on head commit (**PR remains draft**)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016t4N6DgAA8KaNCxn4wNgSb)_